### PR TITLE
Version length - set to fixed length of 8 characters

### DIFF
--- a/version.mk
+++ b/version.mk
@@ -1,6 +1,6 @@
 ifndef VERSION
 
-VERSION := $(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*' --dirty 2>/dev/null || echo v0.0.0) | sed 's/^v//')
+VERSION := $(shell (git describe --tags --abbrev=8 --match 'v[0-9]*\.[0-9]*\.[0-9]*' --dirty 2>/dev/null || echo v0.0.0) | sed 's/^v//')
 
 version:
 	@echo ${VERSION}


### PR DESCRIPTION
Closes #502.

Fix abbrev length to 8 to solve getting different versions on different machines
