### PR TITLE
Add metadata to status-updater sensor metadata

### DIFF
--- a/helm/kfp-operator/templates/eventing/status-updater.yaml
+++ b/helm/kfp-operator/templates/eventing/status-updater.yaml
@@ -57,6 +57,8 @@ metadata:
 spec:
   template:
     serviceAccountName: {{ include "kfp-operator.fullname" . }}-status-updater-submitter
+    metadata:
+      {{- $.Values.manager.argo.metadata | toYaml | nindent 6 }}
   dependencies:
   - eventName: {{ include "kfp-operator.fullname" $ }}-events
     eventSourceName: {{ include "kfp-operator.fullname" $ }}-events


### PR DESCRIPTION
Metadata configuration should be applied to all Argo resources consistently