### PR TITLE
Initialise struct correctly for multi schema handling

### DIFF
--- a/provider-service/vai/internal/provider/job_enricher.go
+++ b/provider-service/vai/internal/provider/job_enricher.go
@@ -24,7 +24,12 @@ func (dje DefaultJobEnricher) Enrich(
 		return nil, err
 	}
 	job.Name = pv.name
-	job.Labels = pv.labels
+	if job.Labels == nil {
+		job.Labels = map[string]string{}
+	}
+	for k, v := range pv.labels {
+		job.Labels[k] = v
+	}
 	job.PipelineSpec = pv.pipelineSpec
 	return job, nil
 }

--- a/provider-service/vai/internal/provider/job_enricher_test.go
+++ b/provider-service/vai/internal/provider/job_enricher_test.go
@@ -50,6 +50,20 @@ var _ = Describe("DefaultJobEnricher", func() {
 			Expect(job.PipelineSpec).To(Equal(expectedReturn.pipelineSpec))
 		})
 
+		It("enrich job with existing labels with pipeline values returned by pipelineSchemaHandler", func() {
+			mockPipelineSchemaHandler.On("extract", input).Return(&expectedReturn, nil)
+
+			expectedCombinedLabels := map[string]string{"key": "value", "key2": "value2"}
+
+			job := aiplatformpb.PipelineJob{Labels: map[string]string{"key2": "value2"}}
+			_, err := dje.Enrich(&job, input)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(job.Name).To(Equal(expectedReturn.name))
+			Expect(job.Labels).To(Equal(expectedCombinedLabels))
+			Expect(job.PipelineSpec).To(Equal(expectedReturn.pipelineSpec))
+		})
+
 		It("enrich job returns error on pipelineSchemaHandler error", func() {
 			mockPipelineSchemaHandler.On("extract", input).Return(nil, errors.New("an error"))
 

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -65,7 +65,10 @@ func NewVAIProvider(
 			pipelineBucket:      config.Parameters.PipelineBucket,
 			labelGen:            DefaultLabelGen{},
 		},
-		jobEnricher: DefaultJobEnricher{pipelineSchemaHandler: DefaultPipelineSchemaHandler{}},
+		jobEnricher: DefaultJobEnricher{pipelineSchemaHandler: DefaultPipelineSchemaHandler{
+			schema2Handler:   Schema2Handler{},
+			schema2_1Handler: Schema2_1Handler{},
+		}},
 	}, nil
 }
 


### PR DESCRIPTION
The pipeline schema handler wasn't getting initialised correctly in the builder causing panic. Also bug noticed that labels from pipeline definition were replacing what was on the job rather than merging the two