### PR TITLE
Fix eventsource container port

### DIFF
--- a/helm/kfp-operator/templates/eventsource/deployment.yaml
+++ b/helm/kfp-operator/templates/eventsource/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           command:
             - /run_completion_eventsource_server
           args:
-            - --port={{ .Values.eventsourceServer.port }}
+            - --port=50051
             - --mlmd-url={{ .Values.eventsourceServer.mlmdUrl }}
             {{ if .Values.logging.verbosity }}
             - --zap-log-level={{ .Values.logging.verbosity }}


### PR DESCRIPTION
https://github.com/sky-uk/kfp-operator/pull/76 has refactored the evetnsource server's ports. Unfortunately, we have missed the containerport and broken the deployment.
