### PR TITLE
Make eventsource metadata configurable

### DIFF
--- a/helm/kfp-operator/templates/eventsource/_helpers.tpl
+++ b/helm/kfp-operator/templates/eventsource/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Common labels
+*/}}
+{{- define "kfp-operator.eventsourceServer.labels" -}}
+app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+{{- end }}

--- a/helm/kfp-operator/templates/eventsource/deployment.yaml
+++ b/helm/kfp-operator/templates/eventsource/deployment.yaml
@@ -5,16 +5,16 @@ metadata:
   name: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
   namespace: {{ .Values.namespace.name }}
   labels:
-    app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+    {{- include "kfp-operator.eventsourceServer.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+      {{- include "kfp-operator.eventsourceServer.labels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
-      labels:
-        app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+      {{- $defaultMetadata := dict "labels"  ((include "kfp-operator.eventsourceServer.labels" .) | fromYaml) -}}
+      {{- (merge .Values.eventsourceServer.metadata $defaultMetadata) | toYaml | nindent 6 }}
     spec:
       securityContext:
         runAsNonRoot: true

--- a/helm/kfp-operator/templates/eventsource/service.yaml
+++ b/helm/kfp-operator/templates/eventsource/service.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
   namespace: {{ .Values.namespace.name }}
   labels:
-    app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+    {{- include "kfp-operator.eventsourceServer.labels" . | nindent 4 }}
 spec:
   selector:
-    app: {{ include "kfp-operator.fullname" . }}-model-update-eventsource-server
+    {{- include "kfp-operator.eventsourceServer.labels" . | nindent 4 }}
   ports:
     - name: grpc
       port: 8080

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -33,6 +33,7 @@ logging:
 
 eventsourceServer:
   install: true
+  metadata: {}
   port: 50051
   mlmdUrl:
   rbac:


### PR DESCRIPTION
Exposes the `metadata` field of the eventsource server deployment so that it can be overridden by configuration.

Also aligns the definition of labels in this sub-chart with those of the manager.