### PR TITLE
Added make targets for running KFP Operator locally in minikube

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ protoc 21.12
 hugo extended_0.135.0
 golang 1.20
 nodejs 22.9.0
+minikube 1.31.2

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,6 +115,12 @@ Finally, bring down the environment after your tests:
 make integration-test-down
 ```
 
+## Run locally
+
+Running `make minikube-up NAME=provider` (set `provider` to the name of your chosen provider e.g. `NAME=vai`) will spin up a local K8s cluster with the operator deployed along with your chosen provider.
+
+You can optionally perform additional provider setup and teardown steps by including a `provider-setup.sh` and `provider-teardown.sh` script.
+
 ## Coding Guidelines
 
 ### Logging

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include common.mk
 include version.mk
 include newline.mk
+include minikube.mk
 
 # Image URL to use all building/pushing image targets
 IMG ?= kfp-operator-controller

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Kubefelow Pipelines Operator provides a declarative API for managing and running machine learning pipelines on Kubeflow with [Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+The Kubeflow Pipelines Operator provides a declarative API for managing and running machine learning pipelines on Kubeflow with [Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
 We currently only support TFX pipelines.
 

--- a/local/values.yaml
+++ b/local/values.yaml
@@ -1,0 +1,43 @@
+namespace:
+  create: false
+fullnameOverride: kfp-operator
+logging:
+  verbosity: info
+manager:
+  multiversion:
+    enabled: true
+  webhookCertificates:
+    provider: cert-manager
+  argo:
+    serviceAccount:
+      name: kfp-operator-argo
+      create: true
+  configuration:
+    defaultProvider: kfp
+    defaultExperiment: Default
+    runCompletionTTL: 30s
+  monitoring:
+    create: false
+  runcompletionWebhook:
+    port: 8082
+    endpoints:
+    - host: kfp-operator-run-completion-event-trigger.kfp-operator-system
+      path: ""
+      port: 50051
+
+runcompletionEventTrigger:
+  enabled: true
+  replicas: 1
+  nats:
+    subject: events
+    server:
+      port: 4222
+  server:
+    port: 50051
+
+statusFeedback:
+  enabled: true
+
+providers:
+  - kfp
+  - vai

--- a/minikube.mk
+++ b/minikube.mk
@@ -33,6 +33,7 @@ minikube-install-provider: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PO
 minikube-install-provider:
 	$(MAKE) -C argo/providers docker-push
 	$(MAKE) -C argo/providers/stub docker-push
+	$(MAKE) -C provider-service docker-push
 	$(MAKE) minikube-helm-install-provider VERSION=${VERSION} CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES} NAME=${NAME}
 	$(MAKE) minikube-provider-setup
 

--- a/minikube.mk
+++ b/minikube.mk
@@ -1,0 +1,71 @@
+minikube-install-dependencies:
+	$(HELM) repo add argo https://argoproj.github.io/argo-helm
+	$(HELM) install argo-workflows argo/argo-workflows -n argo --create-namespace
+	$(HELM) install argo-events argo/argo-events -n argo-events --create-namespace
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.crds.yaml
+	openssl req -new -newkey rsa:2048 -days 365 -keyout ./local/kfp-operator-webhook.key -out ./local/kfp-operator-webhook.csr \
+	  -subj "/C=US/ST=California/L=San Francisco/O=My Organization/OU=My Unit/CN=kfp-operator-webhook-service.kfp-operator-system.svc" \
+	  -extensions san -config <(echo "[req]"; echo "distinguished_name=req_distinguished_name"; echo "x509_extensions = san"; \
+	  echo "[req_distinguished_name]"; echo "C=US"; echo "ST=California"; echo "L=San Francisco"; echo "O=My Organization"; \
+	  echo "OU=My Unit"; echo "CN=kfp-operator-webhook-service.kfp-operator-system.svc"; \
+	  echo "[san]"; echo "subjectAltName=DNS:kfp-operator-webhook-service.kfp-operator-system.svc,DNS:kfp-operator-webhook-service") -nodes
+	openssl x509 -req -in ./local/kfp-operator-webhook.csr -signkey ./local/kfp-operator-webhook.key -out ./local/kfp-operator-webhook.crt \
+	  -extensions v3_req -extfile <(echo "[v3_req]"; echo "subjectAltName=DNS:kfp-operator-webhook-service.kfp-operator-system.svc,DNS:kfp-operator-webhook-service")
+	kubectl create namespace kfp-operator-system
+	kubectl create secret tls webhook-server-cert --cert=./local/kfp-operator-webhook.crt --key=./local/kfp-operator-webhook.key --namespace kfp-operator-system
+
+minikube-helm-install-operator: helm-package-operator ./local/values.yaml
+	$(HELM) install -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=localhost:5000/kfp-operator
+
+minikube-install-operator: export VERSION=$(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*') | sed 's/^v//')
+minikube-install-operator: export REGISTRY_PORT=$(shell docker inspect local-kfp-operator --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
+minikube-install-operator: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PORT}/kfp-operator
+minikube-install-operator:
+	$(MAKE) docker-push docker-push-triggers
+	$(MAKE) minikube-helm-install-operator VERSION=${VERSION} CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
+
+minikube-helm-install-provider: helm-package-provider
+	$(HELM) install -f $(NAME).yaml provider-$(NAME) dist/provider-$(VERSION).tgz --set containerRegistry=localhost:5000/kfp-operator
+
+minikube-install-provider: export VERSION=$(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*') | sed 's/^v//')
+minikube-install-provider: export REGISTRY_PORT=$(shell docker inspect local-kfp-operator --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
+minikube-install-provider: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PORT}/kfp-operator
+minikube-install-provider:
+	$(MAKE) -C argo/providers docker-push
+	$(MAKE) -C argo/providers/stub docker-push
+	$(MAKE) minikube-helm-install-provider VERSION=${VERSION} CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES} NAME=${NAME}
+	$(MAKE) minikube-provider-setup
+
+minikube-provider-setup:
+	@if [ -f ./provider-setup.sh ]; then \
+		echo "Running provider setup script"; \
+		bash ./provider-setup.sh; \
+	else \
+		echo "Provider setup script not found"; \
+	fi
+
+minikube-provider-teardown:
+	@if [ -f ./provider-teardown.sh ]; then \
+		echo "Running provider teardown script"; \
+		bash ./provider-teardown.sh; \
+	else \
+		echo "Provider teardown script not found"; \
+	fi
+
+minikube-start:
+	minikube start -p local-kfp-operator --driver=docker --registry-mirror="https://mirror.gcr.io"
+	minikube addons enable registry -p local-kfp-operator
+
+minikube-up:
+	@if [ -z ${NAME} ]; then \
+		echo "You must specify the name of the provider you want to install"; \
+		exit 1; \
+	fi
+	$(MAKE) minikube-start
+	$(MAKE) minikube-install-dependencies
+	$(MAKE) minikube-install-operator
+	$(MAKE) minikube-install-provider
+
+minikube-down:
+	minikube delete -p local-kfp-operator
+	$(MAKE) minikube-provider-teardown


### PR DESCRIPTION
Connects to #380 

## Summary of changes

- Added make targets that do the following:
  - `minikube-up` 
    - Starts a minikube cluster called `local-kfp-operator`
    - Installs dependencies on the cluster required for KFP Operator
    - Installs the operator itself
    - Installs a provider based on the `NAME` parameter given the the make target
    - Runs a `provider-setup.sh` script (if it exists) to perform any additional required steps for the chosen provider
  - `minikube-down`
    - Deletes the minikube cluster that was created by `minikube-up`
    - Runs a `provider-teardown.sh` script (if it exists) to perform any clean up steps for the chosen provider 

## Tasks

- [x] Documentation updated
