### PR TITLE
Add FlatMap and FlatMapErr

### DIFF
--- a/apis/pipelines/utils.go
+++ b/apis/pipelines/utils.go
@@ -85,6 +85,19 @@ func Flatten[R any](rrs ...[]R) (out []R) {
 	return
 }
 
+func FlatMap[R, S any](rs []R, mapFn func(R) []S) []S {
+	return Flatten(Map(rs, mapFn)...)
+}
+
+func FlatMapErr[R, S any](rs []R, mapFn func(R) ([]S, error)) ([]S, error) {
+	ss, err := MapErr(rs, mapFn)
+	if err != nil {
+		return nil, err
+	}
+
+	return Flatten(ss...), nil
+}
+
 func Collect[R, S any](rs []R, mapFn func(R) (S, bool)) []S {
 	var ss []S
 


### PR DESCRIPTION
Adds `FlatMap` and `FlatMapErr` functions for collection utils as shorthands for `Flatten(Map)`