### PR TITLE
Remove select-provider-parameter argo workflow template and all related steps

### DIFF
--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -164,26 +164,6 @@ spec:
         valueFrom:
           parameter: '{{steps.provider.outputs.parameters.provider-output}}'
     steps:
-    - - name: select-provider-image
-        templateRef:
-          name: kfp-operator-common-steps
-          template: select-provider-parameter
-        arguments:
-          parameters:
-          - name: field
-            value: image
-          - name: provider-config
-            value: '{{workflow.parameters.provider-config}}'
-    - - name: select-provider-sa
-        templateRef:
-          name: kfp-operator-common-steps
-          template: select-provider-parameter
-        arguments:
-          parameters:
-          - name: field
-            value: serviceAccount
-          - name: provider-config
-            value: '{{workflow.parameters.provider-config}}'
     - - name: url-encode-resource-id
         templateRef:
           name: kfp-operator-common-steps

--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -5,24 +5,6 @@ metadata:
   namespace: kfp-operator-system
 spec:
   templates:
-  - name: select-provider-parameter
-    inputs:
-      parameters:
-      - name: field
-      - name: provider-config
-      artifacts:
-      - name: provider-config
-        path: /provider-config.json
-        raw:
-          data: |
-            {{workflow.parameters.provider-config}}
-    script:
-      command:
-      - ash
-      image: mikefarah/yq:4.45.1
-      source: yq e -r '.{{inputs.parameters.field}}' '/provider-config.json'
-    metadata: {}
-    activeDeadlineSeconds: 300
   - name: select-resource-image
     inputs:
       artifacts:

--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -5,25 +5,6 @@ metadata:
   namespace: {{ include "kfp-operator.argoNamespace" . }}
 spec:
   templates:
-  - name: select-provider-parameter
-    inputs:
-      parameters:
-      - name: field
-      - name: provider-config
-      artifacts:
-      - name: provider-config
-        path: /provider-config.json
-        raw:
-          data: |
-            {{`{{workflow.parameters.provider-config}}`}}
-    script:
-      command:
-      - ash
-      image: mikefarah/yq:4.45.1
-      source: yq e -r '.{{`{{inputs.parameters.field}}`}}' '/provider-config.json'
-    metadata:
-      {{- .Values.manager.argo.metadata | toYaml | nindent 6 }}
-    activeDeadlineSeconds: {{ .Values.manager.argo.stepTimeoutSeconds.default }}
   - name: select-resource-image
     inputs:
       artifacts:

--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -170,26 +170,6 @@ spec:
         valueFrom:
           parameter: '{{`{{steps.provider.outputs.parameters.provider-output}}`}}'
     steps:
-    - - name: select-provider-image
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: select-provider-parameter
-        arguments:
-          parameters:
-          - name: field
-            value: image
-          - name: provider-config
-            value: '{{`{{workflow.parameters.provider-config}}`}}'
-    - - name: select-provider-sa
-        templateRef:
-          name: {{ include "kfp-operator.fullname" . }}-common-steps
-          template: select-provider-parameter
-        arguments:
-          parameters:
-          - name: field
-            value: serviceAccount
-          - name: provider-config
-            value: '{{`{{workflow.parameters.provider-config}}`}}'
     - - name: url-encode-resource-id
         templateRef:
           name: {{ include "kfp-operator.fullname" . }}-common-steps


### PR DESCRIPTION
Connected to #512 and #511 

Remove select-provider-parameter argo workflow template. Remove select-provider-image and select-provider-sa steps from delete argo workflow template, which was left out of the above connected PR by mistake.