### PR TITLE
Fix delete run schedule not found with provider VAI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test: fmt vet unit-test decoupled-test
 test-argo:
 	$(MAKE) -C argo/common test
 	$(MAKE) -C argo/status-updater test
-	$(MAKE) -C argo/kfp-compiler test
+	#$(MAKE) -C argo/kfp-compiler test
 	$(MAKE) -C argo/providers test
 
 test-all: test helm-test test-argo
@@ -187,12 +187,12 @@ include docker-targets.mk
 
 docker-build-argo:
 	$(MAKE) -C argo/status-updater docker-build
-	$(MAKE) -C argo/kfp-compiler docker-build
+	#$(MAKE) -C argo/kfp-compiler docker-build
 	$(MAKE) -C argo/providers docker-build
 
 docker-push-argo:
 	$(MAKE) -C argo/status-updater docker-push
-	$(MAKE) -C argo/kfp-compiler docker-push
+	#$(MAKE) -C argo/kfp-compiler docker-push
 	$(MAKE) -C argo/providers docker-push
 
 ##@ Docs

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test: fmt vet unit-test decoupled-test
 test-argo:
 	$(MAKE) -C argo/common test
 	$(MAKE) -C argo/status-updater test
-	#$(MAKE) -C argo/kfp-compiler test
+	$(MAKE) -C argo/kfp-compiler test
 	$(MAKE) -C argo/providers test
 
 test-all: test helm-test test-argo
@@ -187,12 +187,12 @@ include docker-targets.mk
 
 docker-build-argo:
 	$(MAKE) -C argo/status-updater docker-build
-	#$(MAKE) -C argo/kfp-compiler docker-build
+	$(MAKE) -C argo/kfp-compiler docker-build
 	$(MAKE) -C argo/providers docker-build
 
 docker-push-argo:
 	$(MAKE) -C argo/status-updater docker-push
-	#$(MAKE) -C argo/kfp-compiler docker-push
+	$(MAKE) -C argo/kfp-compiler docker-push
 	$(MAKE) -C argo/providers docker-push
 
 ##@ Docs

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -418,14 +418,18 @@ func (vaip VAIProvider) DeleteRunSchedule(ctx context.Context, providerConfig VA
 		Name: scheduleId,
 	})
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil
-		} else {
-			return err
-		}
+		return handleScheduleNotFound(err)
 	}
 
-	return deleteSchedule.Wait(ctx)
+	return handleScheduleNotFound(deleteSchedule.Wait(ctx))
+}
+
+func handleScheduleNotFound(err error) error {
+	if status.Code(err) == codes.NotFound {
+		return nil
+	} else {
+		return err
+	}
 }
 
 func (vaip VAIProvider) CreateExperiment(_ context.Context, _ VAIProviderConfig, _ ExperimentDefinition) (string, error) {

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -427,9 +427,8 @@ func (vaip VAIProvider) DeleteRunSchedule(ctx context.Context, providerConfig VA
 func handleScheduleNotFound(err error) error {
 	if status.Code(err) == codes.NotFound {
 		return nil
-	} else {
-		return err
 	}
+	return err
 }
 
 func (vaip VAIProvider) CreateExperiment(_ context.Context, _ VAIProviderConfig, _ ExperimentDefinition) (string, error) {

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/argo/common"
 	. "github.com/sky-uk/kfp-operator/argo/providers/base"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -250,6 +252,23 @@ var _ = Context("VAI Provider", func() {
 
 			_, err = extractPipelineNameFromPipelineSpec(ctx, pbStruct)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("handleScheduleNotFound", func() {
+		It("should ignore NotFound status", func() {
+			notFoundError := status.Error(codes.NotFound, "I can't find what you are looking for")
+			Expect(handleScheduleNotFound(notFoundError)).To(BeNil())
+		})
+
+		It("should return any other grpc status error", func() {
+			abortError := status.Error(codes.Aborted, "Abort, Abort")
+			Expect(handleScheduleNotFound(abortError)).To(Equal(abortError))
+		})
+
+		It("should return any other error", func() {
+			otherError := errors.New("panic")
+			Expect(handleScheduleNotFound(otherError)).To(Equal(otherError))
 		})
 	})
 })


### PR DESCRIPTION
connects to #128 

On deleting a run schedule if Vertex AI responds with NotFound status then ignore the error as nothing to delete.

Without this change the resource was stuck in a "Deleting" status and never recovered.

Have checked with deleting pipelines and they got successfully deleted so no change needed for that.