### PR TITLE
Update alpine image versions to 3.20.1

### DIFF
--- a/argo/kfp-compiler/Dockerfile
+++ b/argo/kfp-compiler/Dockerfile
@@ -19,7 +19,7 @@ COPY dist/*-${WHEEL_VERSION}-*.whl /
 RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
     rm /*-${WHEEL_VERSION}-*.whl
 
-FROM alpine:3.14.2
+FROM alpine:3.20.1
 
 WORKDIR /
 COPY --from=PYTHON38 /kfp-compiler kfp-compiler/py3.8

--- a/argo/providers/stub/Dockerfile
+++ b/argo/providers/stub/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.0
+FROM alpine:3.20.1
 
 WORKDIR /
 COPY inject.sh inject.sh


### PR DESCRIPTION
Closes #334 

Updates the Alpine images to the latest version. [`3.20.1` ](https://hub.docker.com/layers/library/alpine/3.20.1/images/sha256-dabf91b69c191a1a0a1628fd6bdd029c0c4018041c7f052870bb13c5a222ae76?context=explore)

## Tasks

- [x] Documentation updated
