### PR TITLE
Empty metadata in common delete step is incorrect

### DIFF
--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -110,7 +110,8 @@ spec:
       - name: provider-output
         valueFrom:
           path: /tmp/provider-output.json
-    metadata: {}
+    metadata:
+      {{- .Values.manager.argo.metadata | toYaml | nindent 6 }}
     activeDeadlineSeconds: {{ .Values.manager.argo.stepTimeoutSeconds.default }}
     container:
       image: curlimages/curl:8.12.1


### PR DESCRIPTION
Closes #545.

Matches kustomize as metadata was {}

## Tasks

- [X] Correct helm workflow template
