### PR TITLE
Remove python 3.8 and add tfx 1.15 build in kfp compiler

### DIFF
--- a/argo/kfp-compiler/Dockerfile
+++ b/argo/kfp-compiler/Dockerfile
@@ -1,10 +1,3 @@
-FROM python:3.8.18 AS PYTHON38
-ARG WHEEL_VERSION
-
-COPY dist/*-${WHEEL_VERSION}-*.whl /
-RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
-    rm /*-${WHEEL_VERSION}-*.whl
-
 FROM python:3.9.13 AS PYTHON39
 ARG WHEEL_VERSION
 
@@ -22,7 +15,6 @@ RUN pip install /*-${WHEEL_VERSION}-*.whl --target=/kfp-compiler && \
 FROM alpine:3.20.1
 
 WORKDIR /
-COPY --from=PYTHON38 /kfp-compiler kfp-compiler/py3.8
 COPY --from=PYTHON39 /kfp-compiler kfp-compiler/py3.9
 COPY --from=PYTHON310 /kfp-compiler kfp-compiler/py3.10
 ADD resources/compile.sh kfp-compiler/compile.sh

--- a/argo/kfp-compiler/Makefile
+++ b/argo/kfp-compiler/Makefile
@@ -13,23 +13,23 @@ penguin-staging:
 	cp ../../docs-gen/includes/quickstart/penguin_pipeline/*.py $(PENGUIN_STAGING)
 	cp integration/Dockerfile $(PENGUIN_STAGING)
 
-penguin-38: penguin-staging
-	docker build --build-arg PYTHON_VERSION=3.8.17 --build-arg TFX_VERSION=1.9.1 -t penguin:3.8 $(PENGUIN_STAGING)
-
 penguin-39: penguin-staging
 	docker build --build-arg PYTHON_VERSION=3.9.13 --build-arg TFX_VERSION=1.9.1 -t penguin:3.9 $(PENGUIN_STAGING)
 
 penguin-310: penguin-staging
 	docker build --build-arg PYTHON_VERSION=3.10.12 --build-arg TFX_VERSION=1.14.0 -t penguin:3.10 $(PENGUIN_STAGING)
 
-integration-test: docker-build penguin-38 penguin-39 penguin-310
+penguin-310-115: penguin-staging
+	docker build --build-arg PYTHON_VERSION=3.10.12 --build-arg TFX_VERSION=1.15.0 -t penguin:3.10-1.15 $(PENGUIN_STAGING)
+
+integration-test: docker-build penguin-39 penguin-310 penguin-310-115
 	$(eval TMP := $(shell mktemp -d))
 	echo '{"rootLocation": "pipeline_root", "servingLocation": "serving", "name": "test", "image": "test-pipeline", "tfxComponents": "pipeline.create_components"}' > $(TMP)/pipeline_config.json
 	docker run -v $(TMP):/shared kfp-operator-argo-kfp-compiler /shared
 	docker run -v $(TMP):/shared --entrypoint /shared/compile.sh penguin:3.10 --output_file /tmp/pipeline.yaml --pipeline_config /shared/pipeline_config.json  --execution_mode v1
-	docker run -v $(TMP):/shared --entrypoint /shared/compile.sh penguin:3.8 --output_file /tmp/pipeline.yaml --pipeline_config /shared/pipeline_config.json --execution_mode v2
 	docker run -v $(TMP):/shared --entrypoint /shared/compile.sh penguin:3.9 --output_file /tmp/pipeline.yaml --pipeline_config /shared/pipeline_config.json --execution_mode v2
 	docker run -v $(TMP):/shared --entrypoint /shared/compile.sh penguin:3.10 --output_file /tmp/pipeline.yaml --pipeline_config /shared/pipeline_config.json  --execution_mode v2
+	docker run -v $(TMP):/shared --entrypoint /shared/compile.sh penguin:3.10-1.15 --output_file /tmp/pipeline.yaml --pipeline_config /shared/pipeline_config.json  --execution_mode v2
 
 ##@ Build
 


### PR DESCRIPTION
### Context 

This PR removes deprecated Python 3.8 and adds an integration test for TFX 1.15. This PR does not address Python vulnerabilities as we cannot support versions of Python >3.10 because of TFX. 

## Tasks
- Updated kfp-compiler integration tests Makefile removing Python 3.8 integration test and adding TFX 1.15 integration test
- Updated kfp-compiler Dockerfile to remove Python 3.8 

