### PR TITLE
Cleanup provider service docker config

### DIFF
--- a/provider-service/kfp/Makefile
+++ b/provider-service/kfp/Makefile
@@ -4,7 +4,6 @@ include ../../help.mk
 include ./get-proto.mk
 
 IMG := kfp-operator-kfp-provider-service
-DOCKER_BUILD_EXTRA_PARAMS=--build-context base-source=".."
 
 all: build
 

--- a/provider-service/vai/Makefile
+++ b/provider-service/vai/Makefile
@@ -3,7 +3,6 @@ include ../../docker-targets.mk
 include ../../help.mk
 
 IMG := kfp-operator-vai-provider-service
-DOCKER_BUILD_EXTRA_PARAMS=--build-context base-source=".."
 
 ##@ Development
 


### PR DESCRIPTION
Closes #491

Remove DOCKER_BUILD_EXTRA_PARAMS from kfp and vai provider service makefiles because they are not used to pass into the docker-targets.mk's docker-build target