### PR TITLE
Force serialisation of name and values in NamedValue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ##@ Package
 
-helm-package: helm-cmd
+helm-package: helm-cmd helm-test
 	$(HELM) package helm/kfp-operator --version $(VERSION) --app-version $(VERSION) -d dist
 
 helm-install: helm-package values.yaml

--- a/apis/common_types.go
+++ b/apis/common_types.go
@@ -21,8 +21,8 @@ const Group = "pipelines.kubeflow.org"
 
 //+kubebuilder:object:generate=true
 type NamedValue struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 //+kubebuilder:object:generate=true

--- a/apis/config/v1alpha2/kfp_controller_config_types.go
+++ b/apis/config/v1alpha2/kfp_controller_config_types.go
@@ -12,9 +12,7 @@ type Configuration struct {
 
 	WorkflowTemplatePrefix string `json:"workflowTemplatePrefix,omitempty"`
 
-	Multiversion bool `json:"multiversion,omitempty"`
-
-	DefaultBeamArgs []apis.NamedValue `json:"defaultBeamArgs,omitempty"`
+	DefaultBeamArgs map[string]string `json:"defaultBeamArgs,omitempty"`
 
 	DefaultExperiment string `json:"defaultExperiment,omitempty"`
 

--- a/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -6,7 +6,6 @@
 package v1alpha2
 
 import (
-	"github.com/sky-uk/kfp-operator/apis"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -15,8 +14,10 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 	*out = *in
 	if in.DefaultBeamArgs != nil {
 		in, out := &in.DefaultBeamArgs, &out.DefaultBeamArgs
-		*out = make([]apis.NamedValue, len(*in))
-		copy(*out, *in)
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	out.Debug = in.Debug
 }

--- a/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -183,23 +183,13 @@ spec:
                     type: boolean
                 type: object
               defaultBeamArgs:
-                items:
-                  properties:
-                    name:
-                      type: string
-                    value:
-                      type: string
-                  required:
-                  - name
-                  - value
-                  type: object
-                type: array
+                additionalProperties:
+                  type: string
+                type: object
               defaultExperiment:
                 type: string
               kfpEndpoint:
                 type: string
-              multiversion:
-                type: boolean
               pipelineStorage:
                 type: string
               workflowTemplatePrefix:

--- a/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -189,6 +189,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
                   type: object
                 type: array
               defaultExperiment:
@@ -380,6 +383,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
                   type: object
                 type: array
               defaultExperiment:

--- a/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -114,6 +114,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
                   type: object
                 type: array
               env:
@@ -123,6 +126,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
                   type: object
                 type: array
               image:

--- a/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -117,6 +117,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
                   type: object
                 type: array
               schedule:

--- a/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -182,17 +182,9 @@ spec:
                     type: boolean
                 type: object
               defaultBeamArgs:
-                items:
-                  properties:
-                    name:
-                      type: string
-                    value:
-                      type: string
-                  required:
-                    - name
-                    - value
-                  type: object
-                type: array
+                additionalProperties:
+                  type: string
+                type: object
               defaultExperiment:
                 type: string
               kfpEndpoint:
@@ -201,8 +193,6 @@ spec:
                 type: string
               workflowTemplatePrefix:
                 type: string
-              multiversion:
-                type: boolean
             type: object
         type: object
     served: true

--- a/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -188,6 +188,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                    - name
+                    - value
                   type: object
                 type: array
               defaultExperiment:
@@ -378,6 +381,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                    - name
+                    - value
                   type: object
                 type: array
               defaultExperiment:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -129,6 +129,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                    - name
+                    - value
                   type: object
                 type: array
               env:
@@ -138,6 +141,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                    - name
+                    - value
                   type: object
                 type: array
               image:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -132,6 +132,9 @@ spec:
                       type: string
                     value:
                       type: string
+                  required:
+                    - name
+                    - value
                   type: object
                 type: array
               schedule:


### PR DESCRIPTION
After conversion from v1alpha2 to v1alpha3, environment variables and Beam arguments with empty values are serialised as follows:
```yaml
- name: empty value
- name: not empty value
  value: something
```
This change forces the serialisation to output the value even when empty:
```yaml
- name: empty value
  value: ""
- name: not empty value
  value: something
```