### PR TITLE
compile-files argo template and step

### DIFF
--- a/config/manager/workflows/compiled.yaml
+++ b/config/manager/workflows/compiled.yaml
@@ -50,6 +50,37 @@ spec:
       image: kfp-operator-argo-kfp-compiler:latest
       mirrorVolumeMounts: true
       name: compile
+  - name: combine-files
+    inputs:
+      artifacts:
+        - name: resource
+          path: /resource.json
+        - name: resource-definition
+          path: /resource-definition.yaml
+          raw:
+            data: |
+              {{workflow.parameters.resource-definition}}
+    outputs:
+      artifacts:
+        - name: combined
+          path: /tmp/combined.json
+    container:
+      image: mikefarah/yq:4.45.1
+      command: [sh,-c]
+      args:
+        - |
+          echo "resource-definition.yaml:"
+          cat /resource-definition.yaml
+
+          echo "Converting resource-definition.yaml to json"
+          RESOURCE_DEFINITION_JSON=$(yq eval -o=json /resource-definition.yaml)
+          RESOURCE_JSON=$(cat /resource.json)
+
+          echo "Combining resource definition and resource"
+          COMBINED=$(echo "{\"pipelineDefinition\": $RESOURCE_DEFINITION_JSON, \"compiledPipeline\": $RESOURCE_JSON}")
+
+          echo "Combined resource file:"
+          echo $COMBINED | tee /tmp/combined.json
   - name: create
     inputs:
       parameters:
@@ -196,6 +227,14 @@ spec:
             value: '{{steps.select-resource-image.outputs.result}}'
           - name: provider-config
             value: '{{workflow.parameters.provider-config}}'
+    - - name: combine-files
+        templateRef:
+          name: kfp-operator-compiled-workflow-steps
+          template: combine-files
+        arguments:
+          artifacts:
+          - from: '{{steps.compile.outputs.artifacts.resource}}'
+            name: resource
     - - name: provider
         templateRef:
           name: kfp-operator-compiled-workflow-steps
@@ -271,6 +310,14 @@ spec:
             value: '{{steps.select-resource-image.outputs.result}}'
           - name: provider-config
             value: '{{workflow.parameters.provider-config}}'
+    - - name: combine-files
+        templateRef:
+          name: kfp-operator-compiled-workflow-steps
+          template: combine-files
+        arguments:
+          artifacts:
+          - from: '{{steps.compile.outputs.artifacts.resource}}'
+            name: resource
     - - name: provider
         templateRef:
           name: kfp-operator-compiled-workflow-steps

--- a/helm/kfp-operator/templates/workflows/compiled.yaml
+++ b/helm/kfp-operator/templates/workflows/compiled.yaml
@@ -53,6 +53,37 @@ spec:
       mirrorVolumeMounts: true
       name: compile
       {{- include "kfp-operator.notEmptyYaml" .Values.manager.argo.containerDefaults | nindent 6 }}
+  - name: combine-files
+    inputs:
+      artifacts:
+        - name: resource
+          path: /resource.json
+        - name: resource-definition
+          path: /resource-definition.yaml
+          raw:
+            data: |
+              {{`{{workflow.parameters.resource-definition}}`}}
+    outputs:
+      artifacts:
+        - name: combined
+          path: /tmp/combined.json
+    container:
+      image: mikefarah/yq:4.45.1
+      command: [sh,-c]
+      args:
+        - |
+          echo "resource-definition.yaml:"
+          cat /resource-definition.yaml
+
+          echo "Converting resource-definition.yaml to json"
+          RESOURCE_DEFINITION_JSON=$(yq eval -o=json /resource-definition.yaml)
+          RESOURCE_JSON=$(cat /resource.json)
+
+          echo "Combining resource definition and resource"
+          COMBINED=$(echo "{\"pipelineDefinition\": $RESOURCE_DEFINITION_JSON, \"compiledPipeline\": $RESOURCE_JSON}")
+
+          echo "Combined resource file:"
+          echo $COMBINED | tee /tmp/combined.json
   - name: create
     inputs:
       parameters:
@@ -203,6 +234,14 @@ spec:
             value: '{{`{{steps.select-resource-image.outputs.result}}`}}'
           - name: provider-config
             value: '{{`{{workflow.parameters.provider-config}}`}}'
+    - - name: combine-files
+        templateRef:
+          name: kfp-operator-compiled-workflow-steps
+          template: combine-files
+        arguments:
+          artifacts:
+          - from: '{{`{{steps.compile.outputs.artifacts.resource}}`}}'
+            name: resource
     - - name: provider
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-compiled-workflow-steps
@@ -278,6 +317,14 @@ spec:
             value: '{{`{{steps.select-resource-image.outputs.result}}`}}'
           - name: provider-config
             value: '{{`{{workflow.parameters.provider-config}}`}}'
+    - - name: combine-files
+        templateRef:
+          name: kfp-operator-compiled-workflow-steps
+          template: combine-files
+        arguments:
+          artifacts:
+          - from: '{{`{{steps.compile.outputs.artifacts.resource}}`}}'
+            name: resource
     - - name: provider
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-compiled-workflow-steps


### PR DESCRIPTION
Connected to #464 
Introduce compile-files template and compile-files step to create/update compiled argo templates that will combine resource-definition.yaml and resource.json
The output artifact will be used later on for the workflow to call the provider-service API (not on this change).

## Tasks

- [x] Update template
- [x] Update helm template