### PR TITLE
Kubeflow Provider - handle NotFound in pipeline resource deletion

### DIFF
--- a/argo/providers/kfp/provider.go
+++ b/argo/providers/kfp/provider.go
@@ -93,9 +93,9 @@ func (kfpp KfpProvider) DeletePipeline(ctx context.Context, providerConfig KfpPr
 	}, nil)
 
 	if err != nil {
-		var errorResult *pipeline_service.DeletePipelineDefault
-		if errors.As(err, &errorResult) && errorResult.Payload.Code == kfpApiConstants.KfpResourceNotFoundCode {
-			err = nil
+		var deletePipelineError *pipeline_service.DeletePipelineDefault
+		if errors.As(err, &deletePipelineError) {
+			return ignoreNotFound(err, deletePipelineError.Payload.Code)
 		}
 	}
 
@@ -322,9 +322,9 @@ func (kfpp KfpProvider) DeleteRunSchedule(ctx context.Context, providerConfig Kf
 	}, nil)
 
 	if err != nil {
-		var errorResult *job_service.DeleteJobDefault
-		if errors.As(err, &errorResult) && errorResult.Payload.Code == kfpApiConstants.KfpResourceNotFoundCode {
-			err = nil
+		var deleteJobError *job_service.DeleteJobDefault
+		if errors.As(err, &deleteJobError) {
+			return ignoreNotFound(err, deleteJobError.Payload.Code)
 		}
 	}
 
@@ -421,4 +421,11 @@ func (kfpp KfpProvider) EventingServer(ctx context.Context, providerConfig KfpPr
 		MetadataStore:  metadataStore,
 		KfpApi:         kfpApi,
 	}, nil
+}
+
+func ignoreNotFound(err error, code int32) error {
+	if code == kfpApiConstants.KfpResourceNotFoundCode {
+		return nil
+	}
+	return err
 }

--- a/argo/providers/vai/provider.go
+++ b/argo/providers/vai/provider.go
@@ -418,13 +418,13 @@ func (vaip VAIProvider) DeleteRunSchedule(ctx context.Context, providerConfig VA
 		Name: scheduleId,
 	})
 	if err != nil {
-		return handleScheduleNotFound(err)
+		return ignoreNotFound(err)
 	}
 
-	return handleScheduleNotFound(deleteSchedule.Wait(ctx))
+	return ignoreNotFound(deleteSchedule.Wait(ctx))
 }
 
-func handleScheduleNotFound(err error) error {
+func ignoreNotFound(err error) error {
 	if status.Code(err) == codes.NotFound {
 		return nil
 	}

--- a/argo/providers/vai/provider_unit_test.go
+++ b/argo/providers/vai/provider_unit_test.go
@@ -255,20 +255,20 @@ var _ = Context("VAI Provider", func() {
 		})
 	})
 
-	Describe("handleScheduleNotFound", func() {
+	Describe("ignoreNotFound", func() {
 		It("should ignore NotFound status", func() {
 			notFoundError := status.Error(codes.NotFound, "I can't find what you are looking for")
-			Expect(handleScheduleNotFound(notFoundError)).To(BeNil())
+			Expect(ignoreNotFound(notFoundError)).To(BeNil())
 		})
 
 		It("should return any other grpc status error", func() {
 			abortError := status.Error(codes.Aborted, "Abort, Abort")
-			Expect(handleScheduleNotFound(abortError)).To(Equal(abortError))
+			Expect(ignoreNotFound(abortError)).To(Equal(abortError))
 		})
 
 		It("should return any other error", func() {
 			otherError := errors.New("panic")
-			Expect(handleScheduleNotFound(otherError)).To(Equal(otherError))
+			Expect(ignoreNotFound(otherError)).To(Equal(otherError))
 		})
 	})
 })


### PR DESCRIPTION
Connects to https://github.com/sky-uk/kfp-operator/issues/128

On deleting a pipeline resource with kubeflow provider when the pipeline didnt actually exist within kubeflow the deletion workflow failed and resource stayed in "deleting" status forever.

This change fixes that. On deleting check error to see if not found if so then ignore.

Refactored existing code in delete run schedule which was doing same logic.