### PR TITLE
Log all errors when fetching PubSub subscriptions

### DIFF
--- a/provider-service/base/pkg/streams/sources/pub_sub_source.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source.go
@@ -43,7 +43,9 @@ func NewPubSubSource(ctx context.Context, project string, subscription string) (
 
 	runsSubscription := pubSubClient.Subscription(subscription)
 	exists, err := runsSubscription.Exists(ctx)
-	if err != nil || !exists {
+	if err != nil {
+		return nil, fmt.Errorf("something went wrong while trying to fetch subscription %s, %s", subscription, err)
+	} else if !exists {
 		return nil, fmt.Errorf("subscription %s does not exist on topic", subscription)
 	}
 


### PR DESCRIPTION
In the PubSub source for the Provider service, we currently check that the subscription we initialise the source with exists before subscribing to the topic.

The problem is that we effectively interpret all errors as Not Found. This can obviously cause confusion while debugging by masking the real error.