### PR TITLE
Fix GitHub pages nojekyll

### DIFF
--- a/docs-gen/Makefile
+++ b/docs-gen/Makefile
@@ -11,7 +11,7 @@ quickstart:
 	$(MAKE) -C includes/quickstart docker-build
 
 clean:
-	find ../docs ! -name '.nojekyll' -delete
+	find ../docs -mindepth 1 ! -name '.nojekyll' -delete
 
 serve:
 	hugo server -b http://localhost:1313/

--- a/docs-gen/Makefile
+++ b/docs-gen/Makefile
@@ -11,7 +11,7 @@ quickstart:
 	$(MAKE) -C includes/quickstart docker-build
 
 clean:
-	rm -rf ../docs/
+	find ../docs ! -name '.nojekyll' -delete
 
 serve:
 	hugo server -b http://localhost:1313/


### PR DESCRIPTION
Closes #360

within this repo the use of Jekyll to build GH Pages was disabled (as it now explicitly requires GH Actions, that is disabled). As a consequence, the KFP Operator website silently stopped being updated. GH Pages provides instructions to disable the Jekyll build (we didn't need it) and publish the website: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages

`-mindepth 1` was needed as find on linux returns the base directory in the results (i.e. ../docs) which then wasnt empty (as had the .nojekyll) so command failed, mindepth of 1 ensures top level is filtered from the results.

## Tasks

- [X] add new .nojekyll file to /docs
- [X] change make task so it doesn't get deleted