### PR TITLE
Link binaries statically to fix cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ integration-test-all: integration-test
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go --zap-devel --config config/manager/controller_manager_config.yaml

--- a/argo/providers/kfp/Makefile
+++ b/argo/providers/kfp/Makefile
@@ -38,7 +38,7 @@ test: unit-test decoupled-test
 ##@ Build
 
 build: generate
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/providers/stub/Makefile
+++ b/argo/providers/stub/Makefile
@@ -5,7 +5,7 @@ IMG := kfp-operator-stub-provider
 ##@ Build
 
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/providers/vai/Makefile
+++ b/argo/providers/vai/Makefile
@@ -19,7 +19,7 @@ generate: mockgen
 	$(MOCKGEN) -destination mock_pipeline_client.go -package=vai github.com/sky-uk/kfp-operator/argo/providers/vai PipelineJobClient
 
 build: generate
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/provider ./cmd
 
 ##@ Containers
 

--- a/argo/run-completer/Makefile
+++ b/argo/run-completer/Makefile
@@ -17,7 +17,7 @@ test: unit-test decoupled-test
 ##@ Build
 
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/run-completer ./cmd
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/run-completer ./cmd
 
 fmt: ## Run go fmt against code.
 	go fmt ./...


### PR DESCRIPTION
`go build` only linked statically when cross-compiling. Builds on Linux CI machines linked dynamically and produced broken build.

This change unconditionally links all GO binaries statically