### PR TITLE
Succeed RC when dependencies are not met

### DIFF
--- a/apis/pipelines/v1alpha5/runconfiguration_types.go
+++ b/apis/pipelines/v1alpha5/runconfiguration_types.go
@@ -71,6 +71,19 @@ type RunConfigurationStatus struct {
 	Conditions               Conditions                `json:"conditions,omitempty"`
 }
 
+func (rcs *RunConfigurationStatus) SetSynchronizationState(state apis.SynchronizationState, message string) {
+	rcs.SynchronizationState = state
+	condition := metav1.Condition{
+		Type:               ConditionTypes.SynchronizationSucceeded,
+		Message:            message,
+		ObservedGeneration: rcs.ObservedGeneration,
+		Reason:             string(state),
+		LastTransitionTime: metav1.Now(),
+		Status:             ConditionStatusForSynchronizationState(state),
+	}
+	rcs.Conditions = rcs.Conditions.MergeIntoConditions(condition)
+}
+
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:shortName="mlrc"
 //+kubebuilder:subresource:status

--- a/apis/pipelines/v1alpha5/test_generators.go
+++ b/apis/pipelines/v1alpha5/test_generators.go
@@ -116,18 +116,20 @@ func RandomRun() *Run {
 	}
 }
 
-func WithValueFrom(runSpec *RunSpec) {
-	runSpec.RuntimeParameters = append(runSpec.RuntimeParameters, RandomList(func() RuntimeParameter {
-		return RuntimeParameter{
-			Name: RandomString(),
-			ValueFrom: &ValueFrom{
-				RunConfigurationRef: RunConfigurationRef{
-					Name:           RandomString(),
-					OutputArtifact: RandomString(),
-				},
+func RandomRunConfigurationRefRuntimeParameter() RuntimeParameter {
+	return RuntimeParameter{
+		Name: RandomString(),
+		ValueFrom: &ValueFrom{
+			RunConfigurationRef: RunConfigurationRef{
+				Name:           RandomString(),
+				OutputArtifact: RandomString(),
 			},
-		}
-	})...)
+		},
+	}
+}
+
+func WithValueFrom(runSpec *RunSpec) {
+	runSpec.RuntimeParameters = append(runSpec.RuntimeParameters, RandomList(RandomRunConfigurationRefRuntimeParameter)...)
 }
 
 func RandomRunSpec() RunSpec {

--- a/controllers/pipelines/run_controller_decoupled_test.go
+++ b/controllers/pipelines/run_controller_decoupled_test.go
@@ -334,6 +334,7 @@ func createRcWithLatestRun(succeeded pipelinesv1.RunReference) *pipelinesv1.RunC
 	Expect(k8sClient.Create(ctx, referencedRc)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, referencedRc.GetNamespacedName(), referencedRc)).To(Succeed())
+		g.Expect(referencedRc.Status.ObservedGeneration).To(Equal(referencedRc.Generation))
 		g.Expect(referencedRc.Status.SynchronizationState).To(Equal(apis.Succeeded))
 	}).Should(Succeed())
 	referencedRc.Status.LatestRuns.Succeeded = succeeded

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -101,14 +101,24 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if hasChanged, err := r.syncWithRuns(ctx, desiredProvider, runConfiguration); hasChanged || err != nil {
-		return ctrl.Result{}, err
+	var newStatus pipelinesv1.RunConfigurationStatus
+
+	if resolvedParameters, err := runConfiguration.Spec.Run.ResolveRuntimeParameters(runConfiguration.Status.Dependencies); err == nil {
+		if hasChanged, err := r.syncWithRuns(ctx, desiredProvider, runConfiguration); hasChanged || err != nil {
+			return ctrl.Result{}, err
+		}
+
+		newStatus, err = r.syncStatus(ctx, desiredProvider, runConfiguration, resolvedParameters)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		newStatus = runConfiguration.Status
+		newStatus.SetSynchronizationState(apis.Succeeded, "")
 	}
 
-	newStatus, err := r.syncStatus(ctx, desiredProvider, runConfiguration)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	newStatus.ObservedGeneration = runConfiguration.GetGeneration()
+	newStatus.Provider = desiredProvider
 
 	if !reflect.DeepEqual(newStatus, runConfiguration.Status) {
 		runConfiguration.Status = newStatus
@@ -179,12 +189,10 @@ func (r *RunConfigurationReconciler) syncWithRuns(ctx context.Context, provider 
 	return true, r.EC.Client.Status().Update(ctx, runConfiguration)
 }
 
-func (r *RunConfigurationReconciler) syncStatus(ctx context.Context, provider string, runConfiguration *pipelinesv1.RunConfiguration) (status pipelinesv1.RunConfigurationStatus, err error) {
+func (r *RunConfigurationReconciler) syncStatus(ctx context.Context, provider string, runConfiguration *pipelinesv1.RunConfiguration, resolvedParameters []apis.NamedValue) (status pipelinesv1.RunConfigurationStatus, err error) {
 	status = runConfiguration.Status
-	status.ObservedGeneration = runConfiguration.GetGeneration()
-	status.Provider = provider
 
-	desiredSchedules, err := r.constructRunSchedulesForTriggers(provider, runConfiguration)
+	desiredSchedules, err := r.constructRunSchedulesForTriggers(provider, runConfiguration, resolvedParameters)
 	if err != nil {
 		return
 	}
@@ -219,16 +227,7 @@ func (r *RunConfigurationReconciler) syncStatus(ctx context.Context, provider st
 	}
 
 	state, message := aggregateState(dependentSchedules)
-	status.SynchronizationState = state
-	condition := metav1.Condition{
-		Type:               pipelinesv1.ConditionTypes.SynchronizationSucceeded,
-		Message:            message,
-		ObservedGeneration: status.ObservedGeneration,
-		Reason:             string(state),
-		LastTransitionTime: metav1.Now(),
-		Status:             pipelinesv1.ConditionStatusForSynchronizationState(state),
-	}
-	status.Conditions = status.Conditions.MergeIntoConditions(condition)
+	status.SetSynchronizationState(state, message)
 
 	return
 }
@@ -352,13 +351,8 @@ func (r *RunConfigurationReconciler) constructRunForRunConfiguration(provider st
 	return &run, nil
 }
 
-func (r *RunConfigurationReconciler) constructRunSchedulesForTriggers(provider string, runConfiguration *pipelinesv1.RunConfiguration) ([]pipelinesv1.RunSchedule, error) {
+func (r *RunConfigurationReconciler) constructRunSchedulesForTriggers(provider string, runConfiguration *pipelinesv1.RunConfiguration, resolvedParameters []apis.NamedValue) ([]pipelinesv1.RunSchedule, error) {
 	var schedules []pipelinesv1.RunSchedule
-
-	runtimeParameters, err := runConfiguration.Spec.Run.ResolveRuntimeParameters(runConfiguration.Status.Dependencies)
-	if err != nil {
-		return nil, err
-	}
 
 	for _, schedule := range runConfiguration.Spec.Triggers.Schedules {
 		runSchedule := pipelinesv1.RunSchedule{
@@ -371,7 +365,7 @@ func (r *RunConfigurationReconciler) constructRunSchedulesForTriggers(provider s
 					Name:    runConfiguration.Spec.Run.Pipeline.Name,
 					Version: runConfiguration.Status.ObservedPipelineVersion,
 				},
-				RuntimeParameters: runtimeParameters,
+				RuntimeParameters: resolvedParameters,
 				ExperimentName:    runConfiguration.Spec.Run.ExperimentName,
 				Artifacts:         runConfiguration.Spec.Run.Artifacts,
 				Schedule:          schedule,

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -252,9 +252,8 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 
 			Expect(k8sClient.Status().Update(ctx, runConfiguration)).To(Succeed())
 
-			oldState := runConfiguration.Status.SynchronizationState
 			Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {
-				g.Expect(fetchedRc.Status.SynchronizationState).To(Equal(oldState))
+				g.Expect(fetchedRc.Status.ObservedGeneration).To(Equal(fetchedRc.Generation))
 				g.Expect(fetchedRc.Status.Dependencies.RunConfigurations[runConfigurationName].ProviderId).To(BeEmpty())
 				g.Expect(fetchedRc.Status.Dependencies.RunConfigurations[runConfigurationName].Artifacts).To(BeEmpty())
 			})).Should(Succeed())
@@ -381,6 +380,7 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 			Expect(k8sClient.Create(ctx, runConfiguration)).To(Succeed())
 			Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {
 				g.Expect(fetchedRc.Status.Triggers.RunConfigurations).To(HaveKey(referencedRc.Name))
+				g.Expect(fetchedRc.Status.ObservedGeneration).To(Equal(fetchedRc.Generation))
 			})).Should(Succeed())
 
 			runConfiguration.Spec.Triggers.RunConfigurations = nil

--- a/controllers/pipelines/runconfiguration_controller_decoupled_test.go
+++ b/controllers/pipelines/runconfiguration_controller_decoupled_test.go
@@ -64,7 +64,10 @@ var _ = Describe("RunConfiguration controller k8s integration", Serial, func() {
 		runConfiguration := pipelinesv1.RandomRunConfiguration()
 		runConfiguration.Spec.Triggers = pipelinesv1.RandomScheduleTrigger()
 		runConfiguration.Spec.Triggers.OnChange = []pipelinesv1.OnChangeType{pipelinesv1.OnChangeTypes.RunSpec}
-		runConfiguration.Spec.Run.RuntimeParameters = apis.RandomList(pipelinesv1.RandomRunConfigurationRefRuntimeParameter)
+		runConfiguration.Spec.Run.RuntimeParameters = []pipelinesv1.RuntimeParameter{
+			pipelinesv1.RandomRunConfigurationRefRuntimeParameter(),
+		}
+
 		Expect(k8sClient.Create(ctx, runConfiguration)).To(Succeed())
 
 		Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -110,25 +110,25 @@ var _ = BeforeEach(func() {
 	allRuns := &pipelinesv1.RunList{}
 	Expect(k8sClient.List(ctx, allRuns)).To(Succeed())
 	for _, r := range allRuns.Items {
-		Expect(k8sClient.Delete(ctx, &r)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &r))).To(Succeed())
 	}
 
 	allRunSchedules := &pipelinesv1.RunScheduleList{}
 	Expect(k8sClient.List(ctx, allRunSchedules)).To(Succeed())
 	for _, r := range allRunSchedules.Items {
-		Expect(k8sClient.Delete(ctx, &r)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &r))).To(Succeed())
 	}
 
 	allRcs := &pipelinesv1.RunConfigurationList{}
 	Expect(k8sClient.List(ctx, allRcs)).To(Succeed())
 	for _, r := range allRcs.Items {
-		Expect(k8sClient.Delete(ctx, &r)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &r))).To(Succeed())
 	}
 
 	allPipelines := &pipelinesv1.PipelineList{}
 	Expect(k8sClient.List(ctx, allPipelines)).To(Succeed())
 	for _, r := range allPipelines.Items {
-		Expect(k8sClient.Delete(ctx, &r)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &r))).To(Succeed())
 	}
 })
 


### PR DESCRIPTION
Schedules and Runs should only be created once all dependencies have been met.

This also stabilizes some previously flakey tests

Closes #273 
