### PR TITLE
Make namespace metadata configurable

### DIFF
--- a/helm/kfp-operator/templates/namespace.yaml
+++ b/helm/kfp-operator/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace.name }}
-  labels:
-    {{- include "kfp-operator.labels" . | nindent 4 }}
+  {{- $defaultMetadata := dict "labels"  ((include "kfp-operator.labels" .) | fromYaml) -}}
+  {{- (merge .Values.namespace.metadata $defaultMetadata) | toYaml | nindent 2 }}
 {{- end -}}

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -10,6 +10,7 @@ containerRegistry: "ghcr.io/kfp-operator"
 namespace:
   create: true
   name: "kfp-operator-system"
+  metadata: {}
 
 manager:
   metadata: {}


### PR DESCRIPTION
Introduce Helm configuration to allow specifying namespace metadata.