### PR TITLE
Add controller managed service for provider deployment

### DIFF
--- a/apis/config/v1alpha6/kfp_controller_config_types.go
+++ b/apis/config/v1alpha6/kfp_controller_config_types.go
@@ -34,7 +34,7 @@ type DefaultProviderValues struct {
 	Replicas             int                `json:"replicas,omitempty"`
 	PodTemplateSpec      v1.PodTemplateSpec `json:"podTemplateSpec,omitempty"`
 	ServiceContainerName string             `json:"serviceContainerName,omitempty"`
-	ServicePort int `json:"servicePort,omitempty"`
+	ServicePort          int                `json:"servicePort,omitempty"`
 }
 
 type ServiceConfiguration struct {

--- a/apis/config/v1alpha6/kfp_controller_config_types.go
+++ b/apis/config/v1alpha6/kfp_controller_config_types.go
@@ -34,6 +34,7 @@ type DefaultProviderValues struct {
 	Replicas             int                `json:"replicas,omitempty"`
 	PodTemplateSpec      v1.PodTemplateSpec `json:"podTemplateSpec,omitempty"`
 	ServiceContainerName string             `json:"serviceContainerName,omitempty"`
+	ServicePort int `json:"servicePort,omitempty"`
 }
 
 type ServiceConfiguration struct {

--- a/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/config/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -7916,6 +7916,8 @@ spec:
                     type: integer
                   serviceContainerName:
                     type: string
+                  servicePort:
+                    type: integer
                 type: object
               multiversion:
                 type: boolean

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -27,6 +27,10 @@ spec:
           runAsNonRoot: true
         containers:
         - name: provider-service
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
           volumeMounts: []
           securityContext:
             allowPrivilegeEscalation: false
@@ -44,3 +48,5 @@ spec:
                 fieldPath: metadata.namespace
           - name: OPERATORWEBHOOK
             value: http://kfp-operator-runcompletion-webhook-service.kfp-operator-system:80/events
+          - name: SERVER_PORT
+            value: 8080

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -20,6 +20,7 @@ spec:
   defaultProviderValues:
     replicas: 1
     serviceContainerName: provider-service
+    servicePort: 8080
     podTemplateSpec:
       spec:
         volumes: []

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -50,4 +50,4 @@ spec:
           - name: OPERATORWEBHOOK
             value: http://kfp-operator-runcompletion-webhook-service.kfp-operator-system:80/events
           - name: SERVER_PORT
-            value: 8080
+            value: '8080'

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
 - runconfiguration_editor_role.yaml
 - runconfiguration_viewer_role.yaml
 - deployment_manager_role.yaml
+- service_manager_role.yaml

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -23,3 +23,16 @@ subjects:
   - kind: ServiceAccount
     name: controller-manager
     namespace: kfp-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-services-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: kfp-operator-system

--- a/config/rbac/service_manager_role.yaml
+++ b/config/rbac/service_manager_role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: service-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/pipelines/internal/workflowfactory/suite_integration_test.go
+++ b/controllers/pipelines/internal/workflowfactory/suite_integration_test.go
@@ -91,6 +91,7 @@ func StubProvider[R pipelinesv1.Resource](
 		},
 		Spec: pipelinesv1.ProviderSpec{
 			ServiceImage:   "kfp-operator-stub-provider",
+			Image:          "kfp-operator-stub-provider",
 			ExecutionMode:  "none",
 			ServiceAccount: "default",
 			Parameters: map[string]*apiextensionsv1.JSON{

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -274,7 +274,7 @@ func syncDeployment(existingDeployment, desiredDeployment *appsv1.Deployment) *a
 func (r *ProviderReconciler) getService(ctx context.Context, provider pipelinesv1.Provider) (*v1.Service, error) {
 	sl := &v1.ServiceList{}
 	err := r.EC.Client.NonCached.List(ctx, sl, &client.ListOptions{
-		Namespace:     provider.Namespace,
+		Namespace: provider.Namespace,
 	})
 	if err != nil {
 		return nil, err
@@ -321,9 +321,9 @@ func (r *ProviderReconciler) buildService(
 			Namespace: deployment.Namespace,
 		},
 		Spec: v1.ServiceSpec{
-			Ports:     ports,
-			Type:      v1.ServiceTypeClusterIP,
-			Selector:  deployment.Labels,
+			Ports:    ports,
+			Type:     v1.ServiceTypeClusterIP,
+			Selector: deployment.Labels,
 		},
 	}
 

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -82,7 +82,11 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func (r *ProviderReconciler) reconcileService(ctx context.Context, provider *pipelinesv1.Provider, prefixedProviderName string) error {
+func (r *ProviderReconciler) reconcileService(
+	ctx context.Context,
+	provider *pipelinesv1.Provider,
+	prefixedProviderName string,
+) error {
 	logger := log.FromContext(ctx)
 	existingSvc, err := r.getService(ctx, *provider)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -121,7 +125,11 @@ func (r *ProviderReconciler) reconcileService(ctx context.Context, provider *pip
 	return nil
 }
 
-func (r *ProviderReconciler) reconcileDeployment(ctx context.Context, provider *pipelinesv1.Provider, prefixedProviderName string) error {
+func (r *ProviderReconciler) reconcileDeployment(
+	ctx context.Context,
+	provider *pipelinesv1.Provider,
+	prefixedProviderName string,
+) error {
 	logger := log.FromContext(ctx)
 
 	desiredDeployment, err := constructDeployment(provider, *r.Config.DeepCopy(), prefixedProviderName)
@@ -187,7 +195,11 @@ func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func constructDeployment(provider *pipelinesv1.Provider, config config.KfpControllerConfigSpec, prefixedProviderName string) (*appsv1.Deployment, error) {
+func constructDeployment(
+	provider *pipelinesv1.Provider,
+	config config.KfpControllerConfigSpec,
+	prefixedProviderName string,
+) (*appsv1.Deployment, error) {
 	matchLabels := map[string]string{AppLabel: prefixedProviderName}
 	deploymentLabels := MapConcat(config.DefaultProviderValues.Labels, matchLabels)
 	replicas := int32(config.DefaultProviderValues.Replicas)
@@ -297,7 +309,10 @@ func syncDeployment(existingDeployment, desiredDeployment *appsv1.Deployment) *a
 	return syncedDeployment
 }
 
-func (r *ProviderReconciler) getService(ctx context.Context, provider pipelinesv1.Provider) (*v1.Service, error) {
+func (r *ProviderReconciler) getService(
+	ctx context.Context,
+	provider pipelinesv1.Provider,
+) (*v1.Service, error) {
 	sl := &v1.ServiceList{}
 	err := r.EC.Client.NonCached.List(ctx, sl, &client.ListOptions{
 		Namespace: provider.Namespace,

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -70,13 +70,12 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	duration := time.Since(startTime)
-
 	if err := r.updateProviderStatus(ctx, provider); err != nil {
 		logger.Error(err, "failed to update provider observedGeneration status")
 		return ctrl.Result{}, err
 	}
 
+	duration := time.Since(startTime)
 	logger.Info(fmt.Sprintf("provider %s reconciliation successful", provider.Name), logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
@@ -107,6 +106,8 @@ func (r *ProviderReconciler) reconcileService(
 
 	if existingSvc != nil {
 		if svcIsOutOfSync(existingSvc, desiredSvc) {
+			// Services have immutable fields, inorder to ensure that the service is updated, we delete the existing
+			// service and create a new one
 			if err := r.EC.Client.Delete(ctx, existingSvc); err != nil {
 				logger.Error(err, "unable to delete existing provider service")
 				return err

--- a/controllers/pipelines/provider_controller_test.go
+++ b/controllers/pipelines/provider_controller_test.go
@@ -89,7 +89,7 @@ var _ = Context("Provider Controller", func() {
 					},
 				},
 			}
-			err := setResourceHashAnnotation(&expectedDeployment)
+			err := setDeploymentHashAnnotation(&expectedDeployment)
 			Expect(err).ToNot(HaveOccurred())
 
 			actualDeployment, err := constructDeployment(&provider, config)
@@ -198,7 +198,7 @@ var _ = Context("Provider Controller", func() {
 				Status: appsv1.DeploymentStatus{},
 			}
 
-			err := setResourceHashAnnotation(&desiredDeployment)
+			err := setDeploymentHashAnnotation(&desiredDeployment)
 			Expect(err).ToNot(HaveOccurred())
 
 			syncedDeployment := syncDeployment(&existingDeployment, &desiredDeployment)

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -34,6 +34,10 @@ data:
               runAsNonRoot: true
             containers:
             - name: provider-service
+              ports:
+              - containerPort: 8080
+                name: http
+                protocol: TCP
               volumeMounts: {{- if .Values.provider.volumeMounts }}{{- toYaml .Values.provider.volumeMounts | nindent 14 }}{{ else }} []{{ end }}
               securityContext:
                 allowPrivilegeEscalation: false
@@ -46,4 +50,6 @@ data:
                     fieldPath: metadata.namespace
               - name: OPERATORWEBHOOK
                 value: http://{{ include "kfp-operator.fullname" . }}-runcompletion-webhook-service.{{ .Values.namespace.name }}:80/events
+              - name: SERVER_PORT
+                value: 8080
               {{- if .Values.provider.env }}{{- $.Values.provider.env | toYaml | nindent 14 }}{{ end }}

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -52,5 +52,5 @@ data:
               - name: OPERATORWEBHOOK
                 value: http://{{ include "kfp-operator.fullname" . }}-runcompletion-webhook-service.{{ .Values.namespace.name }}:80/events
               - name: SERVER_PORT
-                value: 8080
+                value: '8080'
               {{- if .Values.provider.env }}{{- $.Values.provider.env | toYaml | nindent 14 }}{{ end }}

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -27,6 +27,7 @@ data:
       defaultProviderValues:
         replicas: {{ .Values.provider.replicas }}
         serviceContainerName: provider-service
+        servicePort: 8080
         podTemplateSpec:
           spec:
             volumes: {{- if .Values.provider.volumes }}{{- toYaml .Values.provider.volumes | nindent 12 }}{{ else }} []{{ end }}

--- a/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/config.kubeflow.org_kfpcontrollerconfigs.yaml
@@ -7916,7 +7916,9 @@ spec:
                   replicas:
                     type: integer
                   serviceContainerName:
-                    type: string  
+                    type: string
+                  servicePort:
+                    type: integer
                 type: object
               multiversion:
                 type: boolean

--- a/helm/kfp-operator/templates/rbac/role_binding.yaml
+++ b/helm/kfp-operator/templates/rbac/role_binding.yaml
@@ -24,4 +24,17 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.manager.serviceAccount.name }}
     namespace: {{ .Values.namespace.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kfp-operator.fullname" . }}-manager-services-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kfp-operator.fullname" . }}-service-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.manager.serviceAccount.name }}
+  namespace: {{ .Values.namespace.name }}
 {{- end -}}

--- a/helm/kfp-operator/templates/rbac/service_manager_role.yaml
+++ b/helm/kfp-operator/templates/rbac/service_manager_role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.manager.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kfp-operator.fullname" . }}-service-manager-role
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end -}}

--- a/provider-service/base/pkg/testutil/testutil.go
+++ b/provider-service/base/pkg/testutil/testutil.go
@@ -1,4 +1,5 @@
 //go:build decoupled || unit
+
 package testutil
 
 import (

--- a/provider-service/kfp/internal/provider/pipeline_service_test.go
+++ b/provider-service/kfp/internal/provider/pipeline_service_test.go
@@ -90,7 +90,7 @@ var _ = Describe("PipelineService", func() {
 			})
 		})
 	})
-	
+
 	Context("PipelineIdForName", func() {
 		It("should return the pipeline ID if exactly one pipeline is found", func() {
 			expectedResult := go_client.ListPipelinesResponse{

--- a/provider-service/kfp/internal/provider/pipeline_upload_service.go
+++ b/provider-service/kfp/internal/provider/pipeline_upload_service.go
@@ -26,7 +26,7 @@ type PipelineUploadService interface {
 }
 
 type DefaultPipelineUploadService struct {
-	ctx                   context.Context
+	ctx context.Context
 	// There is no gRPC client equivalent to the http client. The gRPC pipeline
 	// service has similar methods (CreatePipeline, CreatePipelineVersion), but
 	// require a URL to an already uploaded file rather than actually uploading


### PR DESCRIPTION
Closes #463 

Manage a k8s service from the provider controller. This links up to the provider deployments ports for api access for workflows from within the cluster.

## Tasks

- [x] controller managed Service for provider
- [x] fix integration tests
