### PR TITLE
RunCompletionEvent changes

### DIFF
--- a/argo/common/common_types.go
+++ b/argo/common/common_types.go
@@ -49,6 +49,15 @@ func NamespacedNameFromString(namespacedName string) (NamespacedName, error) {
 	}, nil
 }
 
+// Optionally render structs until https://github.com/golang/go/issues/11939 is addressed
+func (nsn NamespacedName) NonEmptyPtr() *NamespacedName {
+	if nsn.Empty() {
+		return nil
+	}
+
+	return &nsn
+}
+
 func (nsn NamespacedName) MarshalText() ([]byte, error) {
 	serialised, err := nsn.String()
 	if err != nil {

--- a/argo/common/run_completion.go
+++ b/argo/common/run_completion.go
@@ -20,7 +20,7 @@ var RunCompletionStatuses = struct {
 type RunCompletionEvent struct {
 	Status                RunCompletionStatus    `json:"status"`
 	PipelineName          string                 `json:"pipelineName"`
-	RunConfigurationName  string                 `json:"runConfigurationName,omitempty"`
+	RunConfigurationName  NamespacedName                 `json:"runConfigurationName,omitempty"`
 	RunName               NamespacedName         `json:"runName,omitempty"`
 	ServingModelArtifacts []ServingModelArtifact `json:"servingModelArtifacts"`
 }

--- a/argo/common/run_completion.go
+++ b/argo/common/run_completion.go
@@ -20,7 +20,7 @@ var RunCompletionStatuses = struct {
 type RunCompletionEvent struct {
 	Status                RunCompletionStatus    `json:"status"`
 	PipelineName          string                 `json:"pipelineName"`
-	RunConfigurationName  NamespacedName                 `json:"runConfigurationName,omitempty"`
+	RunConfigurationName  NamespacedName         `json:"runConfigurationName,omitempty"`
 	RunName               NamespacedName         `json:"runName,omitempty"`
 	ServingModelArtifacts []ServingModelArtifact `json:"servingModelArtifacts"`
 }

--- a/argo/common/run_completion.go
+++ b/argo/common/run_completion.go
@@ -20,8 +20,9 @@ var RunCompletionStatuses = struct {
 type RunCompletionEvent struct {
 	Status                RunCompletionStatus    `json:"status"`
 	PipelineName          NamespacedName         `json:"pipelineName"`
-	RunConfigurationName  NamespacedName         `json:"runConfigurationName,omitempty"`
-	RunName               NamespacedName         `json:"runName,omitempty"`
-	RunId				  string 			     `json:"runId"`
+	// Optionally render structs until https://github.com/golang/go/issues/11939 is addressed
+	RunConfigurationName  *NamespacedName        `json:"runConfigurationName,omitempty"`
+	RunName               *NamespacedName        `json:"runName,omitempty"`
+	RunId                 string                 `json:"runId"`
 	ServingModelArtifacts []ServingModelArtifact `json:"servingModelArtifacts"`
 }

--- a/argo/common/run_completion.go
+++ b/argo/common/run_completion.go
@@ -19,8 +19,9 @@ var RunCompletionStatuses = struct {
 
 type RunCompletionEvent struct {
 	Status                RunCompletionStatus    `json:"status"`
-	PipelineName          string                 `json:"pipelineName"`
+	PipelineName          NamespacedName         `json:"pipelineName"`
 	RunConfigurationName  NamespacedName         `json:"runConfigurationName,omitempty"`
 	RunName               NamespacedName         `json:"runName,omitempty"`
+	RunId				  string 			     `json:"runId"`
 	ServingModelArtifacts []ServingModelArtifact `json:"servingModelArtifacts"`
 }

--- a/argo/common/suite_unit_test.go
+++ b/argo/common/suite_unit_test.go
@@ -48,7 +48,7 @@ var _ = Context("NamespacedName.String", Serial, func() {
 	namespace := RandomString()
 
 	When("all fields are provided", func() {
-		It("serialises into a '/' separated String", func() {
+		It("serialises into a '/' separated string", func() {
 			serialised, err := NamespacedName{Namespace: namespace, Name: name}.String()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serialised).To(Equal(namespace+"/"+name))
@@ -71,7 +71,7 @@ var _ = Context("NamespacedName.String", Serial, func() {
 	})
 
 	When("nothing is provided", func() {
-		It("serialises into the empty String", func() {
+		It("serialises into the empty string", func() {
 			serialised, err := NamespacedName{}.String()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serialised).To(BeEmpty())
@@ -115,7 +115,7 @@ var _ = Context("NamespacedNameFromString", Serial, func() {
 		})
 	})
 
-	When("empty String", func() {
+	When("empty string", func() {
 		It("deserialises into empty NamespacedName", func() {
 			deserialised, err := NamespacedNameFromString("")
 			Expect(err).NotTo(HaveOccurred())

--- a/argo/common/suite_unit_test.go
+++ b/argo/common/suite_unit_test.go
@@ -43,13 +43,13 @@ var _ = Context("Marshal NamespacedName", Serial, func() {
 	})
 })
 
-var _ = Context("NamespacedName.string", Serial, func() {
+var _ = Context("NamespacedName.String", Serial, func() {
 	name := RandomString()
 	namespace := RandomString()
 
 	When("all fields are provided", func() {
-		It("serialises into a '/' separated string", func() {
-			serialised, err := NamespacedName{Namespace: namespace, Name: name}.string()
+		It("serialises into a '/' separated String", func() {
+			serialised, err := NamespacedName{Namespace: namespace, Name: name}.String()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serialised).To(Equal(namespace+"/"+name))
 		})
@@ -57,7 +57,7 @@ var _ = Context("NamespacedName.string", Serial, func() {
 
 	When("only a name is provided", func() {
 		It("serialises only the name", func() {
-			serialised, err := NamespacedName{Name: name}.string()
+			serialised, err := NamespacedName{Name: name}.String()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serialised).To(Equal(name))
 		})
@@ -65,27 +65,27 @@ var _ = Context("NamespacedName.string", Serial, func() {
 
 	When("only namespace provided", func() {
 		It("errors", func() {
-			_, err := NamespacedName{Namespace: namespace}.string()
+			_, err := NamespacedName{Namespace: namespace}.String()
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("nothing is provided", func() {
-		It("serialises into the empty string", func() {
-			serialised, err := NamespacedName{}.string()
+		It("serialises into the empty String", func() {
+			serialised, err := NamespacedName{}.String()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serialised).To(BeEmpty())
 		})
 	})
 })
 
-var _ = Context("namespacedNameFromString", Serial, func() {
+var _ = Context("NamespacedNameFromString", Serial, func() {
 	name := RandomString()
 	namespace := RandomString()
 
 	When("single `/` with fields", func() {
 		It("deserialises into NamespacedName", func() {
-			deserialised, err := namespacedNameFromString(namespace+"/"+name)
+			deserialised, err := NamespacedNameFromString(namespace+"/"+name)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deserialised).To(Equal(NamespacedName{Namespace: namespace, Name: name}))
 		})
@@ -93,31 +93,31 @@ var _ = Context("namespacedNameFromString", Serial, func() {
 
 	When("single `/` without fields", func() {
 		It("errors", func() {
-			_, err := namespacedNameFromString("/"+name)
+			_, err := NamespacedNameFromString("/"+name)
 			Expect(err).To(HaveOccurred())
-			_, err = namespacedNameFromString(namespace+"/")
+			_, err = NamespacedNameFromString(namespace+"/")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("multiple `/`", func() {
 		It("deserialises into NamespacedName", func() {
-			_, err := namespacedNameFromString(namespace+"/"+name+"/"+RandomString())
+			_, err := NamespacedNameFromString(namespace+"/"+name+"/"+RandomString())
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("no `/`", func() {
 		It("deserialises into empty name only", func() {
-			deserialised, err := namespacedNameFromString(name)
+			deserialised, err := NamespacedNameFromString(name)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deserialised).To(Equal(NamespacedName{Name: name}))
 		})
 	})
 
-	When("empty string", func() {
+	When("empty String", func() {
 		It("deserialises into empty NamespacedName", func() {
-			deserialised, err := namespacedNameFromString("")
+			deserialised, err := NamespacedNameFromString("")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deserialised).To(Equal(NamespacedName{}))
 		})

--- a/argo/common/test_utils.go
+++ b/argo/common/test_utils.go
@@ -28,3 +28,6 @@ func RandomNamespacedName() NamespacedName {
 	}
 }
 
+func UnsafeValue[T any](t T, _ error) T {
+	return t
+}

--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -27,7 +27,7 @@ type RunScheduleDefinition struct {
 	Name                 string                `yaml:"name"`
 	RunConfigurationName common.NamespacedName `yaml:"runConfigurationName"`
 	Version              string                `yaml:"version"`
-	PipelineName         string                `yaml:"pipelineName"`
+	PipelineName         common.NamespacedName `yaml:"pipelineName"`
 	PipelineVersion      string                `yaml:"pipelineVersion"`
 	ExperimentName       string                `yaml:"experimentName"`
 	Schedule             string                `yaml:"schedule"`
@@ -37,7 +37,7 @@ type RunScheduleDefinition struct {
 type RunDefinition struct {
 	Name              common.NamespacedName `yaml:"name"`
 	Version           string                `yaml:"version"`
-	PipelineName      string                `yaml:"pipelineName"`
+	PipelineName      common.NamespacedName `yaml:"pipelineName"`
 	PipelineVersion   string                `yaml:"pipelineVersion"`
 	ExperimentName    string                `yaml:"experimentName"`
 	RuntimeParameters map[string]string     `yaml:"runtimeParameters"`

--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -24,14 +24,14 @@ type ExperimentDefinition struct {
 }
 
 type RunScheduleDefinition struct {
-	Name                 string            `yaml:"name"`
-	RunConfigurationName string            `yaml:"runConfigurationName"`
-	Version              string            `yaml:"version"`
-	PipelineName         string            `yaml:"pipelineName"`
-	PipelineVersion      string            `yaml:"pipelineVersion"`
-	ExperimentName       string            `yaml:"experimentName"`
-	Schedule             string            `yaml:"schedule"`
-	RuntimeParameters    map[string]string `yaml:"runtimeParameters"`
+	Name                 string                `yaml:"name"`
+	RunConfigurationName common.NamespacedName `yaml:"runConfigurationName"`
+	Version              string                `yaml:"version"`
+	PipelineName         string                `yaml:"pipelineName"`
+	PipelineVersion      string                `yaml:"pipelineVersion"`
+	ExperimentName       string                `yaml:"experimentName"`
+	Schedule             string                `yaml:"schedule"`
+	RuntimeParameters    map[string]string     `yaml:"runtimeParameters"`
 }
 
 type RunDefinition struct {

--- a/argo/providers/kfp/eventing_server.go
+++ b/argo/providers/kfp/eventing_server.go
@@ -192,6 +192,7 @@ func (es *KfpEventingServer) eventForWorkflow(ctx context.Context, workflow *uns
 		return nil, err
 	}
 
+	// For compatability with resources created with v0.3.0 and older
 	if resourceReferences.PipelineName.Empty() {
 		pipelineName := getPipelineName(workflow)
 		if pipelineName == "" {
@@ -204,10 +205,10 @@ func (es *KfpEventingServer) eventForWorkflow(ctx context.Context, workflow *uns
 
 	return &common.RunCompletionEvent{
 		Status:                status,
-		PipelineName: 		   resourceReferences.PipelineName,
-		RunConfigurationName:  resourceReferences.RunConfigurationName,
-		RunName:               resourceReferences.RunName,
-		RunId: 				   runId,
+		PipelineName:          resourceReferences.PipelineName,
+		RunConfigurationName:  resourceReferences.RunConfigurationName.NonEmptyPtr(),
+		RunName:               resourceReferences.RunName.NonEmptyPtr(),
+		RunId:                 runId,
 		ServingModelArtifacts: modelArtifacts,
 	}, nil
 }

--- a/argo/providers/kfp/eventing_server_unit_test.go
+++ b/argo/providers/kfp/eventing_server_unit_test.go
@@ -252,8 +252,8 @@ var _ = Context("Eventing Server", func() {
 		event, err := eventingServer.eventForWorkflow(context.Background(), workflow)
 
 		Expect(event.ServingModelArtifacts).To(Equal(artifacts))
-		Expect(event.RunConfigurationName).To(Equal(resourceReferences.RunConfigurationName))
-		Expect(event.RunName).To(Equal(resourceReferences.RunName))
+		Expect(*event.RunConfigurationName).To(Equal(resourceReferences.RunConfigurationName))
+		Expect(*event.RunName).To(Equal(resourceReferences.RunName))
 		Expect(err).NotTo(HaveOccurred())
 	},
 		Entry("workflow succeeded", argo.WorkflowSucceeded),

--- a/argo/providers/kfp/eventing_server_unit_test.go
+++ b/argo/providers/kfp/eventing_server_unit_test.go
@@ -193,12 +193,17 @@ var _ = Context("Eventing Server", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Doesn't emit an event when the workflow has no pipeline name", func() {
+		It("Doesn't emit an event when no ResourceReferences can be found and the workflow has no pipeline name", func() {
 			workflow := &unstructured.Unstructured{}
 			setWorkflowPhase(workflow, argo.WorkflowSucceeded)
 
+			mockMetadataStore := MockMetadataStore{}
+			mockKfpApi := MockKfpApi{}
+
 			eventingServer := KfpEventingServer{
 				Logger: logr.Discard(),
+				MetadataStore: &mockMetadataStore,
+				KfpApi:        &mockKfpApi,
 			}
 
 			event, err := eventingServer.eventForWorkflow(context.Background(), workflow)

--- a/argo/providers/kfp/kfp_api.go
+++ b/argo/providers/kfp/kfp_api.go
@@ -2,7 +2,6 @@ package kfp
 
 import (
 	"context"
-	"fmt"
 	"github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/sky-uk/kfp-operator/argo/providers/base"
@@ -69,15 +68,11 @@ func (gka *GrpcKfpApi) GetRunConfigurationNameFromJob(ctx context.Context, jobId
 	if err != nil {
 		return common.NamespacedName{}, err
 	}
-	fmt.Println(job.Description)
 
 	runScheduleDefinition := base.RunScheduleDefinition{}
 	if err := yaml.Unmarshal([]byte(job.Description), &runScheduleDefinition); err != nil {
-		fmt.Println(err)
 		return common.NamespacedName{}, err
 	}
-
-	fmt.Println(runScheduleDefinition)
 
 	return runScheduleDefinition.RunConfigurationName, nil
 }

--- a/argo/providers/kfp/kfp_api.go
+++ b/argo/providers/kfp/kfp_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	"github.com/sky-uk/kfp-operator/argo/providers/base"
 	"gopkg.in/yaml.v2"
 )
 
@@ -24,8 +23,9 @@ type GrpcKfpApi struct {
 }
 
 type ResourceReferences struct {
-	RunConfigurationName common.NamespacedName
-	RunName              common.NamespacedName
+	RunConfigurationName common.NamespacedName `yaml:"runConfigurationName"`
+	RunName              common.NamespacedName `yaml:"runName"`
+	PipelineName         common.NamespacedName `yaml:"pipelineName"`
 }
 
 func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) (ResourceReferences, error) {
@@ -33,28 +33,32 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 
 	runDetail, err := gka.RunServiceClient.GetRun(ctx, &go_client.GetRunRequest{RunId: runId})
 	if err != nil {
+		return ResourceReferences{}, err
+	}
+	resourceReferences, ok, err := gka.GetResourceReferencesFromDescription(runDetail.Run.Description)
+	if ok || err != nil {
 		return resourceReferences, err
 	}
 
-	resourceReferences.RunName.Name = runDetail.GetRun().GetName()
-
 	for _, ref := range runDetail.GetRun().GetResourceReferences() {
 		if ref.GetKey().GetType() == go_client.ResourceType_JOB && ref.GetRelationship() == go_client.Relationship_CREATOR {
-			rcNameFromJob, err := gka.GetRunConfigurationNameFromJob(ctx, ref.GetKey().GetId())
+			job, err := gka.JobServiceClient.GetJob(ctx, &go_client.GetJobRequest{Id: ref.GetKey().GetId()})
 			if err != nil {
 				return ResourceReferences{}, err
 			}
-
-			if rcNameFromJob.Empty() {
-				// For compatability with resources created with v0.3.0 and older
-				resourceReferences.RunConfigurationName.Name = ref.GetName()
-			} else {
-				resourceReferences.RunConfigurationName = rcNameFromJob
+			resourceReferences, ok, err = gka.GetResourceReferencesFromDescription(job.Description)
+			if ok || err != nil {
+				return resourceReferences, err
 			}
+
+			// For compatability with resources created with v0.3.0 and older
+			resourceReferences.RunConfigurationName.Name = ref.GetName()
 			continue
 		}
 
 		if ref.GetKey().GetType() == go_client.ResourceType_NAMESPACE && ref.GetRelationship() == go_client.Relationship_OWNER {
+			// For compatability with resources created with v0.3.0 and older
+			resourceReferences.RunName.Name = runDetail.GetRun().GetName()
 			resourceReferences.RunName.Namespace = ref.GetKey().GetId()
 			continue
 		}
@@ -63,16 +67,12 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 	return resourceReferences, nil
 }
 
-func (gka *GrpcKfpApi) GetRunConfigurationNameFromJob(ctx context.Context, jobId string) (common.NamespacedName, error) {
-	job, err := gka.JobServiceClient.GetJob(ctx, &go_client.GetJobRequest{Id: jobId})
-	if err != nil {
-		return common.NamespacedName{}, err
+func (gka *GrpcKfpApi) GetResourceReferencesFromDescription(description string) (ResourceReferences, bool, error) {
+	if description == "" {
+		return ResourceReferences{}, false, nil
 	}
 
-	runScheduleDefinition := base.RunScheduleDefinition{}
-	if err := yaml.Unmarshal([]byte(job.Description), &runScheduleDefinition); err != nil {
-		return common.NamespacedName{}, err
-	}
-
-	return runScheduleDefinition.RunConfigurationName, nil
+	resourceReferences := ResourceReferences{}
+	err := yaml.Unmarshal([]byte(description), &resourceReferences)
+	return resourceReferences, true, err
 }

--- a/argo/providers/kfp/kfp_api.go
+++ b/argo/providers/kfp/kfp_api.go
@@ -46,7 +46,7 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 			}
 
 			if rcNameFromJob.Empty() {
-				// For migration from v1alpha4. Remove afterwards.
+				// For compatability with resources created with v0.3.0 and older
 				resourceReferences.RunConfigurationName.Name = ref.GetName()
 			} else {
 				resourceReferences.RunConfigurationName = rcNameFromJob

--- a/argo/providers/kfp/kfp_api.go
+++ b/argo/providers/kfp/kfp_api.go
@@ -23,9 +23,9 @@ type GrpcKfpApi struct {
 }
 
 type ResourceReferences struct {
+	PipelineName         common.NamespacedName `yaml:"pipelineName"`
 	RunConfigurationName common.NamespacedName `yaml:"runConfigurationName"`
 	RunName              common.NamespacedName `yaml:"runName"`
-	PipelineName         common.NamespacedName `yaml:"pipelineName"`
 }
 
 func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) (ResourceReferences, error) {
@@ -52,12 +52,14 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 			}
 
 			// For compatability with resources created with v0.3.0 and older
+			// Pipeline name set by caller
 			resourceReferences.RunConfigurationName.Name = ref.GetName()
 			continue
 		}
 
 		if ref.GetKey().GetType() == go_client.ResourceType_NAMESPACE && ref.GetRelationship() == go_client.Relationship_OWNER {
 			// For compatability with resources created with v0.3.0 and older
+			// Pipeline name set by caller
 			resourceReferences.RunName.Name = runDetail.GetRun().GetName()
 			resourceReferences.RunName.Namespace = ref.GetKey().GetId()
 			continue

--- a/argo/providers/kfp/kfp_api_unit_test.go
+++ b/argo/providers/kfp/kfp_api_unit_test.go
@@ -104,8 +104,11 @@ var _ = Context("KFP API", func() {
 
 		When("GetRun returns run with JOB without Description as CREATOR", func() {
 			It("Returns populated ResourceReferences", func() {
-				runConfigurationName := common.RandomString()
+				runConfigurationName := common.NamespacedName{
+					Name: common.RandomString(),
+				}
 				runName := common.RandomNamespacedName()
+
 				jobId := common.RandomString()
 
 				runDetail := go_client.RunDetail{
@@ -114,7 +117,7 @@ var _ = Context("KFP API", func() {
 						Name: runName.Name,
 						ResourceReferences: []*go_client.ResourceReference{
 							{
-								Name:         runConfigurationName,
+								Name:         runConfigurationName.Name,
 								Relationship: go_client.Relationship_CREATOR,
 								Key: &go_client.ResourceKey{
 									Type: go_client.ResourceType_JOB,
@@ -149,7 +152,9 @@ var _ = Context("KFP API", func() {
 
 		When("GetRun returns run with JOB with Description as CREATOR", func() {
 			It("Returns populated ResourceReferences", func() {
-				runConfigurationName := common.RandomString()
+				runConfigurationName := common.RandomNamespacedName()
+				runConfigurationNameString, err := runConfigurationName.String()
+				Expect(err).NotTo(HaveOccurred())
 				runName := common.NamespacedName{
 					Name: common.RandomString(),
 				}
@@ -172,7 +177,7 @@ var _ = Context("KFP API", func() {
 				}
 
 				jobDetail := go_client.Job{
-					Description: "runConfigurationName: " + runConfigurationName,
+					Description: "runConfigurationName: " + runConfigurationNameString,
 				}
 
 				mockRunServiceClient.EXPECT().

--- a/argo/providers/kfp/kfp_api_unit_test.go
+++ b/argo/providers/kfp/kfp_api_unit_test.go
@@ -153,8 +153,6 @@ var _ = Context("KFP API", func() {
 		When("GetRun returns run with JOB with Description as CREATOR", func() {
 			It("Returns populated ResourceReferences", func() {
 				runConfigurationName := common.RandomNamespacedName()
-				runConfigurationNameString, err := runConfigurationName.String()
-				Expect(err).NotTo(HaveOccurred())
 				runName := common.NamespacedName{
 					Name: common.RandomString(),
 				}
@@ -177,7 +175,7 @@ var _ = Context("KFP API", func() {
 				}
 
 				jobDetail := go_client.Job{
-					Description: "runConfigurationName: " + runConfigurationNameString,
+					Description: "runConfigurationName: " + common.UnsafeValue(runConfigurationName.String()),
 				}
 
 				mockRunServiceClient.EXPECT().

--- a/argo/providers/kfp/kfp_api_unit_test.go
+++ b/argo/providers/kfp/kfp_api_unit_test.go
@@ -189,7 +189,6 @@ var _ = Context("KFP API", func() {
 				resourceReferences, err := kfpApi.GetResourceReferences(context.Background(), runId)
 				Expect(err).To(BeNil())
 				Expect(resourceReferences.RunConfigurationName).To(Equal(runConfigurationName))
-				Expect(resourceReferences.RunName).To(Equal(runName))
 			})
 		})
 	})

--- a/argo/providers/kfp/mock_kfp_api.go
+++ b/argo/providers/kfp/mock_kfp_api.go
@@ -24,7 +24,7 @@ func (mka *MockKfpApi) reset() {
 
 func (mka *MockKfpApi) returnResourceReferencesForRun() ResourceReferences {
 	mka.resourceReferences = ResourceReferences{
-		RunConfigurationName: common.RandomString(),
+		RunConfigurationName: common.RandomNamespacedName(),
 		RunName:              common.RandomNamespacedName(),
 	}
 	mka.err = nil

--- a/argo/providers/kfp/mock_kfp_api.go
+++ b/argo/providers/kfp/mock_kfp_api.go
@@ -26,6 +26,7 @@ func (mka *MockKfpApi) returnResourceReferencesForRun() ResourceReferences {
 	mka.resourceReferences = ResourceReferences{
 		RunConfigurationName: common.RandomNamespacedName(),
 		RunName:              common.RandomNamespacedName(),
+		PipelineName: 		  common.RandomNamespacedName(),
 	}
 	mka.err = nil
 

--- a/argo/providers/kfp/suite_decoupled_test.go
+++ b/argo/providers/kfp/suite_decoupled_test.go
@@ -224,8 +224,8 @@ var _ = Describe("Run completion eventsource", Serial, func() {
 				expectedEvent := common.RunCompletionEvent{
 					Status:                common.RunCompletionStatuses.Succeeded,
 					PipelineName:          resourceReferences.PipelineName,
-					RunConfigurationName:  resourceReferences.RunConfigurationName,
-					RunName:               resourceReferences.RunName,
+					RunConfigurationName:  resourceReferences.RunConfigurationName.NonEmptyPtr(),
+					RunName:               resourceReferences.RunName.NonEmptyPtr(),
 					RunId: runId,
 					ServingModelArtifacts: servingModelArtifacts,
 				}
@@ -433,9 +433,9 @@ var _ = Describe("Run completion eventsource", Serial, func() {
 				expectedEvent := common.RunCompletionEvent{
 					Status:               common.RunCompletionStatuses.Succeeded,
 					PipelineName:         resourceReferences.PipelineName,
-					RunConfigurationName: resourceReferences.RunConfigurationName,
-					RunName:              resourceReferences.RunName,
-					RunId: runId,
+					RunConfigurationName: resourceReferences.RunConfigurationName.NonEmptyPtr(),
+					RunName:              resourceReferences.RunName.NonEmptyPtr(),
+					RunId:                runId,
 				}
 				actualEvent := common.RunCompletionEvent{}
 				err = json.Unmarshal(event.Payload, &actualEvent)

--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -152,14 +152,19 @@ func toRunCompletionEvent(job *aiplatformpb.PipelineJob, runId string) *common.R
 	if err != nil {
 		return nil
 	}
+	pipelineName, err := common.NamespacedNameFromString(job.Labels[labels.PipelineName])
+	if err != nil {
+		return nil
+	}
 
 	return &common.RunCompletionEvent{
 		Status:               runCompletionStatus,
-		PipelineName:         job.Labels[labels.PipelineName],
+		PipelineName:         pipelineName,
 		RunConfigurationName: runConfigurationName,
 		RunName: common.NamespacedName{
 			Name:      runId,
 			Namespace: job.Labels[labels.Namespace]},
+		RunId: runId,
 		ServingModelArtifacts: modelServingArtifactsForJob(job),
 	}
 }

--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -149,6 +149,12 @@ func toRunCompletionEvent(job *aiplatformpb.PipelineJob, runId string) *common.R
 	}
 
 	var runName, runConfigurationName, pipelineName common.NamespacedName
+
+	pipelineName.Name = job.Labels[labels.PipelineName]
+	if pipelineNamespace, ok := job.Labels[labels.PipelineNamespace]; ok {
+		pipelineName.Namespace = pipelineNamespace
+	}
+
 	if legacyNamespace, ok := job.Labels[labels.LegacyNamespace]; ok {
 		// For compatability with resources created with v0.3.0 and older
 		runName = common.NamespacedName{
@@ -172,18 +178,12 @@ func toRunCompletionEvent(job *aiplatformpb.PipelineJob, runId string) *common.R
 			Namespace: job.Labels[labels.RunConfigurationNamespace]}
 	}
 
-	pipelineName.Name = job.Labels[labels.PipelineName]
-	if pipelineNamespace, ok := job.Labels[labels.PipelineNamespace]; ok {
-		pipelineName.Namespace = pipelineNamespace
-	}
-
-
 	return &common.RunCompletionEvent{
-		Status:               runCompletionStatus,
-		PipelineName:         pipelineName,
-		RunConfigurationName: runConfigurationName,
-		RunName: runName,
-		RunId: runId,
+		Status:                runCompletionStatus,
+		PipelineName:          pipelineName,
+		RunConfigurationName:  runConfigurationName.NonEmptyPtr(),
+		RunName:               runName.NonEmptyPtr(),
+		RunId:                 runId,
 		ServingModelArtifacts: modelServingArtifactsForJob(job),
 	}
 }

--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -148,10 +148,15 @@ func toRunCompletionEvent(job *aiplatformpb.PipelineJob, runId string) *common.R
 		return nil
 	}
 
+	runConfigurationName, err := common.NamespacedNameFromString(job.Labels[labels.RunConfiguration])
+	if err != nil {
+		return nil
+	}
+
 	return &common.RunCompletionEvent{
 		Status:               runCompletionStatus,
 		PipelineName:         job.Labels[labels.PipelineName],
-		RunConfigurationName: job.Labels[labels.RunConfiguration],
+		RunConfigurationName: runConfigurationName,
 		RunName: common.NamespacedName{
 			Name:      runId,
 			Namespace: job.Labels[labels.Namespace]},

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -46,7 +46,7 @@ type VAIRun struct {
 }
 
 type RunIntent struct {
-	RunConfigurationName string                `json:"runConfigurationName,omitempty"`
+	RunConfigurationName common.NamespacedName `json:"runConfigurationName,omitempty"`
 	RunName              common.NamespacedName `json:"runName,omitempty"`
 	PipelineName         string                `json:"pipelineName"`
 	PipelineVersion      string                `json:"pipelineVersion"`
@@ -316,11 +316,16 @@ func (vaip VAIProvider) EnqueueRun(ctx context.Context, providerConfig VAIProvid
 
 	var runId string
 
-	if runIntent.RunName.Name != "" {
+	if !runIntent.RunName.Empty() {
 		runId = fmt.Sprintf(runIntent.RunName.Name)
-	} else if runIntent.RunConfigurationName != "" {
-		runId = fmt.Sprintf("%s-%s", runIntent.RunConfigurationName, uuid.New().String())
-		runLabels[labels.RunConfiguration] = runIntent.RunConfigurationName
+	} else if !runIntent.RunConfigurationName.Empty() {
+		runId = fmt.Sprintf("%s-%s", runIntent.RunConfigurationName.Name, uuid.New().String())
+		runConfigurationName, err := runIntent.RunConfigurationName.String()
+		if err != nil {
+			return "", err
+		}
+
+		runLabels[labels.RunConfiguration] = runConfigurationName
 	} else {
 		runId = fmt.Sprintf("%s", uuid.New().String())
 	}

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -27,24 +27,24 @@ import (
 )
 
 var labels = struct {
-	RunConfigurationName      string
-	RunConfigurationNamespace string
 	PipelineName              string
 	PipelineNamespace         string
 	PipelineVersion           string
+	RunConfigurationName      string
+	RunConfigurationNamespace string
 	RunName                   string
 	RunNamespace              string
 	LegacyNamespace 		  string
 	LegacyRunConfiguration    string
 }{
-	RunConfigurationName:      "run-configuration-name",
-	RunConfigurationNamespace: "run-configuration-namespace",
 	PipelineName:              "pipeline-name",
 	PipelineNamespace:         "pipeline-namespace",
 	PipelineVersion:           "pipeline-version",
+	RunConfigurationName:      "runconfiguration-name",
+	RunConfigurationNamespace: "runconfiguration-namespace",
 	RunName:                   "run-name",
 	RunNamespace:              "run-namespace",
-	LegacyNamespace: 	       "namespace",
+	LegacyNamespace:           "namespace",
 	LegacyRunConfiguration:    "run-configuration",
 }
 
@@ -332,7 +332,6 @@ func (vaip VAIProvider) EnqueueRun(ctx context.Context, providerConfig VAIProvid
 		runLabels[labels.RunNamespace] = runIntent.RunName.Namespace
 	} else if !runIntent.RunConfigurationName.Empty() {
 		runId = fmt.Sprintf("%s-%s", runIntent.RunConfigurationName.Name, uuid.New().String())
-
 		runLabels[labels.RunConfigurationName] = runIntent.RunConfigurationName.Name
 		runLabels[labels.RunConfigurationNamespace] = runIntent.RunConfigurationName.Namespace
 	} else {

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -48,7 +48,7 @@ type VAIRun struct {
 type RunIntent struct {
 	RunConfigurationName common.NamespacedName `json:"runConfigurationName,omitempty"`
 	RunName              common.NamespacedName `json:"runName,omitempty"`
-	PipelineName         string                `json:"pipelineName"`
+	PipelineName         common.NamespacedName `json:"pipelineName"`
 	PipelineVersion      string                `json:"pipelineVersion"`
 	RuntimeParameters    map[string]string     `json:"runtimeParameters,omitempty"`
 }
@@ -308,8 +308,13 @@ func (vaip VAIProvider) EnqueueRun(ctx context.Context, providerConfig VAIProvid
 	topic := pubsubClient.Topic(providerConfig.RunsTopic)
 	defer topic.Stop()
 
+	pipelineName, err := runIntent.PipelineName.String()
+	if err !=  nil {
+		return "", err
+	}
+
 	runLabels := map[string]string{
-		labels.PipelineName:    runIntent.PipelineName,
+		labels.PipelineName:    pipelineName,
 		labels.PipelineVersion: runIntent.PipelineVersion,
 		labels.Namespace:       runIntent.RunName.Namespace,
 	}
@@ -332,7 +337,7 @@ func (vaip VAIProvider) EnqueueRun(ctx context.Context, providerConfig VAIProvid
 
 	vaiRun := VAIRun{
 		RunId:             runId,
-		PipelineUri:       providerConfig.pipelineUri(runIntent.PipelineName, runIntent.PipelineVersion),
+		PipelineUri:       providerConfig.pipelineUri(runIntent.PipelineName.Name, runIntent.PipelineVersion),
 		Labels:            runLabels,
 		RuntimeParameters: runIntent.RuntimeParameters,
 	}

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -290,9 +290,12 @@ var _ = Context("VaiEventingServer", func() {
 		Expect(toRunCompletionEvent(&aiplatformpb.PipelineJob{
 			Name: pipelineRunName.Name,
 			Labels: map[string]string{
-				labels.RunConfiguration: common.UnsafeValue(runConfigurationName.String()),
-				labels.PipelineName:     common.UnsafeValue(pipelineName.String()),
-				labels.Namespace:        pipelineRunName.Namespace,
+				labels.RunConfigurationName:      runConfigurationName.Name,
+				labels.RunConfigurationNamespace: runConfigurationName.Namespace,
+				labels.PipelineName:              pipelineName.Name,
+				labels.PipelineNamespace:         pipelineName.Namespace,
+				labels.RunName:         		  pipelineRunName.Name,
+				labels.RunNamespace:      		  pipelineRunName.Namespace,
 			},
 			State: pipelineState,
 			JobDetail: &aiplatformpb.PipelineJobDetail{

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -284,15 +284,13 @@ var _ = Context("VaiEventingServer", func() {
 
 	DescribeTable("toRunCompletionEvent for job that has completed", func(pipelineState aiplatformpb.PipelineState, status common.RunCompletionStatus) {
 		runConfigurationName := common.RandomNamespacedName()
-		runConfigurationNameString, err := runConfigurationName.String()
-		Expect(err).NotTo(HaveOccurred())
 		pipelineName := common.RandomString()
 		pipelineRunName := common.RandomNamespacedName()
 
 		Expect(toRunCompletionEvent(&aiplatformpb.PipelineJob{
 			Name: pipelineRunName.Name,
 			Labels: map[string]string{
-				labels.RunConfiguration: runConfigurationNameString,
+				labels.RunConfiguration: common.UnsafeValue(runConfigurationName.String()),
 				labels.PipelineName:     pipelineName,
 				labels.Namespace:        pipelineRunName.Namespace,
 			},

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -294,8 +294,8 @@ var _ = Context("VaiEventingServer", func() {
 				labels.RunConfigurationNamespace: runConfigurationName.Namespace,
 				labels.PipelineName:              pipelineName.Name,
 				labels.PipelineNamespace:         pipelineName.Namespace,
-				labels.RunName:         		  pipelineRunName.Name,
-				labels.RunNamespace:      		  pipelineRunName.Namespace,
+				labels.RunName:                   pipelineRunName.Name,
+				labels.RunNamespace:              pipelineRunName.Namespace,
 			},
 			State: pipelineState,
 			JobDetail: &aiplatformpb.PipelineJobDetail{
@@ -312,10 +312,10 @@ var _ = Context("VaiEventingServer", func() {
 				},
 			},
 		}, pipelineRunName.Name)).To(Equal(&common.RunCompletionEvent{
-			RunConfigurationName: runConfigurationName,
+			RunConfigurationName: runConfigurationName.NonEmptyPtr(),
 			PipelineName:         pipelineName,
-			RunName:              pipelineRunName,
-			RunId: 				  pipelineRunName.Name,
+			RunName:              pipelineRunName.NonEmptyPtr(),
+			RunId:                pipelineRunName.Name,
 			Status:               status,
 			ServingModelArtifacts: []common.ServingModelArtifact{
 				{

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -284,14 +284,14 @@ var _ = Context("VaiEventingServer", func() {
 
 	DescribeTable("toRunCompletionEvent for job that has completed", func(pipelineState aiplatformpb.PipelineState, status common.RunCompletionStatus) {
 		runConfigurationName := common.RandomNamespacedName()
-		pipelineName := common.RandomString()
+		pipelineName := common.RandomNamespacedName()
 		pipelineRunName := common.RandomNamespacedName()
 
 		Expect(toRunCompletionEvent(&aiplatformpb.PipelineJob{
 			Name: pipelineRunName.Name,
 			Labels: map[string]string{
 				labels.RunConfiguration: common.UnsafeValue(runConfigurationName.String()),
-				labels.PipelineName:     pipelineName,
+				labels.PipelineName:     common.UnsafeValue(pipelineName.String()),
 				labels.Namespace:        pipelineRunName.Namespace,
 			},
 			State: pipelineState,
@@ -312,6 +312,7 @@ var _ = Context("VaiEventingServer", func() {
 			RunConfigurationName: runConfigurationName,
 			PipelineName:         pipelineName,
 			RunName:              pipelineRunName,
+			RunId: 				  pipelineRunName.Name,
 			Status:               status,
 			ServingModelArtifacts: []common.ServingModelArtifact{
 				{

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -283,14 +283,16 @@ var _ = Context("VaiEventingServer", func() {
 	})
 
 	DescribeTable("toRunCompletionEvent for job that has completed", func(pipelineState aiplatformpb.PipelineState, status common.RunCompletionStatus) {
-		runConfigurationName := common.RandomString()
+		runConfigurationName := common.RandomNamespacedName()
+		runConfigurationNameString, err := runConfigurationName.String()
+		Expect(err).NotTo(HaveOccurred())
 		pipelineName := common.RandomString()
 		pipelineRunName := common.RandomNamespacedName()
 
 		Expect(toRunCompletionEvent(&aiplatformpb.PipelineJob{
 			Name: pipelineRunName.Name,
 			Labels: map[string]string{
-				labels.RunConfiguration: runConfigurationName,
+				labels.RunConfiguration: runConfigurationNameString,
 				labels.PipelineName:     pipelineName,
 				labels.Namespace:        pipelineRunName.Namespace,
 			},

--- a/argo/run-completer/suite_decoupled_test.go
+++ b/argo/run-completer/suite_decoupled_test.go
@@ -75,7 +75,7 @@ var _ = Context("Run Completer", Serial, func() {
 			run := pipelinesv1.RandomRun()
 			Expect(k8sClient.Create(ctx, run)).To(Succeed())
 
-			runCompletionEvent := common.RunCompletionEvent{Status: status, RunName: common.NamespacedName{
+			runCompletionEvent := common.RunCompletionEvent{Status: status, RunName: &common.NamespacedName{
 				Name:      run.Name,
 				Namespace: run.Namespace,
 			}}
@@ -94,7 +94,7 @@ var _ = Context("Run Completer", Serial, func() {
 		It("do nothing", func() {
 			ctx := context.Background()
 
-			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: common.NamespacedName{
+			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: &common.NamespacedName{
 				Name:      common.RandomString(),
 				Namespace: common.RandomString(),
 			}}
@@ -107,7 +107,7 @@ var _ = Context("Run Completer", Serial, func() {
 		It("do nothing", func() {
 			ctx := context.Background()
 
-			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: common.NamespacedName{
+			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: &common.NamespacedName{
 				Name:      common.RandomString(),
 			}}
 
@@ -119,7 +119,7 @@ var _ = Context("Run Completer", Serial, func() {
 		It("errors", func() {
 			ctx := context.Background()
 
-			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: common.NamespacedName{
+			runCompletionEvent := common.RunCompletionEvent{Status: common.RunCompletionStatuses.Succeeded, RunName: &common.NamespacedName{
 				Name:      common.RandomString(),
 				Namespace: common.RandomString(),
 			}}

--- a/controllers/pipelines/run_workflow_factory.go
+++ b/controllers/pipelines/run_workflow_factory.go
@@ -28,7 +28,7 @@ func (rdc RunDefinitionCreator) runDefinition(run *pipelinesv1.Run) (providers.R
 	return providers.RunDefinition{
 		Name:              common.NamespacedName{Name: run.Name, Namespace: run.Namespace},
 		Version:           run.ComputeVersion(),
-		PipelineName:      run.Spec.Pipeline.Name,
+		PipelineName:      common.NamespacedName{Name: run.Spec.Pipeline.Name, Namespace: run.Namespace},
 		PipelineVersion:   run.Status.ObservedPipelineVersion,
 		ExperimentName:    experimentName,
 		RuntimeParameters: NamedValuesToMap(run.Spec.RuntimeParameters),

--- a/controllers/pipelines/runschedule_workflow_factory.go
+++ b/controllers/pipelines/runschedule_workflow_factory.go
@@ -28,7 +28,7 @@ func (rcdc RunScheduleDefinitionCreator) runScheduleDefinition(runSchedule *pipe
 		Name:                 runSchedule.ObjectMeta.Name,
 		RunConfigurationName: runConfigurationNameForRunSchedule(runSchedule),
 		Version:              runSchedule.ComputeVersion(),
-		PipelineName:         runSchedule.Spec.Pipeline.Name,
+		PipelineName:         common.NamespacedName{Name: runSchedule.Spec.Pipeline.Name, Namespace: runSchedule.Namespace},
 		PipelineVersion:      runSchedule.Spec.Pipeline.Version,
 		ExperimentName:       experimentName,
 		Schedule:             runSchedule.Spec.Schedule,

--- a/controllers/pipelines/runschedule_workflow_factory.go
+++ b/controllers/pipelines/runschedule_workflow_factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sky-uk/kfp-operator/apis"
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha5"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	providers "github.com/sky-uk/kfp-operator/argo/providers/base"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,24 +36,25 @@ func (rcdc RunScheduleDefinitionCreator) runScheduleDefinition(runSchedule *pipe
 	}, nil
 }
 
-func runConfigurationNameForRunSchedule(runSchedule *pipelinesv1.RunSchedule) string {
+func runConfigurationNameForRunSchedule(runSchedule *pipelinesv1.RunSchedule) (runConfigurationName common.NamespacedName) {
 	rc := pipelinesv1.RunConfiguration{}
 
 	owner := metav1.GetControllerOf(runSchedule)
 	if owner == nil {
-		return ""
+		return
 	}
 
 	ownerGroupVersion, err := schema.ParseGroupVersion(owner.APIVersion)
 	if err != nil {
-		return ""
+		return
 	}
 
 	if ownerGroupVersion.Group == apis.Group && strings.ToLower(owner.Kind) == rc.GetKind() {
-		return owner.Name
+		runConfigurationName.Name = owner.Name
+		runConfigurationName.Namespace = runSchedule.Namespace
 	}
 
-	return ""
+	return
 }
 
 func RunScheduleWorkflowFactory(config config.Configuration) *ResourceWorkflowFactory[*pipelinesv1.RunSchedule, providers.RunScheduleDefinition] {

--- a/controllers/pipelines/runschedule_workflow_factory_test.go
+++ b/controllers/pipelines/runschedule_workflow_factory_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -15,6 +16,7 @@ import (
 var _ = Context("runConfigurationNameForRunSchedule", func() {
 	Specify("returns the name of the owner if set", func() {
 		runSchedule := pipelinesv1.RunSchedule{}
+		runSchedule.Namespace = apis.RandomString()
 		runConfiguration := pipelinesv1.RandomRunConfiguration()
 
 		runSchedule.OwnerReferences = []metav1.OwnerReference{{
@@ -24,11 +26,11 @@ var _ = Context("runConfigurationNameForRunSchedule", func() {
 			Name:       runConfiguration.Name,
 		}}
 
-		Expect(runConfigurationNameForRunSchedule(&runSchedule)).To(Equal(runConfiguration.Name))
+		Expect(runConfigurationNameForRunSchedule(&runSchedule)).To(Equal(common.NamespacedName{Name: runConfiguration.Name, Namespace: runSchedule.Namespace}))
 	})
 
 	Specify("returns the empty string if owner not set", func() {
-		Expect(runConfigurationNameForRunSchedule(&pipelinesv1.RunSchedule{})).To(BeEmpty())
+		Expect(runConfigurationNameForRunSchedule(&pipelinesv1.RunSchedule{}).Empty()).To(BeTrue())
 	})
 
 	Specify("returns the empty string if the controller is not a RunConfiguration", func() {
@@ -41,6 +43,6 @@ var _ = Context("runConfigurationNameForRunSchedule", func() {
 			Name:       apis.RandomString(),
 		})
 
-		Expect(runConfigurationNameForRunSchedule(&runSchedule)).To(BeEmpty())
+		Expect(runConfigurationNameForRunSchedule(&runSchedule).Empty()).To(BeTrue())
 	})
 })


### PR DESCRIPTION
Closes #248 

- Make RunConfigurationName and PipelineName namespaced in all provider integrations
  - Note: v0.3.0 legacy integration is not namespaced
- Add RunId
- Extend NamespacedName:
  - make to/from string functions public
  - replace JSONMarshaller with TextMarshaller to support YAML (instead od adding YAMLMarshaller)
  - add `Empty()` convenvience method