### PR TITLE
Remove inlined Status within RunStatus for V1alpha6

### DIFF
--- a/apis/pipelines/v1alpha5/run_conversion.go
+++ b/apis/pipelines/v1alpha5/run_conversion.go
@@ -10,6 +10,18 @@ func (src *Run) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*hub.Run)
 
 	err := pipelines.TransformInto(src, &dst)
+
+	dst.Status.Status = hub.Status{
+		ProviderId: hub.ProviderAndId{
+			Provider: src.Status.ProviderId.Provider,
+			Id:       src.Status.ProviderId.Id,
+		},
+		SynchronizationState: src.Status.SynchronizationState,
+		Version:              src.Status.Version,
+		ObservedGeneration:   src.Status.ObservedGeneration,
+		Conditions:           hub.Conditions(src.Status.Conditions),
+	}
+
 	if err != nil {
 		return err
 	}
@@ -28,6 +40,15 @@ func (dst *Run) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 	setProviderAnnotation(src.Spec.Provider, &dst.ObjectMeta)
+
+	dst.Status.ProviderId = ProviderAndId{
+		Provider: src.Status.Status.ProviderId.Provider,
+		Id:       src.Status.Status.ProviderId.Id,
+	}
+	dst.Status.SynchronizationState = src.Status.Status.SynchronizationState
+	dst.Status.Version = src.Status.Status.Version
+	dst.Status.ObservedGeneration = src.Status.Status.ObservedGeneration
+	dst.Status.Conditions = Conditions(src.Status.Status.Conditions)
 
 	return nil
 }

--- a/apis/pipelines/v1alpha6/run_types.go
+++ b/apis/pipelines/v1alpha6/run_types.go
@@ -145,7 +145,7 @@ type Dependencies struct {
 }
 
 type RunStatus struct {
-	Status                  `json:",inline"`
+	Status                  Status          `json:"status,inline"`
 	ObservedPipelineVersion string          `json:"observedPipelineVersion,omitempty"`
 	Dependencies            Dependencies    `json:"dependencies,omitempty"`
 	CompletionState         CompletionState `json:"completionState,omitempty"`


### PR DESCRIPTION
This is a suggestion based off some investigatory work when trying to convert `v1alpha5` Runs into `v1alpha6`. When inlining JSON within a struct it can cause issues:
 - Overwriting fields with non-unique keys,
 - Prevents the use of manual marshalling / unmarshalling implementations

The latter is preventing us from removing the current implementation of ProviderId marshalling and replacing the marshalling rules within the `Status` struct instead (This would be much better than the current implementation as it is not possible to marshal and unmarshal a `Status` struct independently from a whole resource struct. eg `Runs`).

By applying this PR we can move away from embedding the Status struct in within the RunStatus which frees up the possibility of custom marshalling in `v1alpha7` handling the ProviderId conversion to a string field in a cleaner way.

Downsides to this are the Status will be nested within the existing `Status` field for Runs.

Links to https://github.com/sky-uk/kfp-operator/issues/364 for v1alpha6 changes to api spec
