### PR TITLE
Use asdf workers

### DIFF
--- a/argo/providers/get-proto.mk
+++ b/argo/providers/get-proto.mk
@@ -6,7 +6,7 @@ define get-proto
 	[ -d "$(1)@$(2)" ] || { \
 		git clone --no-checkout --branch $(2) --single-branch https://$(1) $(1)@$(2) && \
 		cd $(1)@$(2) && \
-		git sparse-checkout set *.proto && \
+		git sparse-checkout set --no-cone *.proto && \
 		git checkout tags/$(2) -b master; \
 	}
 endef

--- a/bibcd.yml
+++ b/bibcd.yml
@@ -2,6 +2,10 @@ version: 1
 context: mlops
 triggering: master-and-prs
 
+defaultNodes:
+  cdBuild: m-asdf
+  prBuild: m-asdf
+
 modules:
   root:
     directory: /


### PR DESCRIPTION
- Uses CI workers with support for [asdf](https://github.com/asdf-vm/asdf)
- Specify `--no-cone` for sparse checkout as this is required for more recent versions of git
