### PR TITLE
Succeed run completer when no namespace is provided

### DIFF
--- a/argo/run-completer/run_completer.go
+++ b/argo/run-completer/run_completer.go
@@ -25,6 +25,10 @@ type RunCompleter struct {
 }
 
 func (c *RunCompleter) CompleteRun(ctx context.Context, runCompletionEvent common.RunCompletionEvent) error {
+	if runCompletionEvent.RunName.Namespace == "" {
+		return nil
+	}
+
 	run := pipelinesv1.Run{}
 
 	if err := c.K8sClient.Get(ctx, types.NamespacedName{Namespace: runCompletionEvent.RunName.Namespace, Name: runCompletionEvent.RunName.Name}, &run); err != nil {

--- a/argo/run-completer/suite_decoupled_test.go
+++ b/argo/run-completer/suite_decoupled_test.go
@@ -107,6 +107,18 @@ var _ = Context("Run Completer", Serial, func() {
 		})
 	})
 
+	When("the run name has no namespace", func() {
+		It("do nothing", func() {
+			ctx := context.Background()
+
+			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: common.NamespacedName{
+				Name:      common.RandomString(),
+			}}
+
+			Expect(runCompleter.CompleteRun(ctx, runCompletionEvent)).To(Succeed())
+		})
+	})
+
 	When("the k8s API is unreachable", func() {
 		It("errors", func() {
 			ctx := context.Background()


### PR DESCRIPTION
Jobs that are not triggered by a one-off run do not contain a namespace in the RunCompletionEvent.
This is a valid scenario and should not fail the workflow.