### PR TITLE
Use `nobody` user in custom alpine docker images

### DIFF
--- a/argo/kfp-compiler/Dockerfile
+++ b/argo/kfp-compiler/Dockerfile
@@ -29,4 +29,5 @@ ADD resources/compile.sh kfp-compiler/compile.sh
 
 ADD resources/entrypoint.sh entrypoint.sh
 
+USER 65534:65534
 ENTRYPOINT ["/entrypoint.sh"]

--- a/argo/providers/stub/Dockerfile
+++ b/argo/providers/stub/Dockerfile
@@ -1,9 +1,10 @@
 FROM alpine:3.20.1
 
 WORKDIR /
+
 COPY inject.sh inject.sh
 COPY compile.sh compile.sh
 COPY bin/provider .
-USER 65532:65532
 
+USER 65534:65534
 ENTRYPOINT ["/bin/sh", "/inject.sh"]


### PR DESCRIPTION
Closes #65

Adds a non-root user to docker images which are currently using a root user. It uses a userid of `65534`  `nobody` for the alpine images.

## Tasks

- [x] Update kfp compiler to use non-root user
- [x] Update stubbed provider to use non-root user
- [x] Documentation updated
