### PR TITLE
Exclude TFX from compiler image

### DIFF
--- a/argo/kfp-compiler/pyproject.toml
+++ b/argo/kfp-compiler/pyproject.toml
@@ -8,11 +8,11 @@ authors = []
 python = "^3.7"
 click = ">=7,<8"
 PyYAML = "^5.4.1"
-tfx = ">=1.2.0"
 kfp = "^1.8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
+tfx = ">=1.2.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
This dependency will always be provided by the pipeline image to be compiled.

This reduces the size of the resulting compiler image from 1.9GB to roughly 100MB.
Also, it will use the pipeline image's TFX version and therefore ensures compatibility.