### PR TITLE
Allow valid docker tags in pipeline identifier

### DIFF
--- a/apis/pipelines/v1alpha5/pipeline_types.go
+++ b/apis/pipelines/v1alpha5/pipeline_types.go
@@ -87,7 +87,7 @@ type PipelineList struct {
 }
 
 // +kubebuilder:validation:Type=string
-// +kubebuilder:validation:Pattern:=`^[\w-]+(?::[\w-]+)?$`
+// +kubebuilder:validation:Pattern:=`^[\w\-]+(?::[\w\-_.]+)?$`
 type PipelineIdentifier struct {
 	Name    string `json:"-"`
 	Version string `json:"-"`

--- a/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -254,7 +254,7 @@ spec:
                   experimentName:
                     type: string
                   pipeline:
-                    pattern: ^[\w-]+(?::[\w-]+)?$
+                    pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                     type: string
                   runtimeParameters:
                     items:

--- a/config/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -138,7 +138,7 @@ spec:
               experimentName:
                 type: string
               pipeline:
-                pattern: ^[\w-]+(?::[\w-]+)?$
+                pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               runtimeParameters:
                 items:

--- a/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -127,7 +127,7 @@ spec:
               experimentName:
                 type: string
               pipeline:
-                pattern: ^[\w-]+(?::[\w-]+)?$
+                pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               runtimeParameters:
                 items:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -271,7 +271,7 @@ spec:
                   experimentName:
                     type: string
                   pipeline:
-                    pattern: ^[\w-]+(?::[\w-]+)?$
+                    pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                     type: string
                   runtimeParameters:
                     items:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -155,7 +155,7 @@ spec:
               experimentName:
                 type: string
               pipeline:
-                pattern: ^[\w-]+(?::[\w-]+)?$
+                pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               runtimeParameters:
                 items:

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -146,7 +146,7 @@ spec:
               experimentName:
                 type: string
               pipeline:
-                pattern: ^[\w-]+(?::[\w-]+)?$
+                pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               runtimeParameters:
                 items:


### PR DESCRIPTION
Pipeline identifiers should support valid kubernetes resource names followed by an optional pipeline version (docker tag followed by hyphen and pipeline hash)

Closes #276 