### PR TITLE
Change default Workflow TTL

### DIFF
--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -72,9 +72,7 @@ spec:
     configMap:
       name: kfp-operator-providers
   ttlStrategy:
-    secondsAfterCompletion: 600
-    secondsAfterFailure: 3600
-    secondsAfterSuccess: 600
+    secondsAfterCompletion: 3600
   arguments:
     parameters:
     - name: provider-name

--- a/config/manager/workflows/compiled.yaml
+++ b/config/manager/workflows/compiled.yaml
@@ -137,9 +137,7 @@ spec:
     configMap:
       name: kfp-operator-providers
   ttlStrategy:
-    secondsAfterCompletion: 600
-    secondsAfterFailure: 3600
-    secondsAfterSuccess: 600
+    secondsAfterCompletion: 3600
   arguments:
     parameters:
     - name: provider-name
@@ -218,9 +216,7 @@ spec:
     configMap:
       name: kfp-operator-providers
   ttlStrategy:
-    secondsAfterCompletion: 600
-    secondsAfterFailure: 3600
-    secondsAfterSuccess: 600
+    secondsAfterCompletion: 3600
   arguments:
     parameters:
     - name: provider-name

--- a/config/manager/workflows/simple.yaml
+++ b/config/manager/workflows/simple.yaml
@@ -87,9 +87,7 @@ spec:
     configMap:
       name: kfp-operator-providers
   ttlStrategy:
-    secondsAfterCompletion: 600
-    secondsAfterFailure: 3600
-    secondsAfterSuccess: 600
+    secondsAfterCompletion: 3600
   arguments:
     parameters:
     - name: provider-name
@@ -143,9 +141,7 @@ spec:
     configMap:
       name: kfp-operator-providers
   ttlStrategy:
-    secondsAfterCompletion: 600
-    secondsAfterFailure: 3600
-    secondsAfterSuccess: 600
+    secondsAfterCompletion: 3600
   arguments:
     parameters:
     - name: provider-name

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -34,9 +34,7 @@ manager:
     containerDefaults: {}
     metadata: {}
     ttlStrategy:
-      secondsAfterCompletion: 600
-      secondsAfterSuccess: 600
-      secondsAfterFailure: 3600
+      secondsAfterCompletion: 3600
   monitoring:
     create: false
     rbacSecured: false


### PR DESCRIPTION
Remove sencondsAfterSuccess and sencondsAfterFailure and increase sencondsAfterCompletion to allow users to set each field and only keep the fallback option.
