### PR TITLE
Populate version in RC if empty

### DIFF
--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -101,6 +101,7 @@ func (r *RunConfigurationReconciler) syncRunSchedule(ctx context.Context, runCon
 	} else if runConfiguration.Status.ProviderId.Id == "" && runSchedule.Status.ProviderId.Id != "" {
 		hasChanged = true
 		runConfiguration.Status.ProviderId = runSchedule.Status.ProviderId
+		runConfiguration.Status.Version = runConfiguration.ComputeVersion()
 
 		err = r.EC.Client.Status().Update(ctx, runConfiguration)
 

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -230,13 +230,17 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 			runConfiguration := pipelinesv1.RandomRunConfiguration()
 			rcHelper := CreateSucceeded(runConfiguration)
 			expectedProviderId := rcHelper.Resource.Status.ProviderId
+			expectedVersion := rcHelper.Resource.Status.Version
 
 			Expect(rcHelper.UpdateStatus(func(configuration *pipelinesv1.RunConfiguration) {
 				configuration.Status.ProviderId = pipelinesv1.ProviderAndId{}
+				configuration.Status.Version = apis.RandomString()
 			})).To(Succeed())
 
 			Eventually(rcHelper.ToMatch(func(g Gomega, configuration *pipelinesv1.RunConfiguration) {
 				g.Expect(configuration.Status.ProviderId).To(Equal(expectedProviderId))
+				g.Expect(configuration.Status.Version).To(Equal(expectedVersion))
+				g.Expect(configuration.Status.SynchronizationState).To(Equal(apis.Succeeded))
 			})).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Relates to #213
Similar to #223, when the ProviderId is empty, the version should be populated from the RunSchedule to avoid unnecessary updates


