### PR TITLE
Fix creation of Kubeflow run configuration with no experiment

### DIFF
--- a/controllers/pipelines/run_workflow_factory.go
+++ b/controllers/pipelines/run_workflow_factory.go
@@ -13,12 +13,11 @@ type RunDefinitionCreator struct {
 }
 
 func (rdc RunDefinitionCreator) runDefinition(run *pipelinesv1.Run) (providers.RunDefinition, error) {
-	var experimentName string
-
+	var experimentName common.NamespacedName
 	if run.Spec.ExperimentName == "" {
-		experimentName = rdc.Config.DefaultExperiment
+		experimentName = common.NamespacedName{Name: rdc.Config.DefaultExperiment}
 	} else {
-		experimentName = run.Spec.ExperimentName
+		experimentName = common.NamespacedName{Name: run.Spec.ExperimentName, Namespace: run.Namespace}
 	}
 
 	if run.Status.ObservedPipelineVersion == "" {
@@ -35,7 +34,7 @@ func (rdc RunDefinitionCreator) runDefinition(run *pipelinesv1.Run) (providers.R
 		Version:           run.ComputeVersion(),
 		PipelineName:      common.NamespacedName{Namespace: run.Namespace, Name: run.Spec.Pipeline.Name},
 		PipelineVersion:   run.Status.ObservedPipelineVersion,
-		ExperimentName:    common.NamespacedName{Namespace: run.Namespace, Name: experimentName},
+		ExperimentName:    experimentName,
 		RuntimeParameters: NamedValuesToMap(runtimeParameters),
 		Artifacts:         run.Spec.Artifacts,
 	}

--- a/controllers/pipelines/runschedule_workflow_factory.go
+++ b/controllers/pipelines/runschedule_workflow_factory.go
@@ -16,12 +16,11 @@ type RunScheduleDefinitionCreator struct {
 }
 
 func (rcdc RunScheduleDefinitionCreator) runScheduleDefinition(runSchedule *pipelinesv1.RunSchedule) (providers.RunScheduleDefinition, error) {
-	var experimentName string
-
+	var experimentName common.NamespacedName
 	if runSchedule.Spec.ExperimentName == "" {
-		experimentName = rcdc.Config.DefaultExperiment
+		experimentName = common.NamespacedName{Name: rcdc.Config.DefaultExperiment}
 	} else {
-		experimentName = runSchedule.Spec.ExperimentName
+		experimentName = common.NamespacedName{Name: runSchedule.Spec.ExperimentName, Namespace: runSchedule.Namespace}
 	}
 
 	return providers.RunScheduleDefinition{
@@ -30,7 +29,7 @@ func (rcdc RunScheduleDefinitionCreator) runScheduleDefinition(runSchedule *pipe
 		Version:              runSchedule.ComputeVersion(),
 		PipelineName:         common.NamespacedName{Name: runSchedule.Spec.Pipeline.Name, Namespace: runSchedule.Namespace},
 		PipelineVersion:      runSchedule.Spec.Pipeline.Version,
-		ExperimentName:       common.NamespacedName{Name: experimentName, Namespace: runSchedule.Namespace},
+		ExperimentName:       experimentName,
 		Schedule:             runSchedule.Spec.Schedule,
 		RuntimeParameters:    NamedValuesToMap(runSchedule.Spec.RuntimeParameters),
 		Artifacts:            runSchedule.Spec.Artifacts,


### PR DESCRIPTION
Closes #337.

Have manually tested creation of new run configuration and it is now successful.

Issue was caused by the namespacing change and the Default experiment not belonging to a namespace.