### PR TITLE
Add GcsOutputDirectory for scheduled job submission in VAI provider

### DIFF
--- a/provider-service/vai/internal/provider/job_builder.go
+++ b/provider-service/vai/internal/provider/job_builder.go
@@ -64,15 +64,9 @@ func (jb DefaultJobBuilder) MkRunPipelineJob(
 	if err != nil {
 		return nil, err
 	}
-	job := &aiplatformpb.PipelineJob{
-		Labels: labels,
-		RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
-			Parameters:         params,
-			GcsOutputDirectory: fmt.Sprintf("%s/%s", jb.pipelineRootStorage, pipelineResourceName),
-		},
-		ServiceAccount: jb.serviceAccount,
-		TemplateUri:    templateUri,
-	}
+
+	job := jb.newPipelineJob(labels, params, pipelineResourceName, templateUri)
+
 	return job, nil
 }
 
@@ -107,14 +101,13 @@ func (jb DefaultJobBuilder) MkRunSchedulePipelineJob(
 		return nil, err
 	}
 
-	job := &aiplatformpb.PipelineJob{
-		Labels:         labels,
-		ServiceAccount: jb.serviceAccount,
-		RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
-			Parameters: params,
-		},
-		TemplateUri: templateUri,
+	pipelineResourceName, err := rsd.PipelineName.String()
+	if err != nil {
+		return nil, err
 	}
+
+	job := jb.newPipelineJob(labels, params, pipelineResourceName, templateUri)
+
 	return job, nil
 }
 
@@ -152,4 +145,17 @@ func (jb DefaultJobBuilder) MkSchedule(
 		schedule.EndTime = timestamppb.New(rsd.Schedule.EndTime.Time)
 	}
 	return schedule, nil
+}
+
+func (jb DefaultJobBuilder) newPipelineJob(labels map[string]string, params map[string]*aiplatformpb.Value, resourceName string, templateUri string) *aiplatformpb.PipelineJob {
+	pipelineJob := &aiplatformpb.PipelineJob{
+		Labels: labels,
+		RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
+			Parameters:         params,
+			GcsOutputDirectory: fmt.Sprintf("%s/%s", jb.pipelineRootStorage, resourceName),
+		},
+		ServiceAccount: jb.serviceAccount,
+		TemplateUri:    templateUri,
+	}
+	return pipelineJob
 }

--- a/provider-service/vai/internal/provider/job_builder_test.go
+++ b/provider-service/vai/internal/provider/job_builder_test.go
@@ -84,9 +84,19 @@ var _ = Describe("JobBuilder", func() {
 				}
 				Expect(job.ServiceAccount).To(Equal(jb.serviceAccount))
 				Expect(job.TemplateUri).To(Equal(expectedTemplateUri))
+				Expect(job.RuntimeConfig.GcsOutputDirectory).To(Equal(fmt.Sprintf("%s/%s/%s", jb.pipelineRootStorage, rsd.PipelineName.Namespace, rsd.PipelineName.Name)))
 			})
 		})
 		When("templateUri is invalid", func() {
+			It("should return error", func() {
+				rsd := testutil.RandomRunScheduleDefinition()
+				rsd.PipelineName.Name = ""
+				_, err := jb.MkRunSchedulePipelineJob(rsd)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("run schedule definition name is invalid", func() {
 			It("should return error", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				rsd.PipelineName.Name = ""

--- a/provider-service/vai/internal/provider/job_builder_test.go
+++ b/provider-service/vai/internal/provider/job_builder_test.go
@@ -96,7 +96,7 @@ var _ = Describe("JobBuilder", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
-		When("run schedule definition name is invalid", func() {
+		When("run schedule definition pipeline's name is invalid", func() {
 			It("should return error", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				rsd.PipelineName.Name = ""


### PR DESCRIPTION
Closes #557.

Realised that on submitting a new reconfiguration with a schedule to VAI for a KFP-SDK compiled pipeline definition that doesn't set the GCS storage value it fails to submit.

Corrected logic to set for both one off run and run schedule submit.