### PR TITLE
Create EventSource Webhook to publish Run Completion Events to eventbus

### DIFF
--- a/helm/kfp-operator/templates/eventing/event-source-webhook.yaml
+++ b/helm/kfp-operator/templates/eventing/event-source-webhook.yaml
@@ -2,16 +2,16 @@
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:
-  name: event-source-webhook
+  name: {{ include "kfp-operator.fullname" . }}-event-source-webhook
   namespace: {{ include "kfp-operator.argoNamespace" . }}
 spec:
   service:
     ports:
-      - port: 12000
-        targetPort: 12000
+      - port: {{ .Values.statusFeedback.webhook.port }}
+        targetPort: {{ .Values.statusFeedback.webhook.port }}
   webhook:
     run-completion-event-source:
-      port: "12000"
-      endpoint: /
+      port: "{{ .Values.statusFeedback.webhook.port }}"
+      endpoint: "{{ .Values.statusFeedback.webhook.endpoint }}"
       method: POST
 {{- end -}}

--- a/helm/kfp-operator/templates/eventing/event-source-webhook.yaml
+++ b/helm/kfp-operator/templates/eventing/event-source-webhook.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.statusFeedback.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: event-source-webhook
+  namespace: {{ include "kfp-operator.argoNamespace" . }}
+spec:
+  service:
+    ports:
+      - port: 12000
+        targetPort: 12000
+  webhook:
+    run-completion-event-source:
+      port: "12000"
+      endpoint: /
+      method: POST
+{{- end -}}

--- a/helm/kfp-operator/templates/eventing/eventsource-webhook.yaml
+++ b/helm/kfp-operator/templates/eventing/eventsource-webhook.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:
-  name: {{ include "kfp-operator.fullname" . }}-event-source-webhook
+  name: {{ include "kfp-operator.fullname" . }}-events-webhook
   namespace: {{ include "kfp-operator.argoNamespace" . }}
 spec:
   service:

--- a/helm/kfp-operator/templates/eventing/nats-sensor.yaml
+++ b/helm/kfp-operator/templates/eventing/nats-sensor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.statusFeedback.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: {{ include "kfp-operator.fullname" . }}-publish-events-to-nats
+  namespace: {{ include "kfp-operator.argoNamespace" . }}
+spec:
+  dependencies:
+    - name: events
+      eventSourceName: event-source-webhook
+      eventName: run-completion-event-source
+  triggers:
+    - template:
+        name: "publish"
+        nats:
+          payload:
+            - dest: data
+              src:
+                useRawData: true
+                dependencyName: events
+                dataKey: body.data
+          subject: events
+          url: eventbus-{{ include "kfp-operator.fullname" . }}-events-stan-svc:4222
+{{- end -}}

--- a/helm/kfp-operator/templates/eventing/nats-sensor.yaml
+++ b/helm/kfp-operator/templates/eventing/nats-sensor.yaml
@@ -14,11 +14,36 @@ spec:
         name: "publish"
         nats:
           payload:
-            - dest: data
-              src:
-                useRawData: true
-                dependencyName: events
-                dataKey: body.data
+          - dest: specversion
+            src:
+              useRawData: true
+              dataKey: body.specversion
+              dependencyName: events
+          - dest: id
+            src:
+              useRawData: true
+              dataKey: body.id
+              dependencyName: events
+          - dest: source
+            src:
+              useRawData: true
+              dataKey: body.source
+              dependencyName: events
+          - dest: type
+            src:
+              useRawData: true
+              dataKey: body.type
+              dependencyName: events
+          - dest: datacontenttype
+            src:
+              useRawData: true
+              dataKey: body.datacontenttype
+              dependencyName: events
+          - dest: data
+            src:
+              useRawData: true
+              dataKey: body.data
+              dependencyName: events
           subject: events
           url: eventbus-{{ include "kfp-operator.fullname" . }}-events-stan-svc:4222
 {{- end -}}

--- a/helm/kfp-operator/templates/eventing/nats-sensor.yaml
+++ b/helm/kfp-operator/templates/eventing/nats-sensor.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   dependencies:
     - name: events
-      eventSourceName: event-source-webhook
+      eventSourceName: {{ include "kfp-operator.fullname" . }}-event-source-webhook
       eventName: run-completion-event-source
   triggers:
     - template:

--- a/helm/kfp-operator/templates/eventing/nats-sensor.yaml
+++ b/helm/kfp-operator/templates/eventing/nats-sensor.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   dependencies:
     - name: events
-      eventSourceName: {{ include "kfp-operator.fullname" . }}-event-source-webhook
+      eventSourceName: {{ include "kfp-operator.fullname" . }}-events-webhook
       eventName: run-completion-event-source
   triggers:
     - template:

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -51,6 +51,9 @@ manager:
 
 statusFeedback:
   enabled: false
+  webhook:
+    endpoint: '/'
+    port: 12000
 
 logging:
   verbosity: # info

--- a/helm/provider/templates/runcompletion/sensor.yaml
+++ b/helm/provider/templates/runcompletion/sensor.yaml
@@ -15,7 +15,7 @@ spec:
     - template:
         name: "publish"
         http:
-          url: http://event-source-webhook-eventsource-svc:12000/
+          url: http://{{ .Values.kfpOperator.fullname}}-event-source-webhook-eventsource-svc:{{ .Values.statusFeedback.webhook.port }}{{ .Values.statusFeedback.webhook.endpoint }}
           payload:
             - dest: specversion
               src:

--- a/helm/provider/templates/runcompletion/sensor.yaml
+++ b/helm/provider/templates/runcompletion/sensor.yaml
@@ -15,7 +15,7 @@ spec:
     - template:
         name: "publish"
         http:
-          url: http://{{ .Values.kfpOperator.fullname}}-event-source-webhook-eventsource-svc:{{ .Values.statusFeedback.webhook.port }}{{ .Values.statusFeedback.webhook.endpoint }}
+          url: http://{{ .Values.kfpOperator.fullname}}-events-webhook-eventsource-svc:{{ .Values.statusFeedback.webhook.port }}{{ .Values.statusFeedback.webhook.endpoint }}
           payload:
             - dest: specversion
               src:

--- a/helm/provider/templates/runcompletion/sensor.yaml
+++ b/helm/provider/templates/runcompletion/sensor.yaml
@@ -14,7 +14,8 @@ spec:
   triggers:
     - template:
         name: "publish"
-        nats:
+        http:
+          url: http://event-source-webhook-eventsource-svc:12000/
           payload:
             - dest: specversion
               src:
@@ -41,5 +42,4 @@ spec:
                 useRawData: true
                 dataKey: body
                 dependencyName: events
-          subject: events
-          url: eventbus-{{ .Values.kfpOperator.fullname }}-events-stan-svc:4222
+          method: POST

--- a/helm/provider/values.yaml
+++ b/helm/provider/values.yaml
@@ -41,3 +41,8 @@ eventsourceServer:
     requests:
       cpu: 100m
       memory: 200Mi
+
+statusFeedback:
+  webhook:
+    port: 12000
+    endpoint: '/'


### PR DESCRIPTION
Closes https://github.com/sky-uk/kfp-operator/issues/356.

As per the ticket above, we've created a new webhook-based argo EventSource, which along with a new Sensor will publish events to the NATS EventBus. The current Run Completion Event Sensor (which is per-Provider) now sends the event via HTTP through the webhook.

Tested in Vertex AI and Kubeflow Pipelines.

Architecture after this change:
![image](https://github.com/user-attachments/assets/1bc5442e-144a-4ebc-b641-70cc412a92f3)
