### PR TITLE
Change to CONTAINER_REPOSITORIES for artifact repository location

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,13 +37,13 @@ make docker-build docker-build-argo
 Push to the container registry:
 
 ```sh
-CONTAINER_REGISTRY_HOSTS=<YOUR_CONTAINER_REGISTRY> make docker-push docker-push-argo
+CONTAINER_REPOSITORIES=<YOUR_CONTAINER_REPOSITORY> make docker-push docker-push-argo
 ```
 
 For example, to push to Google Artifact Registry:
 
 ```sh
-CONTAINER_REGISTRY_HOSTS=europe-docker.pkg.dev/<PROJECT_NAME>/images make docker-push docker-push-argo
+CONTAINER_REPOSITORIES=europe-docker.pkg.dev/<PROJECT_NAME>/images make docker-push docker-push-argo
 ```
 
 ### Building and publishing the Helm chart

--- a/docker-targets.mk
+++ b/docker-targets.mk
@@ -3,15 +3,15 @@ _DOCKER_TARGETS_MK_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(_DOCKER_TARGETS_MK_DIR)/version.mk
 include $(_DOCKER_TARGETS_MK_DIR)/newline.mk
 
-ifeq ($(CONTAINER_REGISTRY_HOSTS)$(OSS_CONTAINER_REGISTRY_HOSTS),)
+ifeq ($(CONTAINER_REPOSITORIES)$(OSS_CONTAINER_REGISTRY_HOSTS),)
 docker-push:
-	$(error CONTAINER_REGISTRY_HOSTS or OSS_CONTAINER_REGISTRY_HOSTS must be provided as a space-separated lists of hosts)
+	$(error CONTAINER_REPOSITORIES or OSS_CONTAINER_REGISTRY_HOSTS must be provided as a space-separated lists of hosts/registry urls)
 else ifneq ($(VERSION), $(VERSION:-dirty=))
 docker-push:
 	$(error Refusing to push dirty image $(VERSION))
 else
 docker-push: docker-build ## Push container image
-	$(foreach host,$(CONTAINER_REGISTRY_HOSTS) $(OSS_CONTAINER_REGISTRY_HOSTS),$(call docker-push-to-registry,$(host)))
+	$(foreach host,$(CONTAINER_REPOSITORIES) $(OSS_CONTAINER_REGISTRY_HOSTS),$(call docker-push-to-registry,$(host)))
 define docker-push-to-registry
 	docker tag ${IMG} $(1)/${IMG}$(NEWLINE)
 	docker push $(1)/${IMG}$(NEWLINE)


### PR DESCRIPTION
Move to using `CONTAINER_REPOSITORIES` envvar for registry location for image push rather than `CONTAINER_REGISTRY_HOSTS` as this allows to include repository/directories within the registry to be supplied not just list of host names which previous env var indicated.
