### PR TITLE
Add short names to CRDs

### DIFF
--- a/apis/pipelines/v1/experiment_types.go
+++ b/apis/pipelines/v1/experiment_types.go
@@ -25,6 +25,7 @@ func (es ExperimentSpec) ComputeVersion() string {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName="mlexp"
 //+kubebuilder:printcolumn:name="KfpId",type="string",JSONPath=".status.kfpId"
 //+kubebuilder:printcolumn:name="SynchronizationState",type="string",JSONPath=".status.synchronizationState"
 //+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"

--- a/apis/pipelines/v1/pipeline_types.go
+++ b/apis/pipelines/v1/pipeline_types.go
@@ -37,6 +37,7 @@ func (ps PipelineSpec) ComputeVersion() string {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName="mlp"
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="KfpId",type="string",JSONPath=".status.kfpId"
 //+kubebuilder:printcolumn:name="SynchronizationState",type="string",JSONPath=".status.synchronizationState"

--- a/apis/pipelines/v1/runconfiguration_types.go
+++ b/apis/pipelines/v1/runconfiguration_types.go
@@ -36,6 +36,7 @@ type RunConfigurationStatus struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName="mlrc"
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="KfpId",type="string",JSONPath=".status.kfpId"
 //+kubebuilder:printcolumn:name="SynchronizationState",type="string",JSONPath=".status.synchronizationState"

--- a/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Experiment
     listKind: ExperimentList
     plural: experiments
+    shortNames:
+    - mlexp
     singular: experiment
   scope: Namespaced
   versions:

--- a/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Pipeline
     listKind: PipelineList
     plural: pipelines
+    shortNames:
+    - mlp
     singular: pipeline
   scope: Namespaced
   versions:

--- a/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -13,6 +13,8 @@ spec:
     kind: RunConfiguration
     listKind: RunConfigurationList
     plural: runconfigurations
+    shortNames:
+    - mlrc
     singular: runconfiguration
   scope: Namespaced
   versions:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Experiment
     listKind: ExperimentList
     plural: experiments
+    shortNames:
+    - mlexp
     singular: experiment
   scope: Namespaced
   versions:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Pipeline
     listKind: PipelineList
     plural: pipelines
+    shortNames:
+    - mlp
     singular: pipeline
   scope: Namespaced
   versions:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -13,6 +13,8 @@ spec:
     kind: RunConfiguration
     listKind: RunConfigurationList
     plural: runconfigurations
+    shortNames:
+    - mlrc
     singular: runconfiguration
   scope: Namespaced
   versions:


### PR DESCRIPTION
Closes #49.

This PR adds the short names `mlp`, `mlrc`, and `mlexp` to the `Pipeline`, `RunConfiguration`, and `Experiment` CRDs respectively, as described in #49.
