### PR TITLE
Unflake tests

### DIFF
--- a/argo/status-updater/suite_decoupled_test.go
+++ b/argo/status-updater/suite_decoupled_test.go
@@ -4,6 +4,7 @@ package status_updater
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
@@ -136,7 +137,7 @@ var _ = Describe("Status Updater", Serial, func() {
 		var LastSucceededRunHasBeenUpdated = func() func(pipelinesv1.RunConfiguration, common.RunCompletionEvent, pipelinesv1.RunConfiguration) {
 			return func(oldRun pipelinesv1.RunConfiguration, event common.RunCompletionEvent, newRun pipelinesv1.RunConfiguration) {
 				Expect(newRun.Status.LatestRuns.Succeeded.ProviderId).To(Equal(event.RunId))
-				Expect(newRun.Status.LatestRuns.Succeeded.Artifacts).To(Equal(event.Artifacts))
+				Expect(newRun.Status.LatestRuns.Succeeded.Artifacts).To(BeComparableTo(event.Artifacts, cmpopts.EquateEmpty()))
 			}
 		}
 

--- a/controllers/pipelines/run_controller_decoupled_test.go
+++ b/controllers/pipelines/run_controller_decoupled_test.go
@@ -327,7 +327,12 @@ var _ = Describe("Run controller k8s integration", Serial, func() {
 
 func createRcWithLatestRun(succeeded pipelinesv1.RunReference) *pipelinesv1.RunConfiguration {
 	referencedRc := pipelinesv1.RandomRunConfiguration()
+	referencedRc.Spec.Triggers = pipelinesv1.Triggers{}
 	Expect(k8sClient.Create(ctx, referencedRc)).To(Succeed())
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, referencedRc.GetNamespacedName(), referencedRc)).To(Succeed())
+		g.Expect(referencedRc.Status.SynchronizationState).To(Equal(apis.Succeeded))
+	}).Should(Succeed())
 	referencedRc.Status.LatestRuns.Succeeded = succeeded
 	Expect(k8sClient.Status().Update(ctx, referencedRc)).To(Succeed())
 

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -50,7 +50,7 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 		Expect(k8sClient.Update(ctx, runConfiguration)).To(Succeed())
 
 		Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {
-			g.Expect(fetchedRc.Status.SynchronizationState).To(Equal(apis.Updating))
+			g.Expect(fetchedRc.Status.SynchronizationState).To(Equal(apis.Succeeded))
 			g.Expect(fetchedRc.Status.ObservedGeneration).To(Equal(runConfiguration.GetGeneration()))
 		})).Should(Succeed())
 


### PR DESCRIPTION
- [x] don't fail on empty arrays
- [x] remove triggers from dependency RCs to speed up tests as schedules don't need to be synced
- [x] fetch latest state of dependency RCs in order to prevent conflicts
- [x] wait for RC to go into succeeded after deleting triggers
- [x] pass for 3 consecutive times, which we all know is the developer's equivalent of statistical significance 😂 