### PR TITLE
Bug - Operator deployment failing

### DIFF
--- a/helm/kfp-operator/templates/deployment.yaml
+++ b/helm/kfp-operator/templates/deployment.yaml
@@ -63,8 +63,8 @@ spec:
             protocol: TCP
         {{- if .Values.manager.monitoring.create }}
         {{ if not .Values.manager.monitoring.rbacSecured }}
-           - containerPort: 8080
-             name: http
+          - name: http
+            containerPort: 8080
         {{- else -}}
         - name: kube-rbac-proxy
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0


### PR DESCRIPTION
On trying to deploy realised tabbing on the deployment yaml was out of line causing helm install to fail.

## Tasks

- [x] Fix
- [x] Test
