### PR TITLE
Fix intermittent decoupled test failures

### DIFF
--- a/argo/providers/vai/eventing_server.go
+++ b/argo/providers/vai/eventing_server.go
@@ -1,6 +1,7 @@
 package vai
 
 import (
+	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
 	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/json"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/go-bexpr"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	aiplatformpb "google.golang.org/genproto/googleapis/cloud/aiplatform/v1"
 	"gopkg.in/yaml.v2"
 )
 

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -3,6 +3,7 @@ package vai
 import (
 	"bytes"
 	aiplatform "cloud.google.com/go/aiplatform/apiv1"
+	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/scheduler/apiv1"
 	"cloud.google.com/go/storage"
@@ -17,7 +18,6 @@ import (
 	. "github.com/sky-uk/kfp-operator/argo/providers/base"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	aiplatformpb "google.golang.org/genproto/googleapis/cloud/aiplatform/v1"
 	schedulerpb "google.golang.org/genproto/googleapis/cloud/scheduler/v1"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/argo/providers/vai/vai_eventing_server_unit_test.go
+++ b/argo/providers/vai/vai_eventing_server_unit_test.go
@@ -3,6 +3,7 @@
 package vai
 
 import (
+	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
@@ -11,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	aiplatformpb "google.golang.org/genproto/googleapis/cloud/aiplatform/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/controllers/pipelines/run_controller_decoupled_test.go
+++ b/controllers/pipelines/run_controller_decoupled_test.go
@@ -261,9 +261,7 @@ var _ = Describe("Run controller k8s integration", Serial, func() {
 			run.SetDependencyRuns(map[string]pipelinesv1.RunReference{excessDependency: {}})
 			Expect(k8sClient.Status().Update(ctx, run)).To(Succeed())
 
-			oldState := run.Status.SynchronizationState
 			Eventually(runHelper.ToMatch(func(g Gomega, fetchedRun *pipelinesv1.Run) {
-				g.Expect(fetchedRun.Status.SynchronizationState).To(Equal(oldState))
 				g.Expect(fetchedRun.Status.Dependencies.RunConfigurations).NotTo(HaveKey(excessDependency))
 			})).Should(Succeed())
 		})

--- a/controllers/pipelines/run_controller_decoupled_test.go
+++ b/controllers/pipelines/run_controller_decoupled_test.go
@@ -325,18 +325,3 @@ var _ = Describe("Run controller k8s integration", Serial, func() {
 		})
 	})
 })
-
-func createRcWithLatestRun(succeeded pipelinesv1.RunReference) *pipelinesv1.RunConfiguration {
-	referencedRc := pipelinesv1.RandomRunConfiguration()
-	referencedRc.Spec.Triggers = pipelinesv1.Triggers{}
-	Expect(k8sClient.Create(ctx, referencedRc)).To(Succeed())
-	Eventually(func(g Gomega) {
-		g.Expect(k8sClient.Get(ctx, referencedRc.GetNamespacedName(), referencedRc)).To(Succeed())
-		g.Expect(referencedRc.Status.ObservedGeneration).To(Equal(referencedRc.Generation))
-		g.Expect(referencedRc.Status.SynchronizationState).To(Equal(apis.Succeeded))
-	}).Should(Succeed())
-	referencedRc.Status.LatestRuns.Succeeded = succeeded
-	Expect(k8sClient.Status().Update(ctx, referencedRc)).To(Succeed())
-
-	return referencedRc
-}

--- a/controllers/pipelines/runconfiguration_test_helper.go
+++ b/controllers/pipelines/runconfiguration_test_helper.go
@@ -1,0 +1,97 @@
+//go:build decoupled
+
+package pipelines
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/sky-uk/kfp-operator/apis"
+	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+)
+
+func createSucceededRcWithSchedule() *pipelinesv1.RunConfiguration {
+	runConfiguration := createStableRcWith(func(runConfiguration *pipelinesv1.RunConfiguration) *pipelinesv1.RunConfiguration {
+		runConfiguration.Spec.Triggers = pipelinesv1.RandomScheduleTrigger()
+		return runConfiguration
+	}, apis.Updating)
+
+	Eventually(matchSchedules(runConfiguration, func(g Gomega, ownedSchedule *pipelinesv1.RunSchedule) {
+		g.Expect(ownedSchedule.Status.SynchronizationState).To(Equal(apis.Creating))
+	})).Should(Succeed())
+
+	Expect(updateOwnedSchedules(runConfiguration, func(ownedSchedule *pipelinesv1.RunSchedule) {
+		ownedSchedule.Status.SynchronizationState = apis.Succeeded
+	})).To(Succeed())
+
+	Eventually(matchRunConfiguration(runConfiguration, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {
+		g.Expect(runConfiguration.Status.SynchronizationState).To(Equal(apis.Succeeded))
+	})).Should(Succeed())
+
+	return runConfiguration
+}
+
+func createSucceededRc() *pipelinesv1.RunConfiguration {
+	return createStableRcWith(func(runConfiguration *pipelinesv1.RunConfiguration) *pipelinesv1.RunConfiguration {
+		return runConfiguration
+	}, apis.Succeeded)
+}
+
+func createSucceededRcWith(modifyRc func(runConfiguration *pipelinesv1.RunConfiguration) *pipelinesv1.RunConfiguration) *pipelinesv1.RunConfiguration {
+	return createStableRcWith(modifyRc, apis.Succeeded)
+}
+
+func createStableRcWith(modifyRc func(runConfiguration *pipelinesv1.RunConfiguration) *pipelinesv1.RunConfiguration, synchronizationState apis.SynchronizationState) *pipelinesv1.RunConfiguration {
+	runConfiguration := pipelinesv1.RandomRunConfiguration()
+	runConfiguration.Spec.Run.RuntimeParameters = []pipelinesv1.RuntimeParameter{}
+	runConfiguration.Spec.Triggers = pipelinesv1.Triggers{}
+	modifiedRc := modifyRc(runConfiguration)
+	Expect(k8sClient.Create(ctx, modifiedRc)).To(Succeed())
+
+	Eventually(matchRunConfiguration(modifiedRc, func(g Gomega, fetchedRc *pipelinesv1.RunConfiguration) {
+		g.Expect(fetchedRc.Status.ObservedGeneration).To(Equal(modifiedRc.Generation))
+		g.Expect(fetchedRc.Status.SynchronizationState).To(Equal(synchronizationState))
+		g.Expect(fetchedRc.Status.Conditions.SynchronizationSucceeded().Reason).To(BeEquivalentTo(synchronizationState))
+		modifiedRc = fetchedRc
+	})).Should(Succeed())
+
+	return modifiedRc
+}
+
+func createRcWithLatestRun(succeeded pipelinesv1.RunReference) *pipelinesv1.RunConfiguration {
+	referencedRc := createSucceededRc()
+	referencedRc.Status.LatestRuns.Succeeded = succeeded
+	Expect(k8sClient.Status().Update(ctx, referencedRc)).To(Succeed())
+
+	return referencedRc
+}
+
+func matchRunConfiguration(runConfiguration *pipelinesv1.RunConfiguration, matcher func(Gomega, *pipelinesv1.RunConfiguration)) func(Gomega) {
+	return func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, runConfiguration.GetNamespacedName(), runConfiguration)).To(Succeed())
+		matcher(g, runConfiguration)
+	}
+}
+
+func updateOwnedSchedules(runConfiguration *pipelinesv1.RunConfiguration, updateFn func(schedule *pipelinesv1.RunSchedule)) error {
+	ownedSchedules, err := findOwnedRunSchedules(ctx, k8sClient, runConfiguration)
+	if err != nil {
+		return err
+	}
+
+	for _, ownedSchedule := range ownedSchedules {
+		updateFn(&ownedSchedule)
+		Expect(k8sClient.Status().Update(ctx, &ownedSchedule)).To(Succeed())
+	}
+
+	return nil
+}
+
+func matchSchedules(runConfiguration *pipelinesv1.RunConfiguration, matcher func(Gomega, *pipelinesv1.RunSchedule)) func(Gomega) {
+	return func(g Gomega) {
+		ownedSchedules, err := findOwnedRunSchedules(ctx, k8sClient, runConfiguration)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ownedSchedules).NotTo(BeEmpty())
+		for _, ownedSchedule := range ownedSchedules {
+			matcher(g, &ownedSchedule)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

Fix intermittent decoupled test failures by waiting for state changes before attempting resource updates. We have introduced `runconfiguration_test_helper.go` in order to separate test utilities from actual tests.

Also address `aiplatform` import deprecation warnings.