### PR TITLE
Fix integration tests by using local container images

### DIFF
--- a/config/testing/integration-test-values.yaml
+++ b/config/testing/integration-test-values.yaml
@@ -1,4 +1,5 @@
 fullnameOverride: kfp-operator-integration-tests
+containerRegistry: ""
 manager:
   argo:
     containerDefaults:


### PR DESCRIPTION
https://github.com/sky-uk/kfp-operator/pull/158 has changed the default `containerRegistry` value, resulting in the integration tests failing as they were trying to pull all images.