### PR TITLE
Change model location for VAI pipeline runs

### DIFF
--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	PushedModelArtifactType     = "tfx.PushedModel"
-	ModelPushedMetadataProperty = "pushed"
-	ModelPushedMetadataValue    = 1
+	PushedModelArtifactType        = "tfx.PushedModel"
+	ModelPushedMetadataProperty    = "pushed"
+	ModelPushedMetadataValue       = 1
 	ModelPushedDestinationProperty = "pushed_destination"
 )
 
@@ -109,11 +109,13 @@ func modelServingArtifactsForJob(job *aiplatformpb.PipelineJob) []ServingModelAr
 			for _, artifact := range output.GetArtifacts() {
 				if artifact.SchemaTitle == PushedModelArtifactType {
 					properties := artifact.Metadata.AsMap()
-					pushedProperty, hasPushed := properties[ModelPushedMetadataProperty]
-					if hasPushed && pushedProperty.(float64) == ModelPushedMetadataValue {
-						pushedDestinationProperty, hasPushedDestination := properties[ModelPushedDestinationProperty]
-						if hasPushedDestination {
-							servingModelArtifacts = append(servingModelArtifacts, ServingModelArtifact{Name: name, Location: pushedDestinationProperty.(string)})
+					if pushedProperty, hasPushed := properties[ModelPushedMetadataProperty]; hasPushed {
+						if pushed, isFloat := pushedProperty.(float64); isFloat && pushed == ModelPushedMetadataValue {
+							if pushedDestinationProperty, hasPushedDestination := properties[ModelPushedDestinationProperty]; hasPushedDestination {
+								if pushedDestination, isString := pushedDestinationProperty.(string); isString {
+									servingModelArtifacts = append(servingModelArtifacts, ServingModelArtifact{Name: name, Location: pushedDestination})
+								}
+							}
 						}
 					}
 				}

--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -16,6 +16,7 @@ const (
 	PushedModelArtifactType     = "tfx.PushedModel"
 	ModelPushedMetadataProperty = "pushed"
 	ModelPushedMetadataValue    = 1
+	ModelPushedDestinationProperty = "pushed_destination"
 )
 
 type PipelineJobClient interface {
@@ -107,9 +108,13 @@ func modelServingArtifactsForJob(job *aiplatformpb.PipelineJob) []ServingModelAr
 		for name, output := range task.GetOutputs() {
 			for _, artifact := range output.GetArtifacts() {
 				if artifact.SchemaTitle == PushedModelArtifactType {
-					pushedProperty, ok := artifact.Metadata.AsMap()[ModelPushedMetadataProperty]
-					if ok && pushedProperty.(float64) == ModelPushedMetadataValue {
-						servingModelArtifacts = append(servingModelArtifacts, ServingModelArtifact{Name: name, Location: artifact.GetUri()})
+					properties := artifact.Metadata.AsMap()
+					pushedProperty, hasPushed := properties[ModelPushedMetadataProperty]
+					if hasPushed && pushedProperty.(float64) == ModelPushedMetadataValue {
+						pushedDestinationProperty, hasPushedDestination := properties[ModelPushedDestinationProperty]
+						if hasPushedDestination {
+							servingModelArtifacts = append(servingModelArtifacts, ServingModelArtifact{Name: name, Location: pushedDestinationProperty.(string)})
+						}
 					}
 				}
 			}

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -12,13 +12,13 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func artifact(pushedDestination string) *aiplatformpb.Artifact {
+func artifact() *aiplatformpb.Artifact {
 	return &aiplatformpb.Artifact{
 		SchemaTitle: "tfx.PushedModel",
 		Metadata: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"pushed":             structpb.NewNumberValue(1),
-				"pushed_destination": structpb.NewStringValue(pushedDestination),
+				"pushed_destination": structpb.NewStringValue("gs://some/where"),
 			},
 		},
 	}
@@ -58,6 +58,9 @@ var _ = Context("VaiEventingServer", func() {
 	Describe("modelServingArtifactsForJob", func() {
 		When("The job has an output with an artifact that doesn't match the SchemaTitle", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				incorrectArtifact.SchemaTitle = "a.Type"
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -65,15 +68,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-												Metadata: &structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"pushed":             structpb.NewNumberValue(1),
-														"pushed_destination": structpb.NewStringValue("gs://some/where"),
-													},
-												},
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -86,6 +81,9 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with an artifact that hasn't been pushed", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				incorrectArtifact.Metadata.Fields["pushed"] = structpb.NewNumberValue(0)
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -93,15 +91,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-												Metadata: &structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"pushed":             structpb.NewNumberValue(0),
-														"pushed_destination": structpb.NewStringValue("gs://some/where"),
-													},
-												},
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -114,6 +104,9 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with an artifact that isn't a float", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				incorrectArtifact.Metadata.Fields["pushed"] = structpb.NewStringValue("42")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -121,15 +114,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-												Metadata: &structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"pushed":             structpb.NewStringValue("42"),
-														"pushed_destination": structpb.NewStringValue("gs://some/where"),
-													},
-												},
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -142,6 +127,9 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with an artifact that has no pushed property", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				delete(incorrectArtifact.Metadata.Fields, "pushed")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -149,9 +137,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -164,6 +150,9 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with an artifact that has a pushed_destination that is not a string", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				incorrectArtifact.Metadata.Fields["pushed"] = structpb.NewNumberValue(42)
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -171,15 +160,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-												Metadata: &structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"pushed":             structpb.NewNumberValue(1),
-														"pushed_destination": structpb.NewNumberValue(42),
-													},
-												},
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -192,6 +173,9 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with an artifact that has no pushed_destination property", func() {
 			It("Produces no servingModelArtifacts", func() {
+				incorrectArtifact := artifact()
+				delete(incorrectArtifact.Metadata.Fields, "pushed_destination")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -199,14 +183,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											{
-												SchemaTitle: "a.Type",
-												Metadata: &structpb.Struct{
-													Fields: map[string]*structpb.Value{
-														"pushed":             structpb.NewNumberValue(1),
-													},
-												},
-											},
+											incorrectArtifact,
 										},
 									},
 								},
@@ -219,6 +196,10 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has an output with several artifacts", func() {
 			It("Produces several servingModelArtifacts", func() {
+				firstArtifact := artifact()
+				secondArtifact := artifact()
+				secondArtifact.Metadata.Fields["pushed_destination"] = structpb.NewStringValue("gs://some/where/else")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -226,8 +207,8 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											artifact("gs://some/where"),
-											artifact("gs://some/where/else"),
+											firstArtifact,
+											secondArtifact,
 										},
 									},
 								},
@@ -240,6 +221,10 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has several outputs with artifacts", func() {
 			It("Produces several servingModelArtifacts", func() {
+				firstArtifact := artifact()
+				secondArtifact := artifact()
+				secondArtifact.Metadata.Fields["pushed_destination"] = structpb.NewStringValue("gs://some/where/else")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -247,12 +232,12 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											artifact("gs://some/where"),
+											firstArtifact,
 										},
 									},
 									"another-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											artifact("gs://some/where/else"),
+											secondArtifact,
 										},
 									},
 								},
@@ -265,6 +250,10 @@ var _ = Context("VaiEventingServer", func() {
 
 		When("The job has several tasks with artifacts", func() {
 			It("Produces several servingModelArtifacts", func() {
+				firstArtifact := artifact()
+				secondArtifact := artifact()
+				secondArtifact.Metadata.Fields["pushed_destination"] = structpb.NewStringValue("gs://some/where/else")
+
 				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
 					JobDetail: &aiplatformpb.PipelineJobDetail{
 						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
@@ -272,7 +261,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											artifact("gs://some/where"),
+											firstArtifact,
 										},
 									},
 								},
@@ -281,7 +270,7 @@ var _ = Context("VaiEventingServer", func() {
 								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 									"another-model": {
 										Artifacts: []*aiplatformpb.Artifact{
-											artifact("gs://some/where/else"),
+											secondArtifact,
 										},
 									},
 								},
@@ -309,7 +298,7 @@ var _ = Context("VaiEventingServer", func() {
 						Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 							"a-model": {
 								Artifacts: []*aiplatformpb.Artifact{
-									artifact("gs://some/where"),
+									artifact(),
 								},
 							},
 						},

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -12,13 +12,13 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func artifact(uri string) *aiplatformpb.Artifact {
+func artifact(pushedDestination string) *aiplatformpb.Artifact {
 	return &aiplatformpb.Artifact{
-		Uri:         uri,
 		SchemaTitle: "tfx.PushedModel",
 		Metadata: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"pushed": structpb.NewNumberValue(1),
+				"pushed_destination": structpb.NewStringValue(pushedDestination),
 			},
 		},
 	}
@@ -66,11 +66,11 @@ var _ = Context("VaiEventingServer", func() {
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
 											{
-												Uri:         "gs://some/where",
 												SchemaTitle: "a.Type",
 												Metadata: &structpb.Struct{
 													Fields: map[string]*structpb.Value{
 														"pushed": structpb.NewNumberValue(1),
+														"pushed_destination": structpb.NewStringValue("gs://some/where"),
 													},
 												},
 											},
@@ -94,11 +94,11 @@ var _ = Context("VaiEventingServer", func() {
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
 											{
-												Uri:         "gs://some/where",
 												SchemaTitle: "a.Type",
 												Metadata: &structpb.Struct{
 													Fields: map[string]*structpb.Value{
 														"pushed": structpb.NewNumberValue(0),
+														"pushed_destination": structpb.NewStringValue("gs://some/where"),
 													},
 												},
 											},
@@ -122,7 +122,6 @@ var _ = Context("VaiEventingServer", func() {
 									"a-model": {
 										Artifacts: []*aiplatformpb.Artifact{
 											{
-												Uri:         "gs://some/where",
 												SchemaTitle: "a.Type",
 											},
 										},
@@ -227,15 +226,7 @@ var _ = Context("VaiEventingServer", func() {
 						Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
 							"a-model": {
 								Artifacts: []*aiplatformpb.Artifact{
-									{
-										Uri:         "gs://some/where",
-										SchemaTitle: "tfx.PushedModel",
-										Metadata: &structpb.Struct{
-											Fields: map[string]*structpb.Value{
-												"pushed": structpb.NewNumberValue(1),
-											},
-										},
-									},
+									artifact("gs://some/where"),
 								},
 							},
 						},

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -17,7 +17,7 @@ func artifact(pushedDestination string) *aiplatformpb.Artifact {
 		SchemaTitle: "tfx.PushedModel",
 		Metadata: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"pushed": structpb.NewNumberValue(1),
+				"pushed":             structpb.NewNumberValue(1),
 				"pushed_destination": structpb.NewStringValue(pushedDestination),
 			},
 		},
@@ -69,7 +69,7 @@ var _ = Context("VaiEventingServer", func() {
 												SchemaTitle: "a.Type",
 												Metadata: &structpb.Struct{
 													Fields: map[string]*structpb.Value{
-														"pushed": structpb.NewNumberValue(1),
+														"pushed":             structpb.NewNumberValue(1),
 														"pushed_destination": structpb.NewStringValue("gs://some/where"),
 													},
 												},
@@ -97,7 +97,35 @@ var _ = Context("VaiEventingServer", func() {
 												SchemaTitle: "a.Type",
 												Metadata: &structpb.Struct{
 													Fields: map[string]*structpb.Value{
-														"pushed": structpb.NewNumberValue(0),
+														"pushed":             structpb.NewNumberValue(0),
+														"pushed_destination": structpb.NewStringValue("gs://some/where"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEmpty())
+			})
+		})
+
+		When("The job has an output with an artifact that isn't a float", func() {
+			It("Produces no servingModelArtifacts", func() {
+				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
+					JobDetail: &aiplatformpb.PipelineJobDetail{
+						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
+							{
+								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
+									"a-model": {
+										Artifacts: []*aiplatformpb.Artifact{
+											{
+												SchemaTitle: "a.Type",
+												Metadata: &structpb.Struct{
+													Fields: map[string]*structpb.Value{
+														"pushed":             structpb.NewStringValue("42"),
 														"pushed_destination": structpb.NewStringValue("gs://some/where"),
 													},
 												},
@@ -123,6 +151,61 @@ var _ = Context("VaiEventingServer", func() {
 										Artifacts: []*aiplatformpb.Artifact{
 											{
 												SchemaTitle: "a.Type",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEmpty())
+			})
+		})
+
+		When("The job has an output with an artifact that has a pushed_destination that is not a string", func() {
+			It("Produces no servingModelArtifacts", func() {
+				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
+					JobDetail: &aiplatformpb.PipelineJobDetail{
+						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
+							{
+								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
+									"a-model": {
+										Artifacts: []*aiplatformpb.Artifact{
+											{
+												SchemaTitle: "a.Type",
+												Metadata: &structpb.Struct{
+													Fields: map[string]*structpb.Value{
+														"pushed":             structpb.NewNumberValue(1),
+														"pushed_destination": structpb.NewNumberValue(42),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEmpty())
+			})
+		})
+
+		When("The job has an output with an artifact that has no pushed_destination property", func() {
+			It("Produces no servingModelArtifacts", func() {
+				Expect(modelServingArtifactsForJob(&aiplatformpb.PipelineJob{
+					JobDetail: &aiplatformpb.PipelineJobDetail{
+						TaskDetails: []*aiplatformpb.PipelineTaskDetail{
+							{
+								Outputs: map[string]*aiplatformpb.PipelineTaskDetail_ArtifactList{
+									"a-model": {
+										Artifacts: []*aiplatformpb.Artifact{
+											{
+												SchemaTitle: "a.Type",
+												Metadata: &structpb.Struct{
+													Fields: map[string]*structpb.Value{
+														"pushed":             structpb.NewNumberValue(1),
+													},
+												},
 											},
 										},
 									},


### PR DESCRIPTION
The URI is not the location of the pushed model, but the base for pipeline step artifacts (which is present for any pipeline run artifact).
This has been changed to use the `pushed_destination` property instead, which is inline with the KFP equivalent.