### PR TITLE
Increase manager resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,9 +46,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/helm/kfp-operator/templates/deployment.yaml
+++ b/helm/kfp-operator/templates/deployment.yaml
@@ -44,10 +44,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 30Mi
+              memory: 300Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 200Mi
           volumeMounts:
             - mountPath: /controller_manager_config.yaml
               name: manager-config


### PR DESCRIPTION
The initially assigned resources are too low.
This change raises the limits until we make them configurable.