### PR TITLE
Fix docs issues

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Note that you can omit `compilerImage` and `kfpSdkImage` when specifying `contai
 
 Unlike imparative Kubeflow Pipelines deployments, the operator takes care of providing all environment-specific configuration and setup for the pipelines. Pipeline creators therefore don't have to provide DAG runners, metadata configs, serving directories, etc. Furthermore, pusher is not required and the operator can extend the pipeline with this very environment-specific component.
 
-For running a pipeline using the operator, only the list of TFX components needs to be returned. Everything else is done by the operator. See the [penguin pipeline](../quickstart/penguin_pipeline/pipeline.py) for an example.
+For running a pipeline using the operator, only the list of TFX components needs to be returned. Everything else is done by the operator. See the [penguin pipeline](./quickstart/penguin_pipeline/pipeline.py) for an example.
 
 ### Lifecycle phases and Parameter types
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -7,11 +7,11 @@ apiVersion: pipelines.kubeflow.com/v1
 kind: Pipeline
 metadata:
     name: penguin-pipeline
-    spec:
-        image: kfp-quickstart:v1
-        tfxComponents: base_pipeline.create_components
-        env:
-            TRAINING_RUNS: 100
+spec:
+    image: kfp-quickstart:v1
+    tfxComponents: base_pipeline.create_components
+    env:
+        TRAINING_RUNS: 100
 ```
 
 ### Fields

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -24,8 +24,8 @@ apiVersion: pipelines.kubeflow.org/v1
 kind: Pipeline
 metadata:
     name: penguin-pipeline
-    spec:
-        image: kfp-quickstart:v1
+spec:
+    image: kfp-quickstart:v1
 EOF
 ```
 

--- a/docs/runconfiguration.md
+++ b/docs/runconfiguration.md
@@ -4,15 +4,15 @@ The RunConfiguration resource represents the lifecycle of Recurring Runs (aka Jo
 Pipeline training runs can be configured using this resource as follows:
 
 ```yaml
-apiVersion: pipelines.kubeflow.com/v1
+apiVersion: pipelines.kubeflow.org/v1
 kind: RunConfiguration
 metadata:
     name: penguin-pipeline-recurring-run
-    spec:
-        pipelineName: penguin-pipeline
-        schedule: '0 0 * * * *'
-        runtimeParameters:
-            TRAINING_RUNS: 100
+spec:
+    pipelineName: penguin-pipeline
+    schedule: '0 0 * * * *'
+    runtimeParameters:
+        TRAINING_RUNS: 100
 ```
 
 Note: The experiment will be created if it does not exist when creating the run configuration.


### PR DESCRIPTION
This PR will fix a couple of small issues in the docs:
- A link to the example penguin pipeline module has a slightly wrong relative path which leads to a 404
- The Pipeline resource yaml examples had `spec` under `metadata` instead of at top level, which causes a type error when trying to deploy to k8s
- The `RunConfiguration` had the wrong `apiVersion`