### PR TITLE
Update default path to generic `/etc/provider-service`

### DIFF
--- a/provider-service/kfp/Dockerfile
+++ b/provider-service/kfp/Dockerfile
@@ -2,6 +2,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY bin/kfp-provider-service /bin/kfp-provider-service
 
-COPY --from=base-source ./base/pkg/config/config.yaml /etc/kfp-provider-service/config.yaml
+COPY --from=base-source ./base/pkg/config/config.yaml /etc/provider-service/config.yaml
 
 CMD ["/bin/kfp-provider-service"]

--- a/provider-service/vai/Dockerfile
+++ b/provider-service/vai/Dockerfile
@@ -2,6 +2,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY bin/vai-provider-service /bin/vai-provider-service
 
-COPY --from=base-source ./base/pkg/config/config.yaml /etc/vai-provider-service/config.yaml
+COPY --from=base-source ./base/pkg/config/config.yaml /etc/provider-service/config.yaml
 
 CMD ["/bin/vai-provider-service"]


### PR DESCRIPTION
Closes #450 

Updates the default path used within docker image for providers to be generic and match path used by viper within config loading. Fixes issue where if no config is explicitly mounted to the correct path the default config is not loaded and the container fails to start up.

## Tasks

- [ ] ...
- [ ] Documentation updated
