### PR TITLE
Initialise ServingModelArtifacts in run completion events

### DIFF
--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -105,7 +105,7 @@ func (es *VaiEventingServer) runCompletionEventForRun(ctx context.Context, run V
 }
 
 func modelServingArtifactsForJob(job *aiplatformpb.PipelineJob) []common.Artifact {
-	var servingModelArtifacts []common.Artifact
+	servingModelArtifacts := []common.Artifact{}
 	for _, task := range job.GetJobDetail().GetTaskDetails() {
 		for name, output := range task.GetOutputs() {
 			for _, artifact := range output.GetArtifacts() {

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -323,7 +323,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 
@@ -346,7 +346,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 
@@ -369,7 +369,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 
@@ -392,7 +392,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 
@@ -415,7 +415,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 
@@ -438,7 +438,7 @@ var _ = Context("VaiEventingServer", func() {
 							},
 						},
 					},
-				})).To(BeEmpty())
+				})).To(Equal([]common.Artifact{}))
 			})
 		})
 


### PR DESCRIPTION
Run Completion Events currently contain a `null` value for `servingModelArtifacts` if none is produced. To simplify tooling integration, it is preferrable to have an empty array instead.

From:
```json
{"servingModelArtifacts":null}
```
To:
```json
{"servingModelArtifacts":[]}
```

> [!NOTE]
> Until Go JSON marshalling supports https://github.com/golang/go/issues/27589, initialising a slice is the only way to marshal empty arrays into JSON instead of null values.
