### PR TITLE
Provider controller synchronise observedGeneration fields

### DIFF
--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -43,4 +43,4 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OPERATORWEBHOOK
-            value: kfp-operator-controller-manager.kfp-operator-system:8082/events
+            value: http://kfp-operator-runcompletion-webhook-service.kfp-operator-system:80/events

--- a/controllers/pipelines/provider_controller_test.go
+++ b/controllers/pipelines/provider_controller_test.go
@@ -218,7 +218,7 @@ var _ = Context("Provider Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-			rc := ProviderReconciler{
+			pr := ProviderReconciler{
 				ResourceReconciler: ResourceReconciler[*pipelinesv1.Provider]{
 					EC: K8sExecutionContext{
 						Client: controllers.OptInClient{
@@ -248,7 +248,7 @@ var _ = Context("Provider Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(initialProvider.Status.ObservedGeneration).To(Equal(expectedStartGeneration))
 
-			err = rc.UpdateProviderStatus(ctx, initialProvider)
+			err = pr.UpdateProviderStatus(ctx, initialProvider)
 			Expect(err).ToNot(HaveOccurred())
 
 			underTest := &pipelinesv1.Provider{}

--- a/controllers/pipelines/provider_controller_test.go
+++ b/controllers/pipelines/provider_controller_test.go
@@ -210,7 +210,7 @@ var _ = Context("Provider Controller", func() {
 		})
 	})
 
-	var _ = Describe("updateProviderStatus", func() {
+	var _ = Describe("UpdateProviderStatus", func() {
 		Specify("Should update the Provider status with the given conditions", func() {
 			ctx := context.Background()
 			scheme := runtime.NewScheme()

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -45,5 +45,5 @@ data:
                   fieldRef:
                     fieldPath: metadata.namespace
               - name: OPERATORWEBHOOK
-                value: {{ include "kfp-operator.fullname" . }}-controller-manager.{{ .Values.namespace.name }}:{{.Values.manager.runcompletionWebhook.servicePort}}/events
+                value: http://{{ include "kfp-operator.fullname" . }}-runcompletion-webhook-service.{{ .Values.namespace.name }}:80/events
               {{- if .Values.provider.env }}{{- $.Values.provider.env | toYaml | nindent 14 }}{{ end }}


### PR DESCRIPTION
Closes #461

This adds support to the provider controller to update provider CRD observedGeneration status field after reconciliation has 
completed successfully. This is required to provide tooling an indication that a given change causing a `Generation`  to increment has been reconciled by the controller of if it is out of sync.

