### PR TITLE
Remove additional level of JSON deserialisation

### DIFF
--- a/helm/kfp-operator/templates/eventing/eventsource.yaml
+++ b/helm/kfp-operator/templates/eventing/eventsource.yaml
@@ -27,7 +27,7 @@ spec:
     eventSourceName: {{ include "kfp-operator.fullname" $ }}-{{ $providerName }}-events
     name: "{{ $providerName }}-events"
     transform:
-      jq: .body = (.body | @base64d | fromjson)
+      jq: .body = (.body | @base64d)
 {{- end }}
   triggers:
 {{- range $providerName, $providerBlock := .Values.providers }}


### PR DESCRIPTION
In order not to have to further serialize on the consumer side, this PR removes an unnecessary level of deserialization.

Further testing is needed to assess this approach.