### PR TITLE
Remove deprecated build comments

### DIFF
--- a/apis/pipelines/object_hasher_test.go
+++ b/apis/pipelines/object_hasher_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/apis/pipelines/utils_test.go
+++ b/apis/pipelines/utils_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/apis/pipelines/v1alpha2/experiment_conversion_test.go
+++ b/apis/pipelines/v1alpha2/experiment_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/experiment_types_test.go
+++ b/apis/pipelines/v1alpha2/experiment_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/pipeline_conversion_test.go
+++ b/apis/pipelines/v1alpha2/pipeline_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/pipeline_types_test.go
+++ b/apis/pipelines/v1alpha2/pipeline_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/runconfiguration_conversion_test.go
+++ b/apis/pipelines/v1alpha2/runconfiguration_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/runconfiguration_types_test.go
+++ b/apis/pipelines/v1alpha2/runconfiguration_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/suite_test.go
+++ b/apis/pipelines/v1alpha2/suite_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha2/test_generators.go
+++ b/apis/pipelines/v1alpha2/test_generators.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha2
 

--- a/apis/pipelines/v1alpha3/experiment_conversion_test.go
+++ b/apis/pipelines/v1alpha3/experiment_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/experiment_types_test.go
+++ b/apis/pipelines/v1alpha3/experiment_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/pipeline_conversion_test.go
+++ b/apis/pipelines/v1alpha3/pipeline_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/pipeline_types_test.go
+++ b/apis/pipelines/v1alpha3/pipeline_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/runconfiguration_conversion_test.go
+++ b/apis/pipelines/v1alpha3/runconfiguration_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/runconfiguration_types_test.go
+++ b/apis/pipelines/v1alpha3/runconfiguration_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha3/test_generators.go
+++ b/apis/pipelines/v1alpha3/test_generators.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha3
 

--- a/apis/pipelines/v1alpha4/experiment_conversion_test.go
+++ b/apis/pipelines/v1alpha4/experiment_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/experiment_types_test.go
+++ b/apis/pipelines/v1alpha4/experiment_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/pipeline_conversion_test.go
+++ b/apis/pipelines/v1alpha4/pipeline_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/pipeline_types_test.go
+++ b/apis/pipelines/v1alpha4/pipeline_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/run_conversion_test.go
+++ b/apis/pipelines/v1alpha4/run_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/run_types_test.go
+++ b/apis/pipelines/v1alpha4/run_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/runconfiguration_conversion_test.go
+++ b/apis/pipelines/v1alpha4/runconfiguration_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/runconfiguration_types_test.go
+++ b/apis/pipelines/v1alpha4/runconfiguration_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/runschedule_conversion_test.go
+++ b/apis/pipelines/v1alpha4/runschedule_conversion_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/runschedule_types_test.go
+++ b/apis/pipelines/v1alpha4/runschedule_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha4/test_generators.go
+++ b/apis/pipelines/v1alpha4/test_generators.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha4
 

--- a/apis/pipelines/v1alpha5/artifact_test.go
+++ b/apis/pipelines/v1alpha5/artifact_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/experiment_types_test.go
+++ b/apis/pipelines/v1alpha5/experiment_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/pipeline_types_test.go
+++ b/apis/pipelines/v1alpha5/pipeline_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/run_types_test.go
+++ b/apis/pipelines/v1alpha5/run_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/runconfiguration_webhook_test.go
+++ b/apis/pipelines/v1alpha5/runconfiguration_webhook_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/runschedule_types_test.go
+++ b/apis/pipelines/v1alpha5/runschedule_types_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package v1alpha5
 

--- a/apis/pipelines/v1alpha5/test_generators.go
+++ b/apis/pipelines/v1alpha5/test_generators.go
@@ -1,5 +1,4 @@
 //go:build integration || decoupled || unit
-// +build integration decoupled unit
 
 package v1alpha5
 

--- a/apis/test_generators.go
+++ b/apis/test_generators.go
@@ -1,5 +1,4 @@
 //go:build integration || decoupled || unit
-// +build integration decoupled unit
 
 package apis
 

--- a/argo/common/suite_unit_test.go
+++ b/argo/common/suite_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package common
 

--- a/argo/common/test_utils.go
+++ b/argo/common/test_utils.go
@@ -1,5 +1,4 @@
 //go:build unit || decoupled || integration
-// +build unit decoupled integration
 
 package common
 

--- a/argo/providers/base/suite_unit_test.go
+++ b/argo/providers/base/suite_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package base
 

--- a/argo/providers/base/utils_test.go
+++ b/argo/providers/base/utils_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package base
 

--- a/argo/providers/kfp/eventing_server_unit_test.go
+++ b/argo/providers/kfp/eventing_server_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package kfp
 

--- a/argo/providers/kfp/kfp_api_unit_test.go
+++ b/argo/providers/kfp/kfp_api_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package kfp
 

--- a/argo/providers/kfp/metadata_store_unit_test.go
+++ b/argo/providers/kfp/metadata_store_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package kfp
 

--- a/argo/providers/kfp/mock_kfp_api.go
+++ b/argo/providers/kfp/mock_kfp_api.go
@@ -1,5 +1,4 @@
 //go:build decoupled || unit
-// +build decoupled unit
 
 package kfp
 

--- a/argo/providers/kfp/mock_metadata_store.go
+++ b/argo/providers/kfp/mock_metadata_store.go
@@ -1,5 +1,4 @@
 //go:build decoupled || unit
-// +build decoupled unit
 
 package kfp
 

--- a/argo/providers/kfp/suite_decoupled_test.go
+++ b/argo/providers/kfp/suite_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package kfp
 

--- a/argo/providers/kfp/suite_unit_test.go
+++ b/argo/providers/kfp/suite_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package kfp
 

--- a/argo/providers/vai/suite_unit_test.go
+++ b/argo/providers/vai/suite_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package vai
 

--- a/argo/status-updater/fake_client.go
+++ b/argo/status-updater/fake_client.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package status_updater
 

--- a/argo/status-updater/suite_decoupled_test.go
+++ b/argo/status-updater/suite_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package status_updater
 

--- a/controllers/pipelines/command_test.go
+++ b/controllers/pipelines/command_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/depending_on_pipeline_reconciler_test.go
+++ b/controllers/pipelines/depending_on_pipeline_reconciler_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/experiment_controller_decoupled_test.go
+++ b/controllers/pipelines/experiment_controller_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/experiment_workflow_integration_test.go
+++ b/controllers/pipelines/experiment_workflow_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package pipelines
 

--- a/controllers/pipelines/pipeline_controller_decoupled_test.go
+++ b/controllers/pipelines/pipeline_controller_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/pipeline_workflow_factory_test.go
+++ b/controllers/pipelines/pipeline_workflow_factory_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/pipeline_workflow_integration_test.go
+++ b/controllers/pipelines/pipeline_workflow_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package pipelines
 

--- a/controllers/pipelines/resource_test_helper.go
+++ b/controllers/pipelines/resource_test_helper.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/run_controller_decoupled_test.go
+++ b/controllers/pipelines/run_controller_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/run_workflow_integration_test.go
+++ b/controllers/pipelines/run_workflow_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package pipelines
 

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/runconfiguration_controller_test.go
+++ b/controllers/pipelines/runconfiguration_controller_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/runschedule_controller_decoupled_test.go
+++ b/controllers/pipelines/runschedule_controller_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/runschedule_workflow_factory_test.go
+++ b/controllers/pipelines/runschedule_workflow_factory_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/runschedule_workflow_integration_test.go
+++ b/controllers/pipelines/runschedule_workflow_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package pipelines
 

--- a/controllers/pipelines/state_handler_test.go
+++ b/controllers/pipelines/state_handler_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/state_handler_test_utils.go
+++ b/controllers/pipelines/state_handler_test_utils.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/suite_integration_test.go
+++ b/controllers/pipelines/suite_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package pipelines
 

--- a/controllers/pipelines/suite_unit_test.go
+++ b/controllers/pipelines/suite_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/test_matchers.go
+++ b/controllers/pipelines/test_matchers.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/test_shared.go
+++ b/controllers/pipelines/test_shared.go
@@ -1,5 +1,4 @@
 //go:build decoupled || integration
-// +build decoupled integration
 
 package pipelines
 

--- a/controllers/pipelines/workflow_factory_test.go
+++ b/controllers/pipelines/workflow_factory_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 

--- a/controllers/pipelines/workflow_repository_decoupled_test.go
+++ b/controllers/pipelines/workflow_repository_decoupled_test.go
@@ -1,5 +1,4 @@
 //go:build decoupled
-// +build decoupled
 
 package pipelines
 

--- a/controllers/pipelines/workflow_test_helper.go
+++ b/controllers/pipelines/workflow_test_helper.go
@@ -1,5 +1,4 @@
 //go:build decoupled || integration
-// +build decoupled integration
 
 package pipelines
 

--- a/controllers/pipelines/workflow_utils_test.go
+++ b/controllers/pipelines/workflow_utils_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 package pipelines
 


### PR DESCRIPTION
See https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md

Note: this does not remove build comments generated by kubebuilder and controller-gen