### PR TITLE
Add capability of compiler to parse beam args with list values

### DIFF
--- a/argo/kfp-compiler/kfp_compiler/compiler.py
+++ b/argo/kfp-compiler/kfp_compiler/compiler.py
@@ -99,7 +99,15 @@ def compile(pipeline_config, output_file):
     click.secho(f'{output_file} written', fg='green')
 
 def dict_to_cli_args(beam_args):
-    return [f'--{k}={v}' for k,v in beam_args.items()]
+    beam_cli_args = []
+    for k, v in beam_args.items():
+        if isinstance(v, str):
+            beam_cli_args.append(f'--{k}={v}')
+        elif isinstance(v, list):
+            for vv in v:
+                beam_cli_args.append(f'--{k}={vv}')
+
+    return beam_cli_args
         
 
 def main():

--- a/argo/kfp-compiler/tests/test_compiler.py
+++ b/argo/kfp-compiler/tests/test_compiler.py
@@ -3,10 +3,13 @@ from kfp_compiler import compiler
 def test_dict_to_cli_args():
     args = {
         'a': 'aVal',
-        'b': 'bVal'
+        'b': 'bVal',
+        'c': ['cVal1', 'cVal2'],
     }
 
     assert compiler.dict_to_cli_args(args) == [
         '--a=aVal',
-        '--b=bVal'
+        '--b=bVal',
+        '--c=cVal1',
+        '--c=cVal2',
     ]


### PR DESCRIPTION
Allowing the compiler to parse beam args with list values would allow multiple `--experiments` flags being used. This is related to issue https://github.com/sky-uk/kfp-operator/issues/31


@jmendesky @adriangay @alexgeorgousis 