### PR TITLE
Cross-compile Go binaries outside docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,7 @@
-# Build the manager binary
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY go.work go.work
-COPY argo/ argo/
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-COPY external/ external/
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY bin/manager /
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-COPY bin/manager /
+
+WORKDIR /
+COPY bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,6 @@ IMG ?= kfp-operator-controller
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:preserveUnknownFields=false"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 all: build
 
 ##@ General
@@ -94,7 +87,7 @@ integration-test-all: integration-test
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go --zap-devel --config config/manager/controller_manager_config.yaml

--- a/argo/common/test_utils.go
+++ b/argo/common/test_utils.go
@@ -1,5 +1,5 @@
-//go:build unit || decoupled
-// +build unit decoupled
+//go:build unit || decoupled || integration
+// +build unit decoupled integration
 
 package common
 

--- a/argo/kfp-compiler/Dockerfile
+++ b/argo/kfp-compiler/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.7.12 AS PYTHON37
+
 ARG WHEEL_VERSION
 
 COPY dist/*-${WHEEL_VERSION}-*.whl /
@@ -14,10 +15,11 @@ RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
 
 FROM alpine:3.14.2
 
-COPY --from=PYTHON37 /kfp-compiler /kfp-compiler/py3.7
-COPY --from=PYTHON39 /kfp-compiler /kfp-compiler/py3.9
-ADD resources/compile.sh /kfp-compiler/compile.sh
+WORKDIR /
+COPY --from=PYTHON37 /kfp-compiler kfp-compiler/py3.7
+COPY --from=PYTHON39 /kfp-compiler kfp-compiler/py3.9
+ADD resources/compile.sh kfp-compiler/compile.sh
 
-ADD resources/entrypoint.sh /entrypoint.sh
+ADD resources/entrypoint.sh entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/argo/kfp-compiler/Dockerfile
+++ b/argo/kfp-compiler/Dockerfile
@@ -1,14 +1,14 @@
 FROM python:3.7.12 AS PYTHON37
 ARG WHEEL_VERSION
 
-COPY argo/kfp-compiler/dist/*-${WHEEL_VERSION}-*.whl /
+COPY dist/*-${WHEEL_VERSION}-*.whl /
 RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
     rm /*-${WHEEL_VERSION}-*.whl
 
 FROM python:3.9.13 AS PYTHON39
 ARG WHEEL_VERSION
 
-COPY argo/kfp-compiler/dist/*-${WHEEL_VERSION}-*.whl /
+COPY dist/*-${WHEEL_VERSION}-*.whl /
 RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
     rm /*-${WHEEL_VERSION}-*.whl
 
@@ -16,8 +16,8 @@ FROM alpine:3.14.2
 
 COPY --from=PYTHON37 /kfp-compiler /kfp-compiler/py3.7
 COPY --from=PYTHON39 /kfp-compiler /kfp-compiler/py3.9
-ADD argo/kfp-compiler/resources/compile.sh /kfp-compiler/compile.sh
+ADD resources/compile.sh /kfp-compiler/compile.sh
 
-ADD argo/kfp-compiler/resources/entrypoint.sh /entrypoint.sh
+ADD resources/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/argo/providers/kfp/Dockerfile
+++ b/argo/providers/kfp/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/static:nonroot
-COPY bin/provider /
+
+WORKDIR /
+COPY bin/provider .
 USER 65532:65532
 
 ENTRYPOINT ["/provider"]

--- a/argo/providers/kfp/Dockerfile
+++ b/argo/providers/kfp/Dockerfile
@@ -1,21 +1,5 @@
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-
-COPY argo argo
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY apis apis
-
-WORKDIR /workspace/argo/providers
-
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o provider ./kfp/cmd
-
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/argo/providers .
+COPY bin/provider /
 USER 65532:65532
 
 ENTRYPOINT ["/provider"]

--- a/argo/providers/kfp/Makefile
+++ b/argo/providers/kfp/Makefile
@@ -38,7 +38,7 @@ test: unit-test decoupled-test
 ##@ Build
 
 build: generate
-	go build -o bin/provider ./cmd
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/providers/stub/Dockerfile
+++ b/argo/providers/stub/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.17.0
-COPY inject.sh /inject.sh
-COPY compile.sh /compile.sh
-COPY bin/provider /
+
+WORKDIR /
+COPY inject.sh inject.sh
+COPY compile.sh compile.sh
+COPY bin/provider .
 USER 65532:65532
 
 ENTRYPOINT ["/bin/sh", "/inject.sh"]

--- a/argo/providers/stub/Dockerfile
+++ b/argo/providers/stub/Dockerfile
@@ -1,23 +1,7 @@
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-
-COPY argo argo
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY apis apis
-
-WORKDIR /workspace/argo/providers
-
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o provider ./stub/cmd
-
 FROM alpine:3.17.0
-WORKDIR /
-COPY argo/providers/stub/inject.sh /inject.sh
-COPY argo/providers/stub/compile.sh /compile.sh
-COPY --from=builder /workspace/argo/providers .
+COPY inject.sh /inject.sh
+COPY compile.sh /compile.sh
+COPY bin/provider /
 USER 65532:65532
 
 ENTRYPOINT ["/bin/sh", "/inject.sh"]

--- a/argo/providers/stub/Makefile
+++ b/argo/providers/stub/Makefile
@@ -5,7 +5,7 @@ IMG := kfp-operator-stub-provider
 ##@ Build
 
 build:
-	go build -o bin/provider ./cmd
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/providers/vai/Dockerfile
+++ b/argo/providers/vai/Dockerfile
@@ -1,21 +1,5 @@
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-
-COPY argo argo
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY apis apis
-
-WORKDIR /workspace/argo/providers
-
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o provider ./vai/cmd
-
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/argo/providers .
+COPY bin/provider /
 USER 65532:65532
 
 ENTRYPOINT ["/provider"]

--- a/argo/providers/vai/Dockerfile
+++ b/argo/providers/vai/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/static:nonroot
-COPY bin/provider /
+
+WORKDIR /
+COPY bin/provider .
 USER 65532:65532
 
 ENTRYPOINT ["/provider"]

--- a/argo/providers/vai/Makefile
+++ b/argo/providers/vai/Makefile
@@ -19,7 +19,7 @@ generate: mockgen
 	$(MOCKGEN) -destination mock_pipeline_client.go -package=vai github.com/sky-uk/kfp-operator/argo/providers/vai PipelineJobClient
 
 build: generate
-	go build -o bin/provider ./cmd
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/run-completer/Dockerfile
+++ b/argo/run-completer/Dockerfile
@@ -1,21 +1,5 @@
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-
-COPY argo argo
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY apis apis
-
-WORKDIR /workspace/argo/run-completer
-
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o run-completer ./cmd
-
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/argo/run-completer .
+COPY bin/run-completer /
 USER 65532:65532
 
 ENTRYPOINT ["/run-completer"]

--- a/argo/run-completer/Dockerfile
+++ b/argo/run-completer/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/static:nonroot
-COPY bin/run-completer /
+
+WORKDIR /
+COPY bin/run-completer .
 USER 65532:65532
 
 ENTRYPOINT ["/run-completer"]

--- a/argo/run-completer/Makefile
+++ b/argo/run-completer/Makefile
@@ -17,7 +17,7 @@ test: unit-test decoupled-test
 ##@ Build
 
 build:
-	go build -o bin/run-completer ./cmd
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/run-completer ./cmd
 
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/docker-targets.mk
+++ b/docker-targets.mk
@@ -18,5 +18,7 @@ define docker-push-to-registry
 endef
 endif
 
+docker-build: GOOS=linux
+docker-build: GOARCH=amd64
 docker-build: build ## Build container image
-	docker build ${DOCKER_BUILD_EXTRA_PARAMS} -t ${IMG} -t ${IMG}:${VERSION} -f Dockerfile $(_DOCKER_TARGETS_MK_DIR)
+	docker build ${DOCKER_BUILD_EXTRA_PARAMS} -t ${IMG} -t ${IMG}:${VERSION} -f Dockerfile .


### PR DESCRIPTION
Cross-compile Go binaries outside Docker containers. This speeds up Docker builds and therefore integration tests significantly.