### PR TITLE
Update controller-gen version to v0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ include newline.mk
 
 # Image URL to use all building/pushing image targets
 IMG ?= kfp-operator-controller
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:ignoreUnexportedFields=false"
 
 all: build
 
@@ -28,7 +26,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include newline.mk
 # Image URL to use all building/pushing image targets
 IMG ?= kfp-operator-controller
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd:ignoreUnexportedFields=false"
 
 all: build
 
@@ -125,7 +125,7 @@ helm-cmd: ## Download helm locally if necessary.
 
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-install,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0)
 
 KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: kfpcontrollerconfigs.config.kubeflow.org
 spec:
   group: config.kubeflow.org
@@ -782,9 +780,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: experiments.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -200,14 +198,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -280,9 +276,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: pipelines.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -300,14 +298,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -380,9 +376,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_providers.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_providers.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: providers.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -78,14 +76,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -150,9 +146,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: runconfigurations.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -309,14 +307,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -448,9 +444,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: runs.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -176,14 +174,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -283,9 +279,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: runschedules.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -151,14 +149,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -231,9 +227,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -1,10 +1,8 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: kfpcontrollerconfigs.config.kubeflow.org
 spec:
   group: config.kubeflow.org
@@ -755,12 +753,6 @@ spec:
                 type: string
               multiversion:
                 type: boolean
-              runCompletionTTL:
-                type: string
-              workflowNamespace:
-                type: string
-              workflowTemplatePrefix:
-                type: string
               runCompletionFeed:
                 properties:
                   endpoints:
@@ -777,15 +769,15 @@ spec:
                   port:
                     type: integer
                 type: object
+              runCompletionTTL:
+                type: string
+              workflowNamespace:
+                type: string
+              workflowTemplatePrefix:
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -2,10 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
     {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
     cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
     {{- end }}
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: experiments.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -131,15 +131,15 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -177,18 +177,18 @@ spec:
     served: true
     storage: false
     subresources:
-      status: { }
-  {{- end }}
+      status: {}
+    {{- end }}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha5
     schema:
       openAPIV3Schema:
@@ -217,14 +217,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -261,9 +259,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -275,11 +273,11 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               observedGeneration:
@@ -297,9 +295,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.12.0
     {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
     cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
     {{- end }}
@@ -35,15 +35,15 @@ spec:
   versions:
   {{- if .Values.manager.multiversion.enabled }}
   - additionalPrinterColumns:
-      - jsonPath: .status.kfpId
-        name: KfpId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.kfpId
+      name: KfpId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -75,8 +75,8 @@ spec:
               tfxComponents:
                 type: string
             required:
-              - image
-              - tfxComponents
+            - image
+            - tfxComponents
             type: object
           status:
             properties:
@@ -94,17 +94,17 @@ spec:
     served: true
     storage: false
     subresources:
-      status: { }
+      status: {}
   - additionalPrinterColumns:
-      - jsonPath: .status.kfpId
-        name: KfpId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.kfpId
+      name: KfpId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -131,8 +131,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               env:
@@ -143,8 +143,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               image:
@@ -152,8 +152,8 @@ spec:
               tfxComponents:
                 type: string
             required:
-              - image
-              - tfxComponents
+            - image
+            - tfxComponents
             type: object
           status:
             properties:
@@ -171,17 +171,17 @@ spec:
     served: true
     storage: false
     subresources:
-      status: { }
+      status: {}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -208,8 +208,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               env:
@@ -220,8 +220,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               image:
@@ -229,8 +229,8 @@ spec:
               tfxComponents:
                 type: string
             required:
-              - image
-              - tfxComponents
+            - image
+            - tfxComponents
             type: object
           status:
             properties:
@@ -251,15 +251,15 @@ spec:
       status: {}
   {{- end }}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha5
     schema:
       openAPIV3Schema:
@@ -286,8 +286,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               env:
@@ -298,8 +298,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               image:
@@ -307,8 +307,8 @@ spec:
               tfxComponents:
                 type: string
             required:
-              - image
-              - tfxComponents
+            - image
+            - tfxComponents
             type: object
           status:
             properties:
@@ -317,14 +317,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -361,9 +359,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -375,11 +373,11 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               observedGeneration:
@@ -397,9 +395,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
@@ -1,11 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: providers.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org
@@ -78,14 +75,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -150,9 +145,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.12.0
     {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
     cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
     {{- end }}
@@ -161,15 +161,15 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -201,8 +201,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               schedule:
@@ -229,12 +229,12 @@ spec:
       status: {}
   {{- end }}
   - additionalPrinterColumns:
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.provider
-        name: Provider
-        type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.provider
+      name: Provider
+      type: string
     name: v1alpha5
     schema:
       openAPIV3Schema:
@@ -264,8 +264,8 @@ spec:
                           pattern: ^([^\[\]:]+):([^\[\]:]+)(?::(\d*))?(?:\[([^\[\]:]+)\])?$
                           type: string
                       required:
-                        - name
-                        - path
+                      - name
+                      - path
                       type: object
                     type: array
                   experimentName:
@@ -289,14 +289,14 @@ spec:
                                 outputArtifact:
                                   type: string
                               required:
-                                - name
-                                - outputArtifact
+                              - name
+                              - outputArtifact
                               type: object
                           required:
-                            - runConfigurationRef
+                          - runConfigurationRef
                           type: object
                       required:
-                        - name
+                      - name
                       type: object
                     type: array
                 type: object
@@ -305,18 +305,18 @@ spec:
                   onChange:
                     items:
                       enum:
-                        - pipeline
-                        - runSpec
+                      - pipeline
+                      - runSpec
+                      type: string
+                    type: array
+                  runConfigurations:
+                    items:
                       type: string
                     type: array
                   schedules:
                     items:
                       type: string
                     type: array
-                  runConfigurations:
-                    type: array
-                    items:
-                      type: string
                 type: object
             type: object
           status:
@@ -326,14 +326,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -370,9 +368,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -384,26 +382,14 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
-              observedPipelineVersion:
-                type: string
-              triggeredPipelineVersion:
-                type: string
-              observedGeneration:
-                type: integer
-                format: int64
-              provider:
-                type: string
-              synchronizationState:
-                type: string
               dependencies:
-                type: object
                 properties:
                   runConfigurations:
                     additionalProperties:
@@ -416,58 +402,64 @@ spec:
                               name:
                                 type: string
                             required:
-                              - location
-                              - name
+                            - location
+                            - name
                             type: object
                           type: array
                         providerId:
                           type: string
                       type: object
                     type: object
-              latestRuns:
                 type: object
+              latestRuns:
                 properties:
                   succeeded:
-                    type: object
                     properties:
-                      providerId:
-                        type: string
                       artifacts:
-                        type: array
                         items:
-                          type: object
+                          properties:
+                            location:
+                              type: string
+                            name:
+                              type: string
                           required:
                           - location
                           - name
-                          properties:
-                            name:
-                              type: string
-                            location:
-                              type: string
-              triggers:
-                type: object
-                properties:
-                  runSpec:
-                    type: object
-                    properties:
-                      version:
+                          type: object
+                        type: array
+                      providerId:
                         type: string
-                  runConfigurations:
                     type: object
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+              observedPipelineVersion:
+                type: string
+              provider:
+                type: string
+              synchronizationState:
+                type: string
+              triggeredPipelineVersion:
+                type: string
+              triggers:
+                properties:
+                  runConfigurations:
                     additionalProperties:
-                      type: object
                       properties:
                         providerId:
                           type: string
+                      type: object
+                    type: object
+                  runSpec:
+                    properties:
+                      version:
+                        type: string
+                    type: object
+                type: object
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.12.0
     {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
     cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
     {{- end }}
@@ -30,7 +30,7 @@ spec:
         caBundle: {{ .Values.manager.webhookCertificates.caBundle }}
         {{- end }}
       conversionReviewVersions:
-        - v1
+      - v1
   {{- end }}
   versions:
   {{- if .Values.manager.multiversion.enabled }}
@@ -93,9 +93,9 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
-              providerId:
-                type: string
               observedPipelineVersion:
+                type: string
+              providerId:
                 type: string
               synchronizationState:
                 type: string
@@ -109,18 +109,18 @@ spec:
       status: {}
   {{- end }}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
-      - jsonPath: .status.completionState
-        name: CompletionState
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.completionState
+      name: CompletionState
+      type: string
     name: v1alpha5
     schema:
       openAPIV3Schema:
@@ -148,8 +148,8 @@ spec:
                       pattern: ^([^\[\]:]+):([^\[\]:]+)(?::(\d*))?(?:\[([^\[\]:]+)\])?$
                       type: string
                   required:
-                    - name
-                    - path
+                  - name
+                  - path
                   type: object
                 type: array
               experimentName:
@@ -173,32 +173,32 @@ spec:
                             outputArtifact:
                               type: string
                           required:
-                            - name
-                            - outputArtifact
+                          - name
+                          - outputArtifact
                           type: object
                       required:
-                        - runConfigurationRef
+                      - runConfigurationRef
                       type: object
                   required:
-                    - name
+                  - name
                   type: object
                 type: array
             type: object
           status:
             properties:
+              completionState:
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -235,9 +235,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -249,17 +249,14 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
-              completionState:
-                type: string
               dependencies:
-                type: object
                 properties:
                   runConfigurations:
                     additionalProperties:
@@ -272,14 +269,15 @@ spec:
                               name:
                                 type: string
                             required:
-                              - location
-                              - name
+                            - location
+                            - name
                             type: object
                           type: array
                         providerId:
                           type: string
                       type: object
                     type: object
+                type: object
               markedCompletedAt:
                 format: date-time
                 type: string
@@ -300,9 +298,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -1,10 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.12.0
     {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
     cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
     {{- end }}
@@ -32,7 +30,7 @@ spec:
         caBundle: {{ .Values.manager.webhookCertificates.caBundle }}
         {{- end }}
       conversionReviewVersions:
-        - v1
+      - v1
   {{- end }}
   versions:
   {{- if .Values.manager.multiversion.enabled }}
@@ -103,15 +101,15 @@ spec:
       status: {}
   {{- end }}
   - additionalPrinterColumns:
-      - jsonPath: .status.providerId
-        name: ProviderId
-        type: string
-      - jsonPath: .status.synchronizationState
-        name: SynchronizationState
-        type: string
-      - jsonPath: .status.version
-        name: Version
-        type: string
+    - jsonPath: .status.providerId
+      name: ProviderId
+      type: string
+    - jsonPath: .status.synchronizationState
+      name: SynchronizationState
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
     name: v1alpha5
     schema:
       openAPIV3Schema:
@@ -139,8 +137,8 @@ spec:
                       pattern: ^([^\[\]:]+):([^\[\]:]+)(?::(\d*))?(?:\[([^\[\]:]+)\])?$
                       type: string
                   required:
-                    - name
-                    - path
+                  - name
+                  - path
                   type: object
                 type: array
               experimentName:
@@ -156,8 +154,8 @@ spec:
                     value:
                       type: string
                   required:
-                    - name
-                    - value
+                  - name
+                  - value
                   type: object
                 type: array
               schedule:
@@ -170,14 +168,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -214,9 +210,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -228,11 +224,11 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               observedGeneration:
@@ -249,10 +245,4 @@ spec:
     served: true
     storage: true
     subresources:
-      status: { }
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+      status: {}

--- a/helm/kfp-operator/templates/rbac/role.yaml
+++ b/helm/kfp-operator/templates/rbac/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: {{ include "kfp-operator.fullname" . }}-manager-role
 rules:
 - apiGroups:


### PR DESCRIPTION
links to #358 

In order to utilise more recent gRPC libraries we need to upgrade the version of controller-gen used. It currently is using version 0.4.1 which is many years out of date. 

This PR upgrades the version used to 0.12.0 which supports v1.27 k8s and above [See here for compatibility](https://github.com/kubernetes-sigs/controller-tools?tab=readme-ov-file#compatibility).  This should be acceptable given it is already an unsupported version [See here for k8s supported versions](https://kubernetes.io/releases/)


