### PR TITLE
Populate RC Provider ID from RS if empty

### DIFF
--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -225,6 +225,22 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 		})
 	})
 
+	When("A RunSchedule with a ProviderId exists for a RunConfiguration without a ProviderId", func() {
+		It("keeps the RunConfiguration in sync", func() {
+			runConfiguration := pipelinesv1.RandomRunConfiguration()
+			rcHelper := CreateSucceeded(runConfiguration)
+			expectedProviderId := rcHelper.Resource.Status.ProviderId
+
+			Expect(rcHelper.UpdateStatus(func(configuration *pipelinesv1.RunConfiguration) {
+				configuration.Status.ProviderId = pipelinesv1.ProviderAndId{}
+			})).To(Succeed())
+
+			Eventually(rcHelper.ToMatch(func(g Gomega, configuration *pipelinesv1.RunConfiguration) {
+				g.Expect(configuration.Status.ProviderId).To(Equal(expectedProviderId))
+			})).Should(Succeed())
+		})
+	})
+
 	When("More than one RunSchedule exists for a RunConfiguration", func() {
 		It("keeps only one matching RunSchedule", func() {
 			runConfiguration := pipelinesv1.RandomRunConfiguration()


### PR DESCRIPTION
Relates to #213. This is a requrement for migration to the new triggers format. It addresses the following rollback scenario:
1. operator migrated to version that supports v1alpha5 with triggers
2. resource updated by operator not populating the provider ID as part of v1alpha5 (conversion to v1alpha4 would leave it empty) - this would change the provider ID in the RS  
3. operator downgraded to previous version

Without this card, the Provider ID in the RC would be empty and not consistent with the one in the RS, resulting in the operator attempting to create a new schedule on the provider, and setting a new provider ID.
