### PR TITLE
Use consistent JSON format across all workflow parameters

### DIFF
--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -11,8 +11,8 @@ type PipelineDefinition struct {
 	Version       string                `json:"version" yaml:"version"`
 	Image         string                `json:"image" yaml:"image"`
 	TfxComponents string                `json:"tfxComponents" yaml:"tfxComponents"`
-	Env           []apis.NamedValue     `json:"env" yaml:"env"`
-	BeamArgs      []apis.NamedValue     `json:"beamArgs" yaml:"beamArgs"`
+	Env           []apis.NamedValue     `json:"env,omitempty" yaml:"env,omitempty"`
+	BeamArgs      []apis.NamedValue     `json:"beamArgs,omitempty" yaml:"beamArgs,omitempty"`
 	Framework     string                `json:"framework" yaml:"framework"`
 }
 
@@ -30,7 +30,7 @@ type RunScheduleDefinition struct {
 	RunConfigurationName common.NamespacedName      `json:"runConfigurationName" yaml:"runConfigurationName"`
 	ExperimentName       common.NamespacedName      `json:"experimentName" yaml:"experimentName"`
 	Schedule             pipelines.Schedule         `json:"schedule" yaml:"schedule"`
-	RuntimeParameters    map[string]string          `json:"runtimeParameters" yaml:"runtimeParameters"`
+	RuntimeParameters    map[string]string          `json:"runtimeParameters,omitempty" yaml:"runtimeParameters,omitempty"`
 	Artifacts            []pipelines.OutputArtifact `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 }
 
@@ -41,7 +41,7 @@ type RunDefinition struct {
 	PipelineVersion      string                     `json:"pipelineVersion" yaml:"pipelineVersion"`
 	RunConfigurationName common.NamespacedName      `json:"runConfigurationName" yaml:"runConfigurationName"`
 	ExperimentName       common.NamespacedName      `json:"experimentName" yaml:"experimentName"`
-	RuntimeParameters    map[string]string          `json:"runtimeParameters" yaml:"runtimeParameters"`
+	RuntimeParameters    map[string]string          `json:"runtimeParameters,omitempty" yaml:"runtimeParameters,omitempty"`
 	Artifacts            []pipelines.OutputArtifact `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 }
 

--- a/argo/providers/base/provider.go
+++ b/argo/providers/base/provider.go
@@ -7,42 +7,42 @@ import (
 )
 
 type PipelineDefinition struct {
-	Name          common.NamespacedName `yaml:"name"`
-	Version       string                `yaml:"version"`
-	Image         string                `yaml:"image"`
-	TfxComponents string                `yaml:"tfxComponents"`
-	Env           []apis.NamedValue     `yaml:"env"`
-	BeamArgs      []apis.NamedValue     `yaml:"beamArgs"`
-	Framework     string                `yaml:"framework"`
+	Name          common.NamespacedName `json:"name" yaml:"name"`
+	Version       string                `json:"version" yaml:"version"`
+	Image         string                `json:"image" yaml:"image"`
+	TfxComponents string                `json:"tfxComponents" yaml:"tfxComponents"`
+	Env           []apis.NamedValue     `json:"env" yaml:"env"`
+	BeamArgs      []apis.NamedValue     `json:"beamArgs" yaml:"beamArgs"`
+	Framework     string                `json:"framework" yaml:"framework"`
 }
 
 type ExperimentDefinition struct {
-	Name        common.NamespacedName `yaml:"name"`
-	Version     string                `yaml:"version"`
-	Description string                `yaml:"description"`
+	Name        common.NamespacedName `json:"name" yaml:"name"`
+	Version     string                `json:"version" yaml:"version"`
+	Description string                `json:"description" yaml:"description"`
 }
 
 type RunScheduleDefinition struct {
-	Name                 common.NamespacedName      `yaml:"name"`
-	Version              string                     `yaml:"version"`
-	PipelineName         common.NamespacedName      `yaml:"pipelineName"`
-	PipelineVersion      string                     `yaml:"pipelineVersion"`
-	RunConfigurationName common.NamespacedName      `yaml:"runConfigurationName"`
-	ExperimentName       common.NamespacedName      `yaml:"experimentName"`
-	Schedule             pipelines.Schedule         `yaml:"schedule"`
-	RuntimeParameters    map[string]string          `yaml:"runtimeParameters"`
-	Artifacts            []pipelines.OutputArtifact `yaml:"artifacts,omitempty"`
+	Name                 common.NamespacedName      `json:"name" yaml:"name"`
+	Version              string                     `json:"version" yaml:"version"`
+	PipelineName         common.NamespacedName      `json:"pipelineName" yaml:"pipelineName"`
+	PipelineVersion      string                     `json:"pipelineVersion" yaml:"pipelineVersion"`
+	RunConfigurationName common.NamespacedName      `json:"runConfigurationName" yaml:"runConfigurationName"`
+	ExperimentName       common.NamespacedName      `json:"experimentName" yaml:"experimentName"`
+	Schedule             pipelines.Schedule         `json:"schedule" yaml:"schedule"`
+	RuntimeParameters    map[string]string          `json:"runtimeParameters" yaml:"runtimeParameters"`
+	Artifacts            []pipelines.OutputArtifact `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 }
 
 type RunDefinition struct {
-	Name                 common.NamespacedName      `yaml:"name"`
-	Version              string                     `yaml:"version"`
-	PipelineName         common.NamespacedName      `yaml:"pipelineName"`
-	PipelineVersion      string                     `yaml:"pipelineVersion"`
-	RunConfigurationName common.NamespacedName      `yaml:"runConfigurationName"`
-	ExperimentName       common.NamespacedName      `yaml:"experimentName"`
-	RuntimeParameters    map[string]string          `yaml:"runtimeParameters"`
-	Artifacts            []pipelines.OutputArtifact `yaml:"artifacts,omitempty"`
+	Name                 common.NamespacedName      `json:"name" yaml:"name"`
+	Version              string                     `json:"version" yaml:"version"`
+	PipelineName         common.NamespacedName      `json:"pipelineName" yaml:"pipelineName"`
+	PipelineVersion      string                     `json:"pipelineVersion" yaml:"pipelineVersion"`
+	RunConfigurationName common.NamespacedName      `json:"runConfigurationName" yaml:"runConfigurationName"`
+	ExperimentName       common.NamespacedName      `json:"experimentName" yaml:"experimentName"`
+	RuntimeParameters    map[string]string          `json:"runtimeParameters" yaml:"runtimeParameters"`
+	Artifacts            []pipelines.OutputArtifact `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 }
 
 type Output struct {

--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -27,7 +27,7 @@ spec:
     inputs:
       artifacts:
       - name: resource-definition
-        path: /resource-definition.yaml
+        path: /resource-definition.json
         raw:
           data: |
             {{workflow.parameters.resource-definition}}
@@ -35,27 +35,9 @@ spec:
       command:
       - ash
       image: mikefarah/yq:4.45.1
-      source: yq e -r '.image' /resource-definition.yaml
+      source: yq e -r '.image' /resource-definition.json
     metadata: {}
     activeDeadlineSeconds: 300
-  - name: yaml-to-json
-    inputs:
-      parameters:
-      - name: yaml
-    outputs:
-      artifacts:
-      - name: json
-        path: /tmp/json.json
-    container:
-      image: mikefarah/yq:4.45.1
-      command: [sh, -c]
-      args:
-      - |
-        echo "input yaml:"
-        echo "{{inputs.parameters.yaml}}"
-
-        echo "output json:"
-        echo "{{inputs.parameters.yaml}}" | yq eval -o=json - | tee /tmp/json.json
   - name: url-encode
     inputs:
       parameters:

--- a/config/manager/workflows/compiled.yaml
+++ b/config/manager/workflows/compiled.yaml
@@ -16,7 +16,7 @@ spec:
         raw:
           data: |
             {{workflow.parameters.resource-definition}}
-        path: /resource-definition.yaml
+        path: /resource-definition.json
       - name: provider-config
         path: /provider-config.json
         raw:
@@ -40,7 +40,7 @@ spec:
       - --output_file
       - /tmp/resource.json
       - --{{workflow.parameters.resource-kind}}_config
-      - /resource-definition.yaml
+      - /resource-definition.json
       - --provider_config
       - /provider-config.json
     volumes:
@@ -118,14 +118,6 @@ spec:
             value: '{{workflow.parameters.provider-config}}'
           - name: pipeline-framework-image
             value: '{{workflow.parameters.pipeline-framework-image}}'
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: kfp-operator-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{workflow.parameters.resource-definition}}'
     - - name: combine-files
         templateRef:
           name: kfp-operator-compiled-workflow-steps
@@ -134,8 +126,11 @@ spec:
           artifacts:
             - from: '{{steps.compile.outputs.artifacts.resource}}'
               name: resource
-            - from: '{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}'
-              name: resource-definition
+            - name: resource-definition
+              raw:
+                data: |
+                  {{workflow.parameters.resource-definition}}
+              path: /resource-definition.json
     - - name: provider
         templateRef:
           name: kfp-operator-common-steps
@@ -191,14 +186,6 @@ spec:
             value: '{{workflow.parameters.provider-config}}'
           - name: pipeline-framework-image
             value: '{{workflow.parameters.pipeline-framework-image}}'
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: kfp-operator-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{workflow.parameters.resource-definition}}'
     - - name: combine-files
         templateRef:
           name: kfp-operator-compiled-workflow-steps
@@ -207,8 +194,11 @@ spec:
           artifacts:
           - from: '{{steps.compile.outputs.artifacts.resource}}'
             name: resource
-          - from: '{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}'
-            name: resource-definition
+          - name: resource-definition
+            raw:
+              data: |
+                {{workflow.parameters.resource-definition}}
+            path: /resource-definition.json
     - - name: url-encode-resource-id
         templateRef:
           name: kfp-operator-common-steps

--- a/config/manager/workflows/simple.yaml
+++ b/config/manager/workflows/simple.yaml
@@ -23,22 +23,17 @@ spec:
         valueFrom:
           parameter: '{{steps.provider.outputs.parameters.provider-output}}'
     steps:
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: kfp-operator-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{workflow.parameters.resource-definition}}'
     - - name: provider
         templateRef:
           name: kfp-operator-common-steps
           template: create
         arguments:
           artifacts:
-          - from: '{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}'
-            name: body
+          - name: body
+            raw:
+              data: |
+                {{workflow.parameters.resource-definition}}
+            path: /body.json
           parameters:
           - name: provider-service-url
             value: '{{workflow.parameters.provider-service-url}}'
@@ -69,14 +64,6 @@ spec:
         valueFrom:
           parameter: '{{steps.provider.outputs.parameters.provider-output}}'
     steps:
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: kfp-operator-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{workflow.parameters.resource-definition}}'
     - - name: url-encode-resource-id
         templateRef:
           name: kfp-operator-common-steps
@@ -91,8 +78,11 @@ spec:
           template: update
         arguments:
           artifacts:
-          - from: '{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}'
-            name: body
+          - name: body
+            raw:
+              data: |
+                {{workflow.parameters.resource-definition}}
+            path: /body.json
           parameters:
           - name: url-encoded-resource-id
             value: '{{steps.url-encode-resource-id.outputs.parameters.url-encoded}}'

--- a/controllers/pipelines/internal/workflowfactory/resource_workflow_factory.go
+++ b/controllers/pipelines/internal/workflowfactory/resource_workflow_factory.go
@@ -8,7 +8,6 @@ import (
 	config "github.com/sky-uk/kfp-operator/apis/config/v1alpha6"
 	pipelinesv1 "github.com/sky-uk/kfp-operator/apis/pipelines/v1alpha6"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/workflowconstants"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -89,13 +88,13 @@ func (workflows ResourceWorkflowFactory[R, ResourceDefinition]) CommonWorkflowMe
 	}
 }
 
-func (workflows *ResourceWorkflowFactory[R, ResourceDefinition]) resourceDefinitionYaml(resource R) (string, error) {
+func (workflows *ResourceWorkflowFactory[R, ResourceDefinition]) resourceDefinitionJson(resource R) (string, error) {
 	resourceDefinition, err := workflows.DefinitionCreator(resource)
 	if err != nil {
 		return "", err
 	}
 
-	marshalled, err := yaml.Marshal(&resourceDefinition)
+	marshalled, err := json.Marshal(&resourceDefinition)
 	if err != nil {
 		return "", err
 	}
@@ -108,7 +107,7 @@ func (workflows *ResourceWorkflowFactory[R, ResourceDefinition]) ConstructCreati
 	providerSvc corev1.Service,
 	resource R,
 ) (*argo.Workflow, error) {
-	resourceDefinition, err := workflows.resourceDefinitionYaml(resource)
+	resourceDefinition, err := workflows.resourceDefinitionJson(resource)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +169,7 @@ func (workflows *ResourceWorkflowFactory[R, ResourceDefinition]) ConstructUpdate
 	providerSvc corev1.Service,
 	resource R,
 ) (*argo.Workflow, error) {
-	resourceDefinition, err := workflows.resourceDefinitionYaml(resource)
+	resourceDefinition, err := workflows.resourceDefinitionJson(resource)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -64,10 +64,6 @@ func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			predicate.ResourceVersionChangedPredicate{},
 		)).
 		Owns(&v1.Service{}).
-		WithEventFilter(predicate.Or(
-			predicate.AnnotationChangedPredicate{},
-			predicate.LabelChangedPredicate{},
-		)).
 		Complete(r)
 }
 

--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -28,7 +28,7 @@ spec:
     inputs:
       artifacts:
       - name: resource-definition
-        path: /resource-definition.yaml
+        path: /resource-definition.json
         raw:
           data: |
             {{`{{workflow.parameters.resource-definition}}`}}
@@ -36,28 +36,10 @@ spec:
       command:
       - ash
       image: mikefarah/yq:4.45.1
-      source: yq e -r '.image' /resource-definition.yaml
+      source: yq e -r '.image' /resource-definition.json
     metadata:
       {{- .Values.manager.argo.metadata | toYaml | nindent 6 }}
     activeDeadlineSeconds: {{ .Values.manager.argo.stepTimeoutSeconds.default }}
-  - name: yaml-to-json
-    inputs:
-      parameters:
-      - name: yaml
-    outputs:
-      artifacts:
-      - name: json
-        path: /tmp/json.json
-    container:
-      image: mikefarah/yq:4.45.1
-      command: [sh, -c]
-      args:
-      - |
-        echo "input yaml:"
-        echo "{{`{{inputs.parameters.yaml}}`}}"
-
-        echo "output json:"
-        echo "{{`{{inputs.parameters.yaml}}`}}" | yq eval -o=json - | tee /tmp/json.json
   - name: url-encode
     inputs:
       parameters:

--- a/helm/kfp-operator/templates/workflows/compiled.yaml
+++ b/helm/kfp-operator/templates/workflows/compiled.yaml
@@ -16,7 +16,7 @@ spec:
         raw:
           data: |
             {{`{{workflow.parameters.resource-definition}}`}}
-        path: /resource-definition.yaml
+        path: /resource-definition.json
       - name: provider-config
         path: /provider-config.json
         raw:
@@ -41,7 +41,7 @@ spec:
       - --output_file
       - /tmp/resource.json
       - --{{`{{workflow.parameters.resource-kind}}`}}_config
-      - /resource-definition.yaml
+      - /resource-definition.json
       - --provider_config
       - /provider-config.json
       {{- include "kfp-operator.notEmptyYaml" .Values.manager.argo.containerDefaults | nindent 6 }}
@@ -121,14 +121,6 @@ spec:
             value: '{{`{{workflow.parameters.provider-config}}`}}'
           - name: pipeline-framework-image
             value: '{{`{{workflow.parameters.pipeline-framework-image}}`}}'
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{`{{workflow.parameters.resource-definition}}`}}'
     - - name: combine-files
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-compiled-workflow-steps
@@ -137,8 +129,11 @@ spec:
           artifacts:
           - from: '{{`{{steps.compile.outputs.artifacts.resource}}`}}'
             name: resource
-          - from: '{{`{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}`}}'
-            name: resource-definition
+          - name: resource-definition
+            raw:
+              data: |
+                {{`{{workflow.parameters.resource-definition}}`}}
+            path: /resource-definition.json
     - - name: provider
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-common-steps
@@ -194,14 +189,6 @@ spec:
             value: '{{`{{workflow.parameters.provider-config}}`}}'
           - name: pipeline-framework-image
             value: '{{`{{workflow.parameters.pipeline-framework-image}}`}}'
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{`{{workflow.parameters.resource-definition}}`}}'
     - - name: combine-files
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-compiled-workflow-steps
@@ -210,8 +197,11 @@ spec:
           artifacts:
           - from: '{{`{{steps.compile.outputs.artifacts.resource}}`}}'
             name: resource
-          - from: '{{`{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}`}}'
-            name: resource-definition
+          - name: resource-definition
+            raw:
+              data: |
+                {{`{{workflow.parameters.resource-definition}}`}}
+            path: /resource-definition.json
     - - name: url-encode-resource-id
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-common-steps

--- a/helm/kfp-operator/templates/workflows/simple.yaml
+++ b/helm/kfp-operator/templates/workflows/simple.yaml
@@ -23,22 +23,17 @@ spec:
         valueFrom:
           parameter: '{{`{{steps.provider.outputs.parameters.provider-output}}`}}'
     steps:
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{`{{workflow.parameters.resource-definition}}`}}'
     - - name: provider
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-common-steps
           template: create
         arguments:
           artifacts:
-          - from: '{{`{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}`}}'
-            name: body
+          - name: body
+            raw:
+              data: |
+                {{`{{workflow.parameters.resource-definition}}`}}
+            path: /body.json
           parameters:
           - name: provider-service-url
             value: '{{`{{workflow.parameters.provider-service-url}}`}}'
@@ -69,14 +64,6 @@ spec:
         valueFrom:
           parameter: '{{`{{steps.provider.outputs.parameters.provider-output}}`}}'
     steps:
-    - - name: convert-resource-definition-yaml-to-json
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: yaml-to-json
-        arguments:
-          parameters:
-          - name: yaml
-            value: '{{`{{workflow.parameters.resource-definition}}`}}'
     - - name: url-encode-resource-id
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-common-steps
@@ -91,8 +78,11 @@ spec:
           template: update
         arguments:
           artifacts:
-          - from: '{{`{{steps.convert-resource-definition-yaml-to-json.outputs.artifacts.json}}`}}'
-            name: body
+          - name: body
+            raw:
+              data: |
+                {{`{{workflow.parameters.resource-definition}}`}}
+            path: /body.json
           parameters:
           - name: url-encoded-resource-id
             value: '{{`{{steps.url-encode-resource-id.outputs.parameters.url-encoded}}`}}'


### PR DESCRIPTION
Closes #519 

Changes all resources passed into workflows to be in JSON format, instead of YAML. 

## Tasks

- [x] Update resources to use JSON format
- [x] Update all workflows to pass resource json as an artifact
- [x] Remove yaml -> json conversion within workflows
