### PR TITLE
Provider CRD read provider in controllers from k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ integration-test-up:
 integration-test: manifests generate helm-cmd yq ## Run integration tests
 	eval $$(minikube -p kfp-operator-tests docker-env) && \
 	$(MAKE) -C argo/providers/stub docker-build && \
-	docker build docs-gen/includes/quickstart -t kfp-quickstart
 	$(HELM) template helm/kfp-operator --values config/testing/integration-test-values.yaml | \
  		$(YQ) e 'select(.kind == "*WorkflowTemplate")' - | \
  		kubectl apply -f -

--- a/apis/pipelines/v1alpha5/test_generators.go
+++ b/apis/pipelines/v1alpha5/test_generators.go
@@ -160,8 +160,9 @@ func RandomRunScheduleSpec() RunScheduleSpec {
 func RandomRun() *Run {
 	return &Run{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandomLowercaseString(),
-			Namespace: "default",
+			Name:        RandomLowercaseString(),
+			Namespace:   "default",
+			Annotations: map[string]string{},
 		},
 		Spec: RandomRunSpec(),
 		Status: RunStatus{

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -56,7 +56,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	commands := r.StateHandler.StateTransition(ctx, *provider, experiment)
+	commands := r.StateHandler.StateTransition(ctx, provider, experiment)
 
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, experiment); err != nil {

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -51,14 +51,12 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	desiredProvider := desiredProvider(experiment, r.Config)
 
-	logger.V(3).Info("found desired provider", "resource", desiredProvider)
-
 	provider, err := loadProvider(ctx, r.EC.Client.NonCached, r.Config.WorkflowNamespace, desiredProvider)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	logger.V(3).Info("found provider", "resource", *provider)
+	logger.V(3).Info("found provider", "resource", desiredProvider)
 
 	commands := r.StateHandler.StateTransition(ctx, *provider, experiment)
 

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -51,7 +51,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	desiredProvider := desiredProvider(experiment, r.Config)
 
-	provider, err := loadProvider(ctx, r.EC.Client.NonCached, r.Config.WorkflowNamespace, desiredProvider)
+	provider, err := r.loadProvider(ctx, r.Config.WorkflowNamespace, desiredProvider)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -56,8 +56,6 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	logger.V(3).Info("found provider", "resource", desiredProvider)
-
 	commands := r.StateHandler.StateTransition(ctx, *provider, experiment)
 
 	for i := range commands {

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -61,7 +61,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	commands := r.StateHandler.StateTransition(ctx, *provider, pipeline)
+	commands := r.StateHandler.StateTransition(ctx, provider, pipeline)
 
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, pipeline); err != nil {

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -56,7 +56,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	desiredProvider := desiredProvider(pipeline, r.Config)
 
-	provider, err := loadProvider(ctx, r.EC.Client.NonCached, r.Config.WorkflowNamespace, desiredProvider)
+	provider, err := r.loadProvider(ctx, r.Config.WorkflowNamespace, desiredProvider)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -38,13 +38,13 @@ func loadProvider(ctx context.Context, reader client.Reader, namespace string, d
 		Name:      desiredProvider,
 	}
 
-	var provider = &pipelinesv1.Provider{}
+	var provider = pipelinesv1.Provider{}
 
-	err := reader.Get(ctx, providerNamespacedName, provider)
+	err := reader.Get(ctx, providerNamespacedName, &provider)
 	if err != nil {
-		return *provider, err
+		return provider, err
 	}
-	return *provider, nil
+	return provider, nil
 }
 
 func (br ResourceReconciler[R]) reconciliationRequestsForWorkflow(resource pipelinesv1.Resource) func(client.Object) []reconcile.Request {

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -40,10 +40,8 @@ func (br ResourceReconciler[R]) loadProvider(ctx context.Context, namespace stri
 	var provider = pipelinesv1.Provider{}
 
 	err := br.EC.Client.NonCached.Get(ctx, providerNamespacedName, &provider)
-	if err != nil {
-		return provider, err
-	}
-	return provider, nil
+
+	return provider, err
 }
 
 func (br ResourceReconciler[R]) reconciliationRequestsForWorkflow(resource pipelinesv1.Resource) func(client.Object) []reconcile.Request {

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -42,7 +42,7 @@ func loadProvider(ctx context.Context, reader client.Reader, namespace string, d
 
 	err := reader.Get(ctx, providerNamespacedName, provider)
 	if err != nil {
-		return nil, err
+		return provider, err
 	}
 	return provider, nil
 }

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -32,15 +32,14 @@ func desiredProvider(resource pipelinesv1.HasProvider, config config.Configurati
 	return config.DefaultProvider
 }
 
-func loadProvider(ctx context.Context, reader client.Reader, namespace string, desiredProvider string) (pipelinesv1.Provider, error) {
+func (br ResourceReconciler[R]) loadProvider(ctx context.Context, namespace string, desiredProvider string) (pipelinesv1.Provider, error) {
 	providerNamespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      desiredProvider,
 	}
-
 	var provider = pipelinesv1.Provider{}
 
-	err := reader.Get(ctx, providerNamespacedName, &provider)
+	err := br.EC.Client.NonCached.Get(ctx, providerNamespacedName, &provider)
 	if err != nil {
 		return provider, err
 	}

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -34,7 +33,6 @@ func desiredProvider(resource pipelinesv1.HasProvider, config config.Configurati
 }
 
 func loadProvider(ctx context.Context, reader client.Reader, namespace string, desiredProvider string) (*pipelinesv1.Provider, error) {
-	logger := log.FromContext(ctx)
 	providerNamespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      desiredProvider,
@@ -44,10 +42,8 @@ func loadProvider(ctx context.Context, reader client.Reader, namespace string, d
 
 	err := reader.Get(ctx, providerNamespacedName, provider)
 	if err != nil {
-		logger.Error(err, "unable to fetch provider")
 		return nil, err
 	}
-	logger.Error(err, "found provider", provider)
 	return provider, nil
 }
 

--- a/controllers/pipelines/reconciler.go
+++ b/controllers/pipelines/reconciler.go
@@ -32,7 +32,7 @@ func desiredProvider(resource pipelinesv1.HasProvider, config config.Configurati
 	return config.DefaultProvider
 }
 
-func loadProvider(ctx context.Context, reader client.Reader, namespace string, desiredProvider string) (*pipelinesv1.Provider, error) {
+func loadProvider(ctx context.Context, reader client.Reader, namespace string, desiredProvider string) (pipelinesv1.Provider, error) {
 	providerNamespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      desiredProvider,
@@ -42,9 +42,9 @@ func loadProvider(ctx context.Context, reader client.Reader, namespace string, d
 
 	err := reader.Get(ctx, providerNamespacedName, provider)
 	if err != nil {
-		return provider, err
+		return *provider, err
 	}
-	return provider, nil
+	return *provider, nil
 }
 
 func (br ResourceReconciler[R]) reconciliationRequestsForWorkflow(resource pipelinesv1.Resource) func(client.Object) []reconcile.Request {

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -89,7 +89,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	commands := r.StateHandler.StateTransition(ctx, *provider, run)
+	commands := r.StateHandler.StateTransition(ctx, provider, run)
 
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, run); err != nil {

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -71,7 +71,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	desiredProvider := desiredProvider(run, r.Config)
 
-	provider, err := loadProvider(ctx, r.EC.Client.NonCached, r.Config.WorkflowNamespace, desiredProvider)
+	provider, err := r.loadProvider(ctx, r.Config.WorkflowNamespace, desiredProvider)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/pipelines/run_workflow_integration_test.go
+++ b/controllers/pipelines/run_workflow_integration_test.go
@@ -46,7 +46,7 @@ var _ = Context("Resource Workflows", Serial, func() {
 				Resource: newRun(),
 			}
 
-			workflow, err := workflowFactory.ConstructUpdateWorkflow(TestProviderConfig, testCtx.Resource)
+			workflow, err := workflowFactory.ConstructUpdateWorkflow(*TestProviderConfig, testCtx.Resource)
 
 			Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -56,7 +56,7 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	commands := r.StateHandler.StateTransition(ctx, *provider, runSchedule)
+	commands := r.StateHandler.StateTransition(ctx, provider, runSchedule)
 
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, runSchedule); err != nil {

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -50,7 +50,7 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	desiredProvider := desiredProvider(runSchedule, r.Config)
 
-	provider, err := loadProvider(ctx, r.EC.Client.NonCached, r.Config.WorkflowNamespace, desiredProvider)
+	provider, err := r.loadProvider(ctx, r.Config.WorkflowNamespace, desiredProvider)
 	if err != nil {
 		logger.Error(err, "Failed to load provider %v", provider)
 		return ctrl.Result{}, err

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -104,8 +104,7 @@ var _ = BeforeSuite(func() {
 	provider := pipelinesv1.RandomProvider()
 	provider.Name = testConfig.DefaultProvider
 	provider.Namespace = testConfig.WorkflowNamespace
-	err = k8sClient.Create(ctx, provider)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(ctx, provider)).To(Succeed())
 
 	go func() {
 		Expect(k8sManager.Start(ctrl.SetupSignalHandler())).To(Succeed())

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"strings"
 	"testing"
 	"time"
 )
@@ -90,7 +89,7 @@ var _ = BeforeSuite(func() {
 	testConfig = config.Configuration{
 		DefaultExperiment: "Default",
 		WorkflowNamespace: "default",
-		DefaultProvider:   strings.ToLower(apis.RandomString()),
+		DefaultProvider:   apis.RandomLowercaseString(),
 		RunCompletionTTL:  &metav1.Duration{Duration: time.Minute},
 	}
 

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect((&pipelinesv1.RunConfiguration{}).SetupWebhookWithManager(k8sManager)).To(Succeed())
 	Expect((&pipelinesv1.Run{}).SetupWebhookWithManager(k8sManager)).To(Succeed())
 
-	var provider = pipelinesv1.RandomProvider()
+	provider := pipelinesv1.RandomProvider()
 	provider.Name = testConfig.DefaultProvider
 	provider.Namespace = testConfig.WorkflowNamespace
 	err = k8sClient.Create(ctx, provider)

--- a/controllers/pipelines/suite_integration_test.go
+++ b/controllers/pipelines/suite_integration_test.go
@@ -119,7 +119,7 @@ func AssertWorkflow[R pipelinesv1.Resource](
 	}
 
 	expectedOutput := setUp(testCtx.Resource)
-	workflow, err := constructWorkflow(TestProviderConfig, testCtx.Resource)
+	workflow, err := constructWorkflow(*TestProviderConfig, testCtx.Resource)
 
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Create(ctx, workflow)).To(Succeed())


### PR DESCRIPTION
Links to #329 

Loads the Provider CRD from k8s to be passed through the controllers. Closely related to #353. 
This just adds the behaviour to actually read the provider resource from k8s. Workflows still remain the same.

