### PR TITLE
Optionally create Argo service account

### DIFF
--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -79,7 +79,7 @@ spec:
     - name: resource-kind
     - name: resource-id
   entrypoint: main
-  serviceAccountName: kfp-operator-workflow-runner
+  serviceAccountName: kfp-operator-argo
   templates:
   - name: main
     outputs:

--- a/config/manager/workflows/compiled.yaml
+++ b/config/manager/workflows/compiled.yaml
@@ -146,7 +146,7 @@ spec:
     - name: resource-kind
     - name: resource-definition
   entrypoint: main
-  serviceAccountName: kfp-operator-workflow-runner
+  serviceAccountName: kfp-operator-argo
   templates:
   - name: main
     outputs:
@@ -228,7 +228,7 @@ spec:
     - name: resource-id
     - name: resource-definition
   entrypoint: main
-  serviceAccountName: kfp-operator-workflow-runner
+  serviceAccountName: kfp-operator-argo
   templates:
   - name: main
     outputs:

--- a/config/manager/workflows/rbac.yaml
+++ b/config/manager/workflows/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: workflow-runner
+  name: argo
   namespace: kfp-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,5 +29,5 @@ roleRef:
   name: kfp-operator-workflow-executor
 subjects:
   - kind: ServiceAccount
-    name: kfp-operator-workflow-runner
+    name: kfp-operator-argo
     namespace: kfp-operator-system

--- a/config/manager/workflows/simple.yaml
+++ b/config/manager/workflows/simple.yaml
@@ -96,7 +96,7 @@ spec:
     - name: resource-kind
     - name: resource-definition
   entrypoint: main
-  serviceAccountName: kfp-operator-workflow-runner
+  serviceAccountName: kfp-operator-argo
   templates:
   - name: main
     outputs:
@@ -153,7 +153,7 @@ spec:
     - name: resource-id
     - name: resource-definition
   entrypoint: main
-  serviceAccountName: kfp-operator-workflow-runner
+  serviceAccountName: kfp-operator-argo
   templates:
   - name: main
     outputs:

--- a/config/testing/integration-test-values.yaml
+++ b/config/testing/integration-test-values.yaml
@@ -4,7 +4,9 @@ manager:
   configuration:
     workflowNamespace: argo
   argo:
-    serviceAccount: default
+    serviceAccount:
+      name: default
+      create: false
     compilerImage: kfp-operator-stub-provider
     containerDefaults:
       imagePullPolicy: Never

--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -79,9 +79,7 @@ spec:
     - name: resource-kind
     - name: resource-id
   entrypoint: main
-  {{ if .Values.manager.argo.serviceAccount -}}
-  serviceAccountName: {{ .Values.manager.argo.serviceAccount }}
-  {{- end }}
+  serviceAccountName: {{ .Values.manager.argo.serviceAccount.name }}
   templates:
   - name: main
     outputs:

--- a/helm/kfp-operator/templates/workflows/compiled.yaml
+++ b/helm/kfp-operator/templates/workflows/compiled.yaml
@@ -151,9 +151,7 @@ spec:
     - name: resource-kind
     - name: resource-definition
   entrypoint: main
-  {{ if .Values.manager.argo.serviceAccount -}}
-  serviceAccountName: {{ .Values.manager.argo.serviceAccount }}
-  {{- end }}
+  serviceAccountName: {{ .Values.manager.argo.serviceAccount.name }}
   templates:
   - name: main
     outputs:
@@ -233,9 +231,7 @@ spec:
     - name: resource-id
     - name: resource-definition
   entrypoint: main
-  {{ if .Values.manager.argo.serviceAccount -}}
-  serviceAccountName: {{ .Values.manager.argo.serviceAccount }}
-  {{- end }}
+  serviceAccountName: {{ .Values.manager.argo.serviceAccount.name }}
   templates:
   - name: main
     outputs:

--- a/helm/kfp-operator/templates/workflows/rbac.yaml
+++ b/helm/kfp-operator/templates/workflows/rbac.yaml
@@ -1,8 +1,11 @@
+{{- if .Values.manager.argo.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.manager.argo.serviceAccount }}
+  name: {{ .Values.manager.argo.serviceAccount.name }}
   namespace: {{ include "kfp-operator.argoNamespace" . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -29,7 +32,7 @@ roleRef:
   name: {{ include "kfp-operator.fullname" . }}-workflow-executor
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.manager.argo.serviceAccount }}
+    name: {{ .Values.manager.argo.serviceAccount.name }}
     namespace: {{ include "kfp-operator.argoNamespace" . }}
 {{- range $providerName, $providerBlock := .Values.providers }}
   - kind: ServiceAccount

--- a/helm/kfp-operator/templates/workflows/simple.yaml
+++ b/helm/kfp-operator/templates/workflows/simple.yaml
@@ -98,9 +98,7 @@ spec:
     - name: resource-kind
     - name: resource-definition
   entrypoint: main
-  {{ if .Values.manager.argo.serviceAccount -}}
-  serviceAccountName: {{ .Values.manager.argo.serviceAccount }}
-  {{- end }}
+  serviceAccountName: {{ .Values.manager.argo.serviceAccount.name }}
   templates:
   - name: main
     outputs:
@@ -155,9 +153,7 @@ spec:
     - name: resource-id
     - name: resource-definition
   entrypoint: main
-  {{ if .Values.manager.argo.serviceAccount -}}
-  serviceAccountName: {{ .Values.manager.argo.serviceAccount }}
-  {{- end }}
+  serviceAccountName: {{ .Values.manager.argo.serviceAccount.name }}
   templates:
   - name: main
     outputs:

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -28,7 +28,9 @@ manager:
   replicas: 1
   configuration: {}
   argo:
-    serviceAccount: "kfp-operator-workflow-runner"
+    serviceAccount:
+      name: "kfp-operator-argo"
+      create: true
     containerDefaults: {}
     metadataDefaults: {}
     ttlStrategy:


### PR DESCRIPTION
Create a service account to run Argo workflows only when required. It allows operators to choose to create that SA externally.