### PR TITLE
Allow HA configuration

### DIFF
--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -8,7 +8,7 @@ controller:
   webhook:
     port: 9443
   leaderElection:
-    leaderElect: false
+    leaderElect: true
     resourceName: kfp-operator-lock
 spec:
   argo:

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
       webhook:
         port: 9443
       leaderElection:
-        leaderElect: false
+        leaderElect: true
         resourceName: kfp-operator-lock
     spec:
       {{- merge (.Values.manager.configuration) (include "kfp-operator.defaultConfiguration" . | fromYaml) | toYaml | nindent 6 -}}

--- a/helm/kfp-operator/templates/deployment.yaml
+++ b/helm/kfp-operator/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "kfp-operator.labels" . | nindent 6 }}
-  replicas: 1
+  replicas: {{ .Values.manager.replicas }}
   template:
     metadata:
       {{- $defaultMetadata := dict "labels"  ((include "kfp-operator.labels" .) | fromYaml) -}}

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -25,6 +25,7 @@ manager:
     requests:
       cpu: 100m
       memory: 200Mi
+  replicas: 1
   configuration: {}
   monitoring:
     create: true


### PR DESCRIPTION
- expose controller replica config entry
- always enable leader election so that even during rolling updates, events won't get processed twice

Closes #138 
