### PR TITLE
Rename integration test minikube profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ decoupled-test: manifests generate ## Run decoupled acceptance tests
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -tags=decoupled -coverprofile cover.out
 
 integration-test-up:
-	minikube start -p argo-integration-tests
+	minikube start -p kfp-operator-tests
 	# Install Argo
 	kubectl create namespace argo --dry-run=client -o yaml | kubectl apply -f -
 	kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflows/master/manifests/quick-start-postgres.yaml
@@ -76,14 +76,14 @@ integration-test-up:
 	kubectl proxy --port=8080 & echo $$! >> config/testing/pids
 
 integration-test: manifests generate ## Run integration tests
-	eval $$(minikube -p argo-integration-tests docker-env) && \
+	eval $$(minikube -p kfp-operator-tests docker-env) && \
 	$(MAKE) docker-build-argo && \
 	docker build docs/quickstart -t kfp-quickstart
 	go test ./... -tags=integration
 
 integration-test-down:
 	(cat config/testing/pids | xargs kill) || true
-	minikube stop -p argo-integration-tests
+	minikube stop -p kfp-operator-tests
 
 unit-test: manifests generate ## Run unit tests
 	go test ./... -tags=unit

--- a/controllers/pipelines/runconfiguration_workflow_integration_test.go
+++ b/controllers/pipelines/runconfiguration_workflow_integration_test.go
@@ -121,8 +121,10 @@ var _ = Context("RunConfiguration Workflows", Serial, func() {
 					PipelineName: "pipeline",
 					Schedule:     "* * * * * *",
 				},
-				Status: pipelinesv1.Status{
-					KfpId: jobKfpId,
+				Status: pipelinesv1.RunConfigurationStatus{
+					Status: pipelinesv1.Status{
+						KfpId: jobKfpId,
+					},
 				},
 			},
 			k8sClient, ctx)


### PR DESCRIPTION
`kfp-operator-tests` is more reflective of what the profile is used for.
Also fix broken integration tests that got missed in the previous PR.

