### PR TITLE
Fix failing Run integration tests

### DIFF
--- a/apis/pipelines/v1alpha4/test_generators.go
+++ b/apis/pipelines/v1alpha4/test_generators.go
@@ -72,7 +72,8 @@ func RandomRun() *Run {
 		},
 		Spec: RandomRunSpec(),
 		Status: RunStatus{
-			Status: RandomStatus(),
+			ObservedPipelineVersion: RandomString(),
+			Status:                  RandomStatus(),
 		},
 	}
 }

--- a/controllers/pipelines/experiment_workflow_integration_test.go
+++ b/controllers/pipelines/experiment_workflow_integration_test.go
@@ -5,10 +5,8 @@ package pipelines
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/sky-uk/kfp-operator/apis"
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha4"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha4"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Context("Resource Workflows", Serial, func() {
@@ -20,18 +18,7 @@ var _ = Context("Resource Workflows", Serial, func() {
 	})
 
 	var newExperiment = func() *pipelinesv1.Experiment {
-		return &pipelinesv1.Experiment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      apis.RandomLowercaseString(),
-				Namespace: "argo",
-			},
-			Status: pipelinesv1.Status{
-				ProviderId: pipelinesv1.ProviderAndId{
-					Provider: "stub",
-					Id:       apis.RandomString(),
-				},
-			},
-		}
+		return withIntegrationTestFields(pipelinesv1.RandomExperiment())
 	}
 
 	DescribeTable("Experiment Workflows", AssertWorkflow[*pipelinesv1.Experiment],

--- a/controllers/pipelines/pipeline_workflow_integration_test.go
+++ b/controllers/pipelines/pipeline_workflow_integration_test.go
@@ -5,10 +5,8 @@ package pipelines
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/sky-uk/kfp-operator/apis"
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha4"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha4"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Context("Resource Workflows", Serial, func() {
@@ -20,21 +18,10 @@ var _ = Context("Resource Workflows", Serial, func() {
 	})
 
 	var newPipeline = func() *pipelinesv1.Pipeline {
-		return &pipelinesv1.Pipeline{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      apis.RandomLowercaseString(),
-				Namespace: "argo",
-			},
-			Spec: pipelinesv1.PipelineSpec{
-				Image: "kfp-operator-stub-provider",
-			},
-			Status: pipelinesv1.Status{
-				ProviderId: pipelinesv1.ProviderAndId{
-					Provider: "stub",
-					Id:       apis.RandomString(),
-				},
-			},
-		}
+		pipeline := withIntegrationTestFields(pipelinesv1.RandomPipeline())
+		pipeline.Spec.Image = "kfp-operator-stub-provider"
+
+		return pipeline
 	}
 
 	DescribeTable("Pipeline Workflows", AssertWorkflow[*pipelinesv1.Pipeline],

--- a/controllers/pipelines/run_workflow_integration_test.go
+++ b/controllers/pipelines/run_workflow_integration_test.go
@@ -30,6 +30,7 @@ var _ = Context("Resource Workflows", Serial, func() {
 				Namespace: "argo",
 			},
 			Status: pipelinesv1.RunStatus{
+				ObservedPipelineVersion: apis.RandomString(),
 				Status: pipelinesv1.Status{
 					ProviderId: pipelinesv1.ProviderAndId{
 						Provider: "stub",

--- a/controllers/pipelines/run_workflow_integration_test.go
+++ b/controllers/pipelines/run_workflow_integration_test.go
@@ -7,11 +7,9 @@ import (
 	argo "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/kfp-operator/apis"
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha4"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha4"
 	"github.com/sky-uk/kfp-operator/argo/providers/base"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -24,21 +22,7 @@ var _ = Context("Resource Workflows", Serial, func() {
 	})
 
 	var newRun = func() *pipelinesv1.Run {
-		return &pipelinesv1.Run{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      apis.RandomLowercaseString(),
-				Namespace: "argo",
-			},
-			Status: pipelinesv1.RunStatus{
-				ObservedPipelineVersion: apis.RandomString(),
-				Status: pipelinesv1.Status{
-					ProviderId: pipelinesv1.ProviderAndId{
-						Provider: "stub",
-						Id:       apis.RandomString(),
-					},
-				},
-			},
-		}
+		return withIntegrationTestFields(pipelinesv1.RandomRun())
 	}
 
 	DescribeTable("Run Workflows", AssertWorkflow[*pipelinesv1.Run],

--- a/controllers/pipelines/runconfiguration_workflow_integration_test.go
+++ b/controllers/pipelines/runconfiguration_workflow_integration_test.go
@@ -5,10 +5,8 @@ package pipelines
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/sky-uk/kfp-operator/apis"
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha4"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha4"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Context("Resource Workflows", Serial, func() {
@@ -20,21 +18,7 @@ var _ = Context("Resource Workflows", Serial, func() {
 	})
 
 	var newRunConfiguration = func() *pipelinesv1.RunConfiguration {
-		return &pipelinesv1.RunConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      apis.RandomLowercaseString(),
-				Namespace: "argo",
-			},
-			Status: pipelinesv1.RunConfigurationStatus{
-				ObservedPipelineVersion: apis.RandomString(),
-				Status: pipelinesv1.Status{
-					ProviderId: pipelinesv1.ProviderAndId{
-						Provider: "stub",
-						Id:       apis.RandomString(),
-					},
-				},
-			},
-		}
+		return withIntegrationTestFields(pipelinesv1.RandomRunConfiguration())
 	}
 
 	DescribeTable("RunConfiguration Workflows", AssertWorkflow[*pipelinesv1.RunConfiguration],

--- a/controllers/pipelines/suite_integration_test.go
+++ b/controllers/pipelines/suite_integration_test.go
@@ -126,3 +126,12 @@ func AssertWorkflow[R pipelinesv1.Resource](
 			g.Expect(output.Id).To(Equal(expectedOutput.Id))
 		}), TestTimeout).Should(Succeed())
 }
+
+func withIntegrationTestFields[T pipelinesv1.Resource](resource T) T {
+	resource.SetNamespace("argo")
+	resourceStatus := resource.GetStatus()
+	resourceStatus.ProviderId.Provider = "stub"
+	resource.SetStatus(resourceStatus)
+
+	return resource
+}


### PR DESCRIPTION
Since introducing `ObservedPipelineVersion` into the Run Status in https://github.com/sky-uk/kfp-operator/commit/e973f34633e81055eba2271b5e6632ae1725b951, the workflow factory required this field to be present.
This PR adds the field to randomly generated Run resources in the integration tests.