### PR TITLE
VAI Provider - Namespaced custom resources for pipelines (scheduled and one off)

### DIFF
--- a/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
+++ b/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
@@ -1,0 +1,9 @@
+name: namespace/test
+image: test-pipeline
+tfxComponents: pipeline.create_components
+env:
+- name: foo
+  value: bar
+beamArgs:
+- name: anArg
+  value:  aValue

--- a/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
+++ b/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
@@ -6,4 +6,4 @@ env:
   value: bar
 beamArgs:
 - name: anArg
-  value:  aValue
+  value: aValue

--- a/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
+++ b/argo/kfp-compiler/acceptance/namespaced_pipeline_conf.yaml
@@ -1,9 +1,0 @@
-name: namespace/test
-image: test-pipeline
-tfxComponents: pipeline.create_components
-env:
-- name: foo
-  value: bar
-beamArgs:
-- name: anArg
-  value: aValue

--- a/argo/kfp-compiler/acceptance/pipeline_conf.yaml
+++ b/argo/kfp-compiler/acceptance/pipeline_conf.yaml
@@ -1,4 +1,4 @@
-name: test
+name: namespace/test
 image: test-pipeline
 tfxComponents: pipeline.create_components
 env:

--- a/argo/kfp-compiler/acceptance/pipeline_conf.yaml
+++ b/argo/kfp-compiler/acceptance/pipeline_conf.yaml
@@ -6,4 +6,4 @@ env:
   value: bar
 beamArgs:
 - name: anArg
-  value:  aValue
+  value: aValue

--- a/argo/kfp-compiler/acceptance/test_compiler.py
+++ b/argo/kfp-compiler/acceptance/test_compiler.py
@@ -8,8 +8,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 runner = CliRunner()
-unnamespaced_config_file_path = 'acceptance/pipeline_conf.yaml'
-namespaced_config_file_path = 'acceptance/namespaced_pipeline_conf.yaml'
+config_file_path = 'acceptance/pipeline_conf.yaml'
 
 
 def provider_config_file_path(execution_mode):
@@ -25,7 +24,7 @@ def test_cli_v1():
     with TemporaryDirectory() as tmp_dir:
         output_file_path = os.path.join(tmp_dir, 'pipeline.yaml')
 
-        result = runner.invoke(compiler.compile, ['--pipeline_config', unnamespaced_config_file_path, '--provider_config', provider_config_file_path('v1'), '--output_file', output_file_path])
+        result = runner.invoke(compiler.compile, ['--pipeline_config', config_file_path, '--provider_config', provider_config_file_path('v1'), '--output_file', output_file_path])
 
         assert result.exit_code == 0
         assert os.stat(output_file_path).st_size != 0
@@ -35,11 +34,7 @@ def test_cli_v1():
         assert workflow['kind'] == 'Workflow'
 
 
-@pytest.mark.parametrize("config_file_path, expected_pipelineinfo_name", [
-    (unnamespaced_config_file_path,  "test"),
-    (namespaced_config_file_path, "namespace-test")
-])
-def test_cli_v2(config_file_path: str, expected_pipelineinfo_name: str):
+def test_cli_v2():
     with TemporaryDirectory() as tmp_dir:
         output_file_path = os.path.join(tmp_dir, 'pipeline.yaml')
 
@@ -51,7 +46,7 @@ def test_cli_v2(config_file_path: str, expected_pipelineinfo_name: str):
         f = open(output_file_path, "r")
         pipeline = yaml.safe_load(f.read())
         assert pipeline['pipelineSpec']['schemaVersion'] == '2.0.0'
-        assert pipeline['pipelineSpec']['pipelineInfo']['name'] == expected_pipelineinfo_name
+        assert pipeline['pipelineSpec']['pipelineInfo']['name'] == "namespace-test"
 
 
 def test_failure():

--- a/argo/kfp-compiler/kfp_compiler/compiler.py
+++ b/argo/kfp-compiler/kfp_compiler/compiler.py
@@ -67,8 +67,10 @@ def load_fn(tfx_components: str, env: list):
 
     return fn
 
-def parseNamespacedPipelineName(namespacedName: str) -> str:
-    return namespacedName.replace("/", "-")
+
+def parse_namespaced_pipeline_name(namespaced_name: str) -> str:
+    return namespaced_name.replace("/", "-")
+
 
 @click.command()
 @click.option('--pipeline_config', help='Pipeline configuration in yaml format', required=True)
@@ -80,9 +82,11 @@ def compile(pipeline_config: str, provider_config: str, output_file: str):
         pipeline_config_contents = yaml.safe_load(pipeline_stream)
         provider_config_contents = yaml.safe_load(provider_stream)
 
-        click.secho(f'Compiling with pipeline: {pipeline_config_contents} and provider {provider_config_contents} ', fg='green')
+        click.secho(f'Compiling with pipeline: {pipeline_config_contents} and provider {provider_config_contents} ',
+                    fg='green')
 
-        pipeline_root, serving_model_directory, temp_location = pipeline_paths_for_config(pipeline_config_contents, provider_config_contents)
+        pipeline_root, serving_model_directory, temp_location = pipeline_paths_for_config(pipeline_config_contents,
+                                                                                          provider_config_contents)
 
         beam_args = provider_config_contents.get('defaultBeamArgs', [])
         beam_args.extend(pipeline_config_contents.get('beamArgs', []))
@@ -96,7 +100,7 @@ def compile(pipeline_config: str, provider_config: str, output_file: str):
 
         compile_fn(pipeline_config_contents, output_file).run(
             pipeline.Pipeline(
-                pipeline_name=parseNamespacedPipelineName(pipeline_config_contents['name']),
+                pipeline_name=parse_namespaced_pipeline_name(pipeline_config_contents['name']),
                 pipeline_root=pipeline_root,
                 components=expanded_components,
                 enable_cache=False,
@@ -134,11 +138,13 @@ def compile_v2(config: dict, output_filename: str):
     )
 
 
-def nameFromNamespacedName(namespacedName: str) -> str:
-    return ""
+def name_from_namespaced_name(namespaced_name: str) -> str:
+    separator_index = namespaced_name.find("/")
+    return namespaced_name[separator_index + 1:]
+
 
 def pipeline_paths_for_config(pipeline_config: dict, provider_config: dict):
-    pipeline_root = provider_config['pipelineRootStorage'] + '/' + nameFromNamespacedName(pipeline_config['name'])  # nbcu-disco-prod-003-kfp-operator-vai-for-you-pipelinestorage/for-you
+    pipeline_root = provider_config['pipelineRootStorage'] + '/' + name_from_namespaced_name(pipeline_config['name'])
     return pipeline_root, pipeline_root + "/serving", pipeline_root + "/tmp"
 
 

--- a/argo/kfp-compiler/kfp_compiler/compiler.py
+++ b/argo/kfp-compiler/kfp_compiler/compiler.py
@@ -67,6 +67,8 @@ def load_fn(tfx_components: str, env: list):
 
     return fn
 
+def parseNamespacedPipelineName(namespacedName: str) -> str:
+    return namespacedName.replace("/", "-")
 
 @click.command()
 @click.option('--pipeline_config', help='Pipeline configuration in yaml format', required=True)
@@ -94,7 +96,7 @@ def compile(pipeline_config: str, provider_config: str, output_file: str):
 
         compile_fn(pipeline_config_contents, output_file).run(
             pipeline.Pipeline(
-                pipeline_name=pipeline_config_contents['name'],
+                pipeline_name=parseNamespacedPipelineName(pipeline_config_contents['name']),
                 pipeline_root=pipeline_root,
                 components=expanded_components,
                 enable_cache=False,
@@ -132,8 +134,11 @@ def compile_v2(config: dict, output_filename: str):
     )
 
 
+def nameFromNamespacedName(namespacedName: str) -> str:
+    return ""
+
 def pipeline_paths_for_config(pipeline_config: dict, provider_config: dict):
-    pipeline_root = provider_config['pipelineRootStorage'] + '/' + pipeline_config['name']
+    pipeline_root = provider_config['pipelineRootStorage'] + '/' + nameFromNamespacedName(pipeline_config['name'])  # nbcu-disco-prod-003-kfp-operator-vai-for-you-pipelinestorage/for-you
     return pipeline_root, pipeline_root + "/serving", pipeline_root + "/tmp"
 
 

--- a/argo/kfp-compiler/kfp_compiler/compiler.py
+++ b/argo/kfp-compiler/kfp_compiler/compiler.py
@@ -68,7 +68,7 @@ def load_fn(tfx_components: str, env: list):
     return fn
 
 
-def parse_namespaced_pipeline_name(namespaced_name: str) -> str:
+def sanitise_namespaced_pipeline_name(namespaced_name: str) -> str:
     return namespaced_name.replace("/", "-")
 
 
@@ -100,7 +100,7 @@ def compile(pipeline_config: str, provider_config: str, output_file: str):
 
         compile_fn(pipeline_config_contents, output_file).run(
             pipeline.Pipeline(
-                pipeline_name=parse_namespaced_pipeline_name(pipeline_config_contents['name']),
+                pipeline_name=sanitise_namespaced_pipeline_name(pipeline_config_contents['name']),
                 pipeline_root=pipeline_root,
                 components=expanded_components,
                 enable_cache=False,
@@ -138,13 +138,8 @@ def compile_v2(config: dict, output_filename: str):
     )
 
 
-def name_from_namespaced_name(namespaced_name: str) -> str:
-    separator_index = namespaced_name.find("/")
-    return namespaced_name[separator_index + 1:]
-
-
 def pipeline_paths_for_config(pipeline_config: dict, provider_config: dict):
-    pipeline_root = provider_config['pipelineRootStorage'] + '/' + name_from_namespaced_name(pipeline_config['name'])
+    pipeline_root = provider_config['pipelineRootStorage'] + '/' + pipeline_config['name']
     return pipeline_root, pipeline_root + "/serving", pipeline_root + "/tmp"
 
 

--- a/argo/kfp-compiler/tests/test_compiler.py
+++ b/argo/kfp-compiler/tests/test_compiler.py
@@ -25,14 +25,9 @@ def test_pipeline_paths_for_config():
     assert serving_model_directory == "pipeline_root/pipeline/serving"
     assert temp_directory == "pipeline_root/pipeline/tmp"
 
+
 def test_sanitise_namespaced_pipeline_name():
     assert compiler.sanitise_namespaced_pipeline_name("pipeline-name") == "pipeline-name"
     assert compiler.sanitise_namespaced_pipeline_name("/pipeline-name") == "-pipeline-name"
     assert compiler.sanitise_namespaced_pipeline_name("mlops/pipeline-name") == "mlops-pipeline-name"
     assert compiler.sanitise_namespaced_pipeline_name("") == ""
-
-def test_name_from_namespaced_name():
-    assert compiler.name_from_namespaced_name("pipeline-name") == "pipeline-name"
-    assert compiler.name_from_namespaced_name("/pipeline-name") == "pipeline-name"
-    assert compiler.name_from_namespaced_name("mlops/pipeline-name") == "pipeline-name"
-    assert compiler.name_from_namespaced_name("") == ""

--- a/argo/kfp-compiler/tests/test_compiler.py
+++ b/argo/kfp-compiler/tests/test_compiler.py
@@ -25,11 +25,11 @@ def test_pipeline_paths_for_config():
     assert serving_model_directory == "pipeline_root/pipeline/serving"
     assert temp_directory == "pipeline_root/pipeline/tmp"
 
-def test_parse_namespaced_pipeline_name():
-    assert compiler.parse_namespaced_pipeline_name("pipeline-name") == "pipeline-name"
-    assert compiler.parse_namespaced_pipeline_name("/pipeline-name") == "-pipeline-name"
-    assert compiler.parse_namespaced_pipeline_name("mlops/pipeline-name") == "mlops-pipeline-name"
-    assert compiler.parse_namespaced_pipeline_name("") == ""
+def test_sanitise_namespaced_pipeline_name():
+    assert compiler.sanitise_namespaced_pipeline_name("pipeline-name") == "pipeline-name"
+    assert compiler.sanitise_namespaced_pipeline_name("/pipeline-name") == "-pipeline-name"
+    assert compiler.sanitise_namespaced_pipeline_name("mlops/pipeline-name") == "mlops-pipeline-name"
+    assert compiler.sanitise_namespaced_pipeline_name("") == ""
 
 def test_name_from_namespaced_name():
     assert compiler.name_from_namespaced_name("pipeline-name") == "pipeline-name"

--- a/argo/kfp-compiler/tests/test_compiler.py
+++ b/argo/kfp-compiler/tests/test_compiler.py
@@ -24,3 +24,15 @@ def test_pipeline_paths_for_config():
     assert pipeline_root == "pipeline_root/pipeline"
     assert serving_model_directory == "pipeline_root/pipeline/serving"
     assert temp_directory == "pipeline_root/pipeline/tmp"
+
+def test_parse_namespaced_pipeline_name():
+    assert compiler.parse_namespaced_pipeline_name("pipeline-name") == "pipeline-name"
+    assert compiler.parse_namespaced_pipeline_name("/pipeline-name") == "-pipeline-name"
+    assert compiler.parse_namespaced_pipeline_name("mlops/pipeline-name") == "mlops-pipeline-name"
+    assert compiler.parse_namespaced_pipeline_name("") == ""
+
+def test_name_from_namespaced_name():
+    assert compiler.name_from_namespaced_name("pipeline-name") == "pipeline-name"
+    assert compiler.name_from_namespaced_name("/pipeline-name") == "pipeline-name"
+    assert compiler.name_from_namespaced_name("mlops/pipeline-name") == "pipeline-name"
+    assert compiler.name_from_namespaced_name("") == ""

--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -9,12 +9,12 @@ import (
 )
 
 type PipelineDefinition struct {
-	Name          string            `yaml:"name"`
-	Version       string            `yaml:"version"`
-	Image         string            `yaml:"image"`
-	TfxComponents string            `yaml:"tfxComponents"`
-	Env           []apis.NamedValue `yaml:"env"`
-	BeamArgs      []apis.NamedValue `yaml:"beamArgs"`
+	Name          common.NamespacedName `yaml:"name"`
+	Version       string                `yaml:"version"`
+	Image         string                `yaml:"image"`
+	TfxComponents string                `yaml:"tfxComponents"`
+	Env           []apis.NamedValue     `yaml:"env"`
+	BeamArgs      []apis.NamedValue     `yaml:"beamArgs"`
 }
 
 type ExperimentDefinition struct {

--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -24,7 +24,7 @@ type ExperimentDefinition struct {
 }
 
 type RunScheduleDefinition struct {
-	Name                 string                     `yaml:"name"`
+	Name                 common.NamespacedName      `yaml:"name"`
 	Version              string                     `yaml:"version"`
 	PipelineName         common.NamespacedName      `yaml:"pipelineName"`
 	PipelineVersion      string                     `yaml:"pipelineVersion"`

--- a/argo/providers/kfp/provider.go
+++ b/argo/providers/kfp/provider.go
@@ -234,7 +234,7 @@ func (kfpp KfpProvider) CreateRunSchedule(ctx context.Context, providerConfig Kf
 				Parameters: jobParameters,
 			},
 			Description:    string(runScheduleAsDescription),
-			Name:           runScheduleDefinition.Name,
+			Name:           runScheduleDefinition.Name.Name,
 			MaxConcurrency: 1,
 			Enabled:        true,
 			NoCatchup:      true,

--- a/argo/providers/kfp/provider.go
+++ b/argo/providers/kfp/provider.go
@@ -43,7 +43,7 @@ func (kfpp KfpProvider) CreatePipeline(ctx context.Context, providerConfig KfpPr
 	}
 
 	result, err := pipelineUploadService.UploadPipeline(&pipeline_upload_service.UploadPipelineParams{
-		Name:       &pipelineDefinition.Name,
+		Name:       &pipelineDefinition.Name.Name,
 		Uploadfile: runtime.NamedReader(pipelineFileName, reader),
 		Context:    ctx,
 	}, nil)

--- a/argo/providers/stub/provider.go
+++ b/argo/providers/stub/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/argoproj/argo-events/eventsources/sources/generic"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/sky-uk/kfp-operator/argo/providers/base"
 )
 
@@ -14,8 +15,8 @@ type StubProviderConfig struct {
 }
 
 type ResourceDefinition struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name    common.NamespacedName `yaml:"name"`
+	Version string                `yaml:"version"`
 }
 
 type ExpectedInput struct {
@@ -71,7 +72,7 @@ func (s StubProvider) DeletePipeline(_ context.Context, providerConfig StubProvi
 }
 
 func (s StubProvider) CreateRun(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{resourceDefinition.Name.Name, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{resourceDefinition.Name, resourceDefinition.Version})
 }
 
 func (s StubProvider) DeleteRun(_ context.Context, providerConfig StubProviderConfig, id string) error {
@@ -79,11 +80,11 @@ func (s StubProvider) DeleteRun(_ context.Context, providerConfig StubProviderCo
 }
 
 func (s StubProvider) CreateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{resourceDefinition.Name, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{resourceDefinition.Name, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubProviderConfig, id string) error {
@@ -91,11 +92,11 @@ func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubPr
 }
 
 func (s StubProvider) CreateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{resourceDefinition.Name, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{resourceDefinition.Name, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteExperiment(_ context.Context, providerConfig StubProviderConfig, id string) error {

--- a/argo/providers/stub/provider.go
+++ b/argo/providers/stub/provider.go
@@ -81,11 +81,11 @@ func (s StubProvider) DeleteRun(_ context.Context, providerConfig StubProviderCo
 }
 
 func (s StubProvider) CreateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{Name: resourceDefinition.Name, Version: resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{Name: resourceDefinition.Name, Version: resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubProviderConfig, id string) error {

--- a/argo/providers/stub/provider.go
+++ b/argo/providers/stub/provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 type StubProviderConfig struct {
+	Namespace     string        `yaml:"namespace"`
 	StubbedOutput base.Output   `yaml:"expectedOutput"`
 	ExpectedInput ExpectedInput `yaml:"expectedInput"`
 }
@@ -80,11 +81,11 @@ func (s StubProvider) DeleteRun(_ context.Context, providerConfig StubProviderCo
 }
 
 func (s StubProvider) CreateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateRunSchedule(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.RunScheduleDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubProviderConfig, id string) error {
@@ -92,11 +93,11 @@ func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubPr
 }
 
 func (s StubProvider) CreateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteExperiment(_ context.Context, providerConfig StubProviderConfig, id string) error {

--- a/argo/providers/stub/provider.go
+++ b/argo/providers/stub/provider.go
@@ -10,7 +10,6 @@ import (
 )
 
 type StubProviderConfig struct {
-	Namespace     string        `yaml:"namespace"`
 	StubbedOutput base.Output   `yaml:"expectedOutput"`
 	ExpectedInput ExpectedInput `yaml:"expectedInput"`
 }
@@ -93,11 +92,11 @@ func (s StubProvider) DeleteRunSchedule(_ context.Context, providerConfig StubPr
 }
 
 func (s StubProvider) CreateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition) (string, error) {
-	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version})
+	return verifyCreateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version})
 }
 
 func (s StubProvider) UpdateExperiment(_ context.Context, providerConfig StubProviderConfig, resourceDefinition base.ExperimentDefinition, id string) (string, error) {
-	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name, Namespace: providerConfig.Namespace}, resourceDefinition.Version}, id)
+	return verifyUpdateCall(providerConfig, ResourceDefinition{common.NamespacedName{Name: resourceDefinition.Name}, resourceDefinition.Version}, id)
 }
 
 func (s StubProvider) DeleteExperiment(_ context.Context, providerConfig StubProviderConfig, id string) error {

--- a/argo/providers/vai/config.go
+++ b/argo/providers/vai/config.go
@@ -2,6 +2,7 @@ package vai
 
 import (
 	"fmt"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	"strings"
 )
 
@@ -28,7 +29,7 @@ func (vaipc VAIProviderConfig) pipelineJobName(name string) string {
 	return fmt.Sprintf("%s/pipelineJobs/%s", vaipc.parent(), name)
 }
 
-func (vaipc VAIProviderConfig) pipelineStorageObject(pipelineName string, pipelineVersion string) string {
+func (vaipc VAIProviderConfig) pipelineStorageObject(pipelineName common.NamespacedName, pipelineVersion string) string {
 	return fmt.Sprintf("%s/%s", pipelineName, pipelineVersion)
 }
 
@@ -36,7 +37,7 @@ func (vaipc VAIProviderConfig) gcsUri(bucket string, pathSegments ...string) str
 	return fmt.Sprintf("gs://%s/%s", bucket, strings.Join(pathSegments, "/"))
 }
 
-func (vaipc VAIProviderConfig) pipelineUri(pipelineName string, pipelineVersion string) string {
+func (vaipc VAIProviderConfig) pipelineUri(pipelineName common.NamespacedName, pipelineVersion string) string {
 	return vaipc.gcsUri(vaipc.PipelineBucket, vaipc.pipelineStorageObject(pipelineName, pipelineVersion))
 }
 

--- a/argo/providers/vai/config.go
+++ b/argo/providers/vai/config.go
@@ -3,7 +3,6 @@ package vai
 import (
 	"fmt"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	"strings"
 )
 
 type VAIProviderConfig struct {
@@ -29,16 +28,20 @@ func (vaipc VAIProviderConfig) pipelineJobName(name string) string {
 	return fmt.Sprintf("%s/pipelineJobs/%s", vaipc.parent(), name)
 }
 
-func (vaipc VAIProviderConfig) pipelineStorageObject(pipelineName common.NamespacedName, pipelineVersion string) string {
-	return fmt.Sprintf("%s/%s", pipelineName, pipelineVersion)
+func (vaipc VAIProviderConfig) pipelineStorageObject(pipelineName common.NamespacedName, pipelineVersion string) (string, error) {
+	namespaceName, err := pipelineName.String()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s", namespaceName, pipelineVersion), nil
 }
 
-func (vaipc VAIProviderConfig) gcsUri(bucket string, pathSegments ...string) string {
-	return fmt.Sprintf("gs://%s/%s", bucket, strings.Join(pathSegments, "/"))
-}
-
-func (vaipc VAIProviderConfig) pipelineUri(pipelineName common.NamespacedName, pipelineVersion string) string {
-	return vaipc.gcsUri(vaipc.PipelineBucket, vaipc.pipelineStorageObject(pipelineName, pipelineVersion))
+func (vaipc VAIProviderConfig) pipelineUri(pipelineName common.NamespacedName, pipelineVersion string) (string, error) {
+	pipelineUri, err := vaipc.pipelineStorageObject(pipelineName, pipelineVersion)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("gs://%s/%s", vaipc.PipelineBucket, pipelineUri), nil
 }
 
 func (vaipc VAIProviderConfig) getMaxConcurrentRunCountOrDefault() int64 {

--- a/argo/providers/vai/config_unit_test.go
+++ b/argo/providers/vai/config_unit_test.go
@@ -26,4 +26,52 @@ var _ = Context("VAI Config", func() {
 		Entry("", -common.RandomInt64(), true),
 		Entry("", common.RandomInt64()+1, false),
 	)
+
+	DescribeTable("pipelineStorageObject", func(pipelineName common.NamespacedName, pipelineVersion string, expectedStorageObject string) {
+		storageObject, err := config.pipelineStorageObject(pipelineName, pipelineVersion)
+		if expectedStorageObject == "" {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(storageObject).To(Equal(expectedStorageObject))
+		}
+	},
+		Entry("", common.NamespacedName{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		}, "version", "myNamespace/myName/version"),
+		Entry("", common.NamespacedName{
+			Name:      "myName",
+			Namespace: "",
+		}, "version", "myName/version"),
+		Entry("", common.NamespacedName{
+			Name:      "",
+			Namespace: "myNamespace",
+		}, "version", ""),
+	)
+
+	DescribeTable("pipelineUri", func(bucket string, pipelineName common.NamespacedName, pipelineVersion string, expectedStorageObject string) {
+		config.PipelineBucket = bucket
+
+		storageObject, err := config.pipelineUri(pipelineName, pipelineVersion)
+		if expectedStorageObject == "" {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(storageObject).To(Equal(expectedStorageObject))
+		}
+	},
+		Entry("", "bucket", common.NamespacedName{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		}, "version", "gs://bucket/myNamespace/myName/version"),
+		Entry("", "", common.NamespacedName{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		}, "version", "gs:///myNamespace/myName/version"),
+		Entry("", "bucket", common.NamespacedName{
+			Name:      "",
+			Namespace: "myNamespace",
+		}, "version", ""),
+	)
 })

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -334,7 +334,7 @@ func (vaip VAIProvider) buildVaiScheduleFromPipelineJob(providerConfig VAIProvid
 				PipelineJob: pipelineJob,
 			},
 		},
-		DisplayName:           fmt.Sprintf("rc-%s", runScheduleDefinition.Name),
+		DisplayName:           fmt.Sprintf("rc-%s-%s", runScheduleDefinition.Name.Namespace, runScheduleDefinition.Name.Name),
 		MaxConcurrentRunCount: providerConfig.getMaxConcurrentRunCountOrDefault(),
 		AllowQueueing:         true,
 	}, nil

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -90,8 +90,6 @@ func enrichJobWithSpecFromTemplateUri(ctx context.Context, providerConfig VAIPro
 		return err
 	}
 
-	// TODO Still need to sort migration of pipeline definitions.
-
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reader)
 	if err != nil {
@@ -238,7 +236,6 @@ func extractRunNameSuffix(pipelineName string) (string, error) {
 
 func (vaip VAIProvider) CreateRun(ctx context.Context, providerConfig VAIProviderConfig, runDefinition RunDefinition) (string, error) {
 	logger := common.LoggerFromContext(ctx)
-	logger.Info(fmt.Sprintf("Creating run with name: [%s] version: [%s]", runDefinition.Name.Name, runDefinition.Version))
 
 	pipelineClient, err := aiplatform.NewPipelineClient(ctx, option.WithEndpoint(providerConfig.vaiEndpoint()))
 	if err != nil {
@@ -273,7 +270,6 @@ func (vaip VAIProvider) CreateRun(ctx context.Context, providerConfig VAIProvide
 		return "", err
 	}
 
-	// get spec from job which has just been mutated above to get the run id from "pipelineInfo/name"
 	runId, err := extractPipelineNameFromSpec(pipelineJob.PipelineSpec.AsMap())
 	if err != nil {
 		logger.Error(err, err.Error())

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -228,6 +228,14 @@ func extractPipelineNameFromSpec(pipelineSpec map[string]any) (string, error) {
 	return runId, nil
 }
 
+func extractRunNameSuffix(pipelineName string) (string, error) {
+	index := strings.LastIndex(pipelineName, "-")
+	if index == -1 {
+		return "", fmt.Errorf("unable to extract suffix from pipelineName: %s", pipelineName)
+	}
+	return pipelineName[index+1:], nil
+}
+
 func (vaip VAIProvider) CreateRun(ctx context.Context, providerConfig VAIProviderConfig, runDefinition RunDefinition) (string, error) {
 	logger := common.LoggerFromContext(ctx)
 	logger.Info(fmt.Sprintf("Creating run with name: [%s] version: [%s]", runDefinition.Name.Name, runDefinition.Version))

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -202,14 +202,12 @@ func (vaip VAIProvider) DeletePipeline(ctx context.Context, providerConfig VAIPr
 	return nil
 }
 
-func ExtractFromMap[T any](targetMap map[string]any, fieldName string) (T, error) {
+func ExtractFromMap[T any](targetMap map[string]any, fieldName string) (result T, err error) {
 	result, ok := targetMap[fieldName].(T)
 	if !ok {
-		err := errors.New("Failed extracting field " + fieldName + "from a given map")
-		var emptyResult T
-		return emptyResult, err
+		err = fmt.Errorf("failed extracting field %s of type %T from the given map", fieldName, result)
 	}
-	return result, nil
+	return result, err
 }
 
 func extractPipelineNameFromSpec(pipelineSpec map[string]any) (string, error) {

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -209,7 +209,7 @@ var _ = Context("VAI Provider", func() {
 			intField, intFieldErr := ExtractFromMap[int](testMap, "intField")
 			mapField, mapFieldErr := ExtractFromMap[map[string]int](testMap, "mapField")
 			_, missingFieldErr := ExtractFromMap[string](testMap, "missingField")
-			_, wrongTypeError := ExtractFromMap[int](testMap, "mapField")
+			_, wrongTypeErr := ExtractFromMap[int](testMap, "mapField")
 
 			Expect(stringField).To(Equal("someString"))
 			Expect(stringFieldErr).ToNot(HaveOccurred())
@@ -220,7 +220,7 @@ var _ = Context("VAI Provider", func() {
 			}))
 			Expect(mapFieldErr).ToNot(HaveOccurred())
 			Expect(missingFieldErr).To(HaveOccurred())
-			Expect(wrongTypeError).To(HaveOccurred())
+			Expect(wrongTypeErr).To(HaveOccurred())
 		})
 	})
 

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -194,4 +194,55 @@ var _ = Context("VAI Provider", func() {
 			}))
 		})
 	})
+
+	Describe("ExtractFromMap", func() {
+		It("should extract a value from a map for any given type if it exists", func() {
+			testMap := map[string]any{
+				"stringField": "someString",
+				"intField":    1,
+				"mapField": map[string]int{
+					"nestedField": 2,
+				},
+			}
+
+			stringField, stringFieldErr := ExtractFromMap[string](testMap, "stringField")
+			intField, intFieldErr := ExtractFromMap[int](testMap, "intField")
+			mapField, mapFieldErr := ExtractFromMap[map[string]int](testMap, "mapField")
+			_, missingFieldErr := ExtractFromMap[string](testMap, "missingField")
+			_, wrongTypeError := ExtractFromMap[int](testMap, "mapField")
+
+			Expect(stringField).To(Equal("someString"))
+			Expect(stringFieldErr).ToNot(HaveOccurred())
+			Expect(intField).To(Equal(1))
+			Expect(intFieldErr).ToNot(HaveOccurred())
+			Expect(mapField).To(Equal(map[string]int{
+				"nestedField": 2,
+			}))
+			Expect(mapFieldErr).ToNot(HaveOccurred())
+			Expect(missingFieldErr).To(HaveOccurred())
+			Expect(wrongTypeError).To(HaveOccurred())
+		})
+	})
+
+	Describe("retrieveRunIdFromSpec", func() {
+		It("should extract a runId from a given pipelineSpec", func() {
+			pipelineName := "pipelineName"
+			pipelineSpec := map[string]any{
+				"pipelineInfo": map[string]any{
+					"name": pipelineName,
+				},
+			}
+			result, err := retrieveRunIdFromSpec(pipelineSpec)
+
+			Expect(result).To(Equal(pipelineName))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should error if pipeline spec is missing a required field", func() {
+			pipelineSpec := map[string]any{}
+			_, err := retrieveRunIdFromSpec(pipelineSpec)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -245,4 +245,19 @@ var _ = Context("VAI Provider", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	DescribeTable("extractRunNameSuffix", func(pipelineName string, expected string) {
+		suffix, err := extractRunNameSuffix(pipelineName)
+		if expected == "" {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(suffix).To(Equal(expected))
+		}
+
+	},
+		Entry("", "pipeline-name", "name"),
+		Entry("", "still-pipeline-name", "name"),
+		Entry("", "pipeline", ""),
+		Entry("", "", ""),
+	)
 })

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -22,7 +22,7 @@ func randomBasicRunDefinition() RunDefinition {
 
 func randomRunScheduleDefinition() RunScheduleDefinition {
 	return RunScheduleDefinition{
-		Name:                 common.RandomString(),
+		Name:                 common.RandomNamespacedName(),
 		Version:              common.RandomString(),
 		PipelineName:         common.RandomNamespacedName(),
 		PipelineVersion:      common.RandomString(),

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -224,7 +224,7 @@ var _ = Context("VAI Provider", func() {
 		})
 	})
 
-	Describe("retrieveRunIdFromSpec", func() {
+	Describe("extractPipelineNameFromSpec", func() {
 		It("should extract a runId from a given pipelineSpec", func() {
 			pipelineName := "pipelineName"
 			pipelineSpec := map[string]any{
@@ -232,7 +232,7 @@ var _ = Context("VAI Provider", func() {
 					"name": pipelineName,
 				},
 			}
-			result, err := retrieveRunIdFromSpec(pipelineSpec)
+			result, err := extractPipelineNameFromSpec(pipelineSpec)
 
 			Expect(result).To(Equal(pipelineName))
 			Expect(err).ToNot(HaveOccurred())
@@ -240,7 +240,7 @@ var _ = Context("VAI Provider", func() {
 
 		It("should error if pipeline spec is missing a required field", func() {
 			pipelineSpec := map[string]any{}
-			_, err := retrieveRunIdFromSpec(pipelineSpec)
+			_, err := extractPipelineNameFromSpec(pipelineSpec)
 
 			Expect(err).To(HaveOccurred())
 		})

--- a/controllers/pipelines/experiment_workflow_integration_test.go
+++ b/controllers/pipelines/experiment_workflow_integration_test.go
@@ -17,7 +17,11 @@ var _ = Context("Resource Workflows", Serial, func() {
 	})
 
 	var newExperiment = func() *pipelinesv1.Experiment {
-		return withIntegrationTestFields(pipelinesv1.RandomExperiment())
+		resource := pipelinesv1.RandomExperiment()
+		resourceStatus := resource.GetStatus()
+		resourceStatus.ProviderId.Provider = TestProvider
+		resource.SetStatus(resourceStatus)
+		return resource
 	}
 
 	DescribeTable("Experiment Workflows", AssertWorkflow[*pipelinesv1.Experiment],

--- a/controllers/pipelines/pipeline_workflow_factory.go
+++ b/controllers/pipelines/pipeline_workflow_factory.go
@@ -3,6 +3,7 @@ package pipelines
 import (
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha5"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	providers "github.com/sky-uk/kfp-operator/argo/providers/base"
 )
 
@@ -12,7 +13,7 @@ type PipelineDefinitionCreator struct {
 
 func (pdc PipelineDefinitionCreator) pipelineDefinition(pipeline *pipelinesv1.Pipeline) (providers.PipelineDefinition, error) {
 	return providers.PipelineDefinition{
-		Name:          pipeline.ObjectMeta.Name,
+		Name:          common.NamespacedName{Name: pipeline.ObjectMeta.Name, Namespace: pipeline.ObjectMeta.Namespace},
 		Version:       pipeline.ComputeVersion(),
 		Image:         pipeline.Spec.Image,
 		TfxComponents: pipeline.Spec.TfxComponents,

--- a/controllers/pipelines/pipeline_workflow_factory_test.go
+++ b/controllers/pipelines/pipeline_workflow_factory_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	providers "github.com/sky-uk/kfp-operator/argo/providers/base"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +27,8 @@ var _ = Describe("PipelineDefinition", func() {
 
 		pipeline := &pipelinesv1.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelineName",
+				Name:      "pipelineName",
+				Namespace: "pipelineNamespace",
 			},
 			Spec: pipelinesv1.PipelineSpec{
 				Image:         "pipelineImage",
@@ -38,7 +40,10 @@ var _ = Describe("PipelineDefinition", func() {
 
 		compilerConfig, _ := wf.pipelineDefinition(pipeline)
 
-		Expect(compilerConfig.Name).To(Equal("pipelineName"))
+		Expect(compilerConfig.Name).To(Equal(common.NamespacedName{
+			Name:      "pipelineName",
+			Namespace: "pipelineNamespace",
+		}))
 		Expect(compilerConfig.Image).To(Equal("pipelineImage"))
 		Expect(compilerConfig.TfxComponents).To(Equal("pipelineTfxComponents"))
 		Expect(compilerConfig.Env).To(Equal(expectedEnv))
@@ -47,7 +52,10 @@ var _ = Describe("PipelineDefinition", func() {
 
 	It("Creates a valid YAML", func() {
 		config := providers.PipelineDefinition{
-			Name:          "pipelineName",
+			Name: common.NamespacedName{
+				Name:      "pipelineName",
+				Namespace: "pipelineNamespace",
+			},
 			Image:         "pipelineImage",
 			TfxComponents: "pipelineTfxComponents",
 			Env: []apis.NamedValue{
@@ -64,7 +72,7 @@ var _ = Describe("PipelineDefinition", func() {
 		m := make(map[interface{}]interface{})
 		yaml.Unmarshal(configYaml, m)
 
-		Expect(m["name"]).To(Equal("pipelineName"))
+		Expect(m["name"]).To(Equal("pipelineNamespace/pipelineName"))
 		Expect(m["image"]).To(Equal("pipelineImage"))
 		Expect(m["tfxComponents"]).To(Equal("pipelineTfxComponents"))
 		env := m["env"].([]interface{})

--- a/controllers/pipelines/runschedule_workflow_factory.go
+++ b/controllers/pipelines/runschedule_workflow_factory.go
@@ -25,7 +25,7 @@ func (rcdc RunScheduleDefinitionCreator) runScheduleDefinition(runSchedule *pipe
 	}
 
 	return providers.RunScheduleDefinition{
-		Name:                 runSchedule.ObjectMeta.Name,
+		Name:                 common.NamespacedName{Name: runSchedule.ObjectMeta.Name, Namespace: runSchedule.Namespace},
 		RunConfigurationName: runConfigurationNameForRunSchedule(runSchedule),
 		Version:              runSchedule.ComputeVersion(),
 		PipelineName:         common.NamespacedName{Name: runSchedule.Spec.Pipeline.Name, Namespace: runSchedule.Namespace},

--- a/controllers/pipelines/suite_integration_test.go
+++ b/controllers/pipelines/suite_integration_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha5"
+	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/sky-uk/kfp-operator/argo/providers/base"
 	"github.com/sky-uk/kfp-operator/argo/providers/stub"
 	"github.com/sky-uk/kfp-operator/external"
@@ -61,7 +62,10 @@ func StubProvider[R pipelinesv1.Resource](stubbedOutput base.Output, resource R)
 		ExpectedInput: stub.ExpectedInput{
 			Id: resource.GetStatus().ProviderId.Id,
 			ResourceDefinition: stub.ResourceDefinition{
-				Name:    resource.GetName(),
+				Name: common.NamespacedName{
+					Name:      resource.GetName(),
+					Namespace: resource.GetNamespace(),
+				},
 				Version: resource.ComputeVersion(),
 			},
 		},

--- a/controllers/pipelines/suite_integration_test.go
+++ b/controllers/pipelines/suite_integration_test.go
@@ -60,7 +60,6 @@ var _ = BeforeEach(func() {
 
 func StubProvider[R pipelinesv1.Resource](stubbedOutput base.Output, resource R) base.Output {
 	providerConfig := stub.StubProviderConfig{
-		Namespace:     TestNamespace,
 		StubbedOutput: stubbedOutput,
 		ExpectedInput: stub.ExpectedInput{
 			Id: resource.GetStatus().ProviderId.Id,


### PR DESCRIPTION
Connects to #40.

Compiler sets pipeline_name which ends up being the pipelineInfo/name in the pipeline definition which is then used in both one off runs and scheduled runs to set the run name.

### Workflow Changes
RunScheduleDefinition and PipelineDefinition Name attribute changed from string (i.e. penguin-pipeline-name) to NamespacedName (i.e. namespace/penguin-pipeline-name) so these values are passed into the relevant workflow.

### Compile Changes
Changes were needed here because it was found there is currently no way to override the "scheduled run name" (i.e. the name given to individual runs) it just uses the pipelineInfo/name value. A request has been made to Google change the [createSchedule](https://pkg.go.dev/cloud.google.com/go/aiplatform@v1.67.0/apiv1/aiplatformpb#CreateScheduleRequest) interface in the Vertex AI Pipeline API to allow setting at creation time but until that is made available this has to be done.

As `/` characters are not valid as a pipeline name we sanitise it to a `-` and set that into the pipeline_name which then gets set into the pipelineInfo/name element on the pipeline yaml. pipeline_paths_for_config automatically includes the namespace in all paths. For example in the pipeline yaml we now have:
```
"base_directory": "gs://your-servicing-bucket/namespace/penguin-pipeline-name/serving"
```

### VAI Provider Changes
CreateRun changed to calculate PipelineJobId from pipelineInfo/name within the job spec (which had previously been processed in the compiler above). Changed this to use the pipeline spec so that both one off and scheduled runs are driven from same place.

GCS paths all changed to use namespaced names

Creating updating run schedule using passed in namespaced name from workflow to add namespace into the display name of the schedule in VAI. The "Scheduled run name" in VAI is picked up from the pipelineInfo/name field in the pipeline spec.

### KFP Provider Changes
Changed so functions as existing, name is used from within the passed NamespacedName value.

### Noticeable changes with VAI
* pipeline yaml uploaded into GCS within namespaced "directory"
* Scheduled run name includes namespace
* schedule display name includes namespace
* one off run named "namespace-penguin-pipeline-name-<random chars>"
* scheduled runs named "namespace-penguin-pipeline-name-<timestamp>"
* artifacts are pushed to namespaced directory in GCS

## Tasks

- [X] add namespace to one off runs
- [X] add namespace to schedules and scheduled run name
- [X] add namespace to storage path
- [X] Documentation updated
