### PR TITLE
Filter Runschedules marked for deletion

### DIFF
--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -61,12 +61,11 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if runConfiguration.Status.Provider != "" && desiredProvider != runConfiguration.Status.Provider {
 		//TODO: refactor to use Commands and introduce a StateHandler
 		runConfiguration.Status.SynchronizationState = apis.Failed
-		if err := r.EC.Client.Status().Update(ctx, runConfiguration); err != nil {
-			return ctrl.Result{}, err
-		}
 
 		message := fmt.Sprintf(`%s: %s`, string(runConfiguration.Status.SynchronizationState), StateHandlerConstants.ProviderChangedError)
 		r.EC.Recorder.Event(runConfiguration, EventTypes.Warning, EventReasons.SyncFailed, message)
+
+		return ctrl.Result{}, r.EC.Client.Status().Update(ctx, runConfiguration)
 	}
 
 	if hasChanged, err := r.handleObservedPipelineVersion(ctx, runConfiguration.Spec.Run.Pipeline, runConfiguration); hasChanged || err != nil {

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -143,7 +143,9 @@ func (r *RunConfigurationReconciler) syncWithRunSchedules(ctx context.Context, p
 	}
 
 	missingSchedules := sliceDiff(desiredSchedules, dependentSchedules, compareRunSchedules)
-	excessSchedules := sliceDiff(dependentSchedules, desiredSchedules, compareRunSchedules)
+	excessSchedules := filter(sliceDiff(dependentSchedules, desiredSchedules, compareRunSchedules), func(schedule pipelinesv1.RunSchedule) bool {
+		return schedule.DeletionTimestamp == nil
+	})
 	isSynced := len(missingSchedules) == 0 && len(excessSchedules) == 0
 
 	if !isSynced {

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -50,7 +50,7 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 		Expect(k8sClient.Update(ctx, runConfiguration)).To(Succeed())
 
 		Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, configuration *pipelinesv1.RunConfiguration) {
-			g.Expect(runConfiguration.Status.SynchronizationState).To(Equal(apis.Succeeded))
+			g.Expect(runConfiguration.Status.SynchronizationState).To(Equal(apis.Updating))
 			g.Expect(runConfiguration.Status.ObservedGeneration).To(Equal(runConfiguration.GetGeneration()))
 		})).Should(Succeed())
 

--- a/controllers/pipelines/utils.go
+++ b/controllers/pipelines/utils.go
@@ -36,3 +36,13 @@ func sliceDiff[T any](as, bs []T, cmp func(T, T) bool) []T {
 
 	return diff
 }
+
+func filter[T any](ts []T, filter func(T) bool) (filtered []T) {
+	for _, t := range ts {
+		if filter(t) {
+			filtered = append(filtered, t)
+		}
+	}
+
+	return
+}

--- a/controllers/pipelines/utils_test.go
+++ b/controllers/pipelines/utils_test.go
@@ -4,6 +4,7 @@
 package pipelines
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,12 +13,23 @@ var _ = Context("Utils", func() {
 	DescribeTable("sliceDiff", func(as, bs, expected []int) {
 		Expect(sliceDiff(as, bs, func(a int, b int) bool {
 			return a == b
-		})).To(Equal(expected))
+		})).To(BeComparableTo(expected, cmpopts.EquateEmpty()))
 	},
 		Entry("", []int{1, 2}, []int{1}, []int{2}),
 		Entry("", []int{2, 1}, []int{1}, []int{2}),
 		Entry("", []int{1}, []int{}, []int{1}),
-		Entry("", []int{1}, []int{1}, nil),
-		Entry("", []int{}, []int{1}, nil),
+		Entry("", []int{1}, []int{1}, []int{}),
+		Entry("", []int{}, []int{1}, []int{}),
+	)
+
+	DescribeTable("filter", func(as, expected []int) {
+		Expect(filter(as, func(a int) bool {
+			return a%2 == 0
+		})).To(BeComparableTo(expected, cmpopts.EquateEmpty()))
+	},
+		Entry("", []int{1, 2}, []int{2}),
+		Entry("", []int{2, 1}, []int{2}),
+		Entry("", []int{1}, []int{}),
+		Entry("", []int{}, []int{}),
 	)
 })


### PR DESCRIPTION
The aggregate State of RunConfigurations is calculated only if no sync is currently performed.
A sync is performed by creating missing and deleting excess schedules.
in each iteration, excess schedules are currently marked for deletion.
This PR stops considering schedules marked for deletion as excess schedules any longer.