### PR TITLE
Handle missing Runs / RunConfigurations in operator webhook

### DIFF
--- a/argo/providers/go.work.sum
+++ b/argo/providers/go.work.sum
@@ -731,6 +731,8 @@ github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjj
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alecthomas/kingpin/v2 v2.3.1 h1:ANLJcKmQm4nIaog7xdr/id6FM6zm5hHnfZrvtKPxqGg=
 github.com/alecthomas/kingpin/v2 v2.3.1/go.mod h1:oYL5vtsvEHZGHxU7DMp32Dvx+qL+ptGn6lWaot2vCNE=
+github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
+github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
@@ -1226,8 +1228,6 @@ github.com/ktrysmt/go-bitbucket v0.9.66 h1:nRKRY0XvV/VkY2JemejtJA49dcPdzYAt24Lzm
 github.com/ktrysmt/go-bitbucket v0.9.66/go.mod h1:Qqa5bm6HwkLOViah8VIMxv1dj/hH1733nqmR8Q5ZHMs=
 github.com/kubeflow/pipelines/api v0.0.0-20220311022801-11635101d944 h1:HqL2Br8x7MM1yL0xNlpr5CPNzvOiw3JebjuqF4NnP/s=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20220118175555-e78ed557ddcb h1:i0RzcKBlfGHueIwrUlKB+AvVZPuMUJIYe1g8nvhwgbo=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo v3.2.1+incompatible h1:J2M7YArHx4gi8p/3fDw8tX19SXhBCoRpviyAZSN3I88=
 github.com/labstack/gommon v0.2.7 h1:2qOPq/twXDrQ6ooBGrn3mrmVOC+biLlatwgIu8lbzRM=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
@@ -1255,6 +1255,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
+github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
@@ -1481,6 +1483,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77 h1:ESFSdwYZvkeru3RtdrYueztKhOBCSAAzS4Gf+k0tEow=

--- a/controllers/webhook/errors.go
+++ b/controllers/webhook/errors.go
@@ -1,0 +1,44 @@
+package webhook
+
+import "net/http"
+
+type EventError interface {
+	error
+	SendHttpError(response http.ResponseWriter)
+}
+
+type InvalidEvent struct {
+	Msg string
+}
+
+func (e *InvalidEvent) Error() string {
+	return e.Msg
+}
+
+func (e *InvalidEvent) SendHttpError(response http.ResponseWriter) {
+	http.Error(response, e.Error(), http.StatusBadRequest)
+}
+
+type FatalError struct {
+	Msg string
+}
+
+func (e *FatalError) Error() string {
+	return e.Msg
+}
+
+func (e *FatalError) SendHttpError(response http.ResponseWriter) {
+	http.Error(response, e.Error(), http.StatusInternalServerError)
+}
+
+type MissingResourceError struct {
+	Msg string
+}
+
+func (e *MissingResourceError) Error() string {
+	return e.Msg
+}
+
+func (e *MissingResourceError) SendHttpError(response http.ResponseWriter) {
+	http.Error(response, e.Error(), http.StatusGone)
+}

--- a/controllers/webhook/event_processor_unit_test.go
+++ b/controllers/webhook/event_processor_unit_test.go
@@ -104,7 +104,7 @@ var _ = Context("ToRunCompletionEvent", func() {
 		})
 	})
 
-	When("neither run configuration nor run passed", func() {
+	When("neither run configuration or run passed", func() {
 		It("returns an error", func() {
 			runCompletionEventData := RandomRunCompletionEventData()
 			stubbedFilterFunc := func(_ []common.PipelineComponent, _ []pipelineshub.OutputArtifact) []common.Artifact {
@@ -112,7 +112,7 @@ var _ = Context("ToRunCompletionEvent", func() {
 			}
 
 			_, err := ResourceArtifactsEventProcessor{filter: stubbedFilterFunc}.ToRunCompletionEvent(&runCompletionEventData, nil, nil)
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(&InvalidEvent{err.Error()}))
 		})
 	})
 })

--- a/controllers/webhook/event_processor_unit_test.go
+++ b/controllers/webhook/event_processor_unit_test.go
@@ -3,60 +3,28 @@
 package webhook
 
 import (
-	"context"
-
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/kfp-operator/apis"
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func schemeWithCRDs() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-
-	groupVersion := schema.GroupVersion{Group: "pipelines.kubeflow.org", Version: "v1beta1"}
-	scheme.AddKnownTypes(groupVersion, &pipelineshub.RunConfiguration{}, &pipelineshub.Run{})
-
-	metav1.AddToGroupVersion(scheme, groupVersion)
-	return scheme
-}
-
-func checkOutputArtifacts(outputArtifacts []pipelineshub.OutputArtifact, expectedArtifacts []pipelineshub.OutputArtifact) {
-	if outputArtifacts == nil {
-		Expect(expectedArtifacts).To(BeEmpty())
-	} else {
-		Expect(outputArtifacts).To(Equal(expectedArtifacts))
-	}
-}
-
 var _ = Context("ToRunCompletionEvent", func() {
-	var ctx = logr.NewContext(context.Background(), logr.Discard())
-
-	When("given valid runCompletionEventData", func() {
-		It("converts to a runCompletionEvent with filtered artifacts", func() {
+	When("run configuration passed and no run passed", func() {
+		It("returns RunCompletionEvent with filtered run configuration artifacts", func() {
 			rc := pipelineshub.RandomRunConfiguration(common.RandomNamespacedName())
+			rc.Spec.Run.Artifacts = []pipelineshub.OutputArtifact{{Name: "runconfig-artifact"}}
 
 			runCompletionEventData := RandomRunCompletionEventData()
 			runCompletionEventData.RunConfigurationName = &common.NamespacedName{
 				Name:      rc.Name,
 				Namespace: rc.Namespace,
 			}
+			runCompletionEventData.RunName = nil
 
-			expectedArtifacts := apis.RandomNonEmptyList(common.RandomArtifact)
+			expectedArtifacts := []common.Artifact{{Name: "runconfig-artifact"}}
 
-			stubbedFilterFunc := func(_ []common.PipelineComponent, _ []pipelineshub.OutputArtifact) []common.Artifact {
-				return expectedArtifacts
-			}
-
-			fakeClient := fake.NewClientBuilder().WithScheme(schemeWithCRDs()).WithObjects(rc).Build()
-
-			result, err := ResourceArtifactsEventProcessor{client: fakeClient, filter: stubbedFilterFunc}.ToRunCompletionEvent(ctx, runCompletionEventData)
+			result, err := ResourceArtifactsEventProcessor{filter: stubbedFilterFunc}.ToRunCompletionEvent(&runCompletionEventData, rc, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(&common.RunCompletionEvent{
 				Status:                runCompletionEventData.Status,
@@ -69,6 +37,82 @@ var _ = Context("ToRunCompletionEvent", func() {
 				Provider:              runCompletionEventData.Provider,
 			}))
 
+		})
+	})
+
+	When("run passed and no run configuration passed", func() {
+		It("returns RunCompletionEvent with filtered run artifacts", func() {
+			run := pipelineshub.RandomRun(common.RandomNamespacedName())
+			run.Spec.Artifacts = []pipelineshub.OutputArtifact{{Name: "run-artifact"}}
+
+			runCompletionEventData := RandomRunCompletionEventData()
+			runCompletionEventData.RunName = &common.NamespacedName{
+				Name:      run.Name,
+				Namespace: run.Namespace,
+			}
+			runCompletionEventData.RunConfigurationName = nil
+
+			expectedArtifacts := []common.Artifact{{Name: "run-artifact"}}
+
+			result, err := ResourceArtifactsEventProcessor{filter: stubbedFilterFunc}.ToRunCompletionEvent(&runCompletionEventData, nil, run)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(&common.RunCompletionEvent{
+				Status:                runCompletionEventData.Status,
+				PipelineName:          runCompletionEventData.PipelineName,
+				RunConfigurationName:  runCompletionEventData.RunConfigurationName,
+				RunName:               runCompletionEventData.RunName,
+				RunId:                 runCompletionEventData.RunId,
+				ServingModelArtifacts: runCompletionEventData.ServingModelArtifacts,
+				Artifacts:             expectedArtifacts,
+				Provider:              runCompletionEventData.Provider,
+			}))
+		})
+	})
+
+	When("both run configuration and run passed", func() {
+		It("returns RunCompletionEvent with filtered run configuration artifacts", func() {
+			rc := pipelineshub.RandomRunConfiguration(common.RandomNamespacedName())
+			rc.Spec.Run.Artifacts = []pipelineshub.OutputArtifact{{Name: "runconfig-artifact"}}
+			run := pipelineshub.RandomRun(common.RandomNamespacedName())
+			run.Spec.Artifacts = []pipelineshub.OutputArtifact{{Name: "run-artifact"}}
+
+			runCompletionEventData := RandomRunCompletionEventData()
+			runCompletionEventData.RunConfigurationName = &common.NamespacedName{
+				Name:      rc.Name,
+				Namespace: rc.Namespace,
+			}
+			runCompletionEventData.RunName = &common.NamespacedName{
+				Name:      run.Name,
+				Namespace: run.Namespace,
+			}
+
+			expectedArtifacts := []common.Artifact{{Name: "runconfig-artifact"}}
+
+			result, err := ResourceArtifactsEventProcessor{filter: stubbedFilterFunc}.ToRunCompletionEvent(&runCompletionEventData, rc, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(&common.RunCompletionEvent{
+				Status:                runCompletionEventData.Status,
+				PipelineName:          runCompletionEventData.PipelineName,
+				RunConfigurationName:  runCompletionEventData.RunConfigurationName,
+				RunName:               runCompletionEventData.RunName,
+				RunId:                 runCompletionEventData.RunId,
+				ServingModelArtifacts: runCompletionEventData.ServingModelArtifacts,
+				Artifacts:             expectedArtifacts,
+				Provider:              runCompletionEventData.Provider,
+			}))
+
+		})
+	})
+
+	When("neither run configuration nor run passed", func() {
+		It("returns an error", func() {
+			runCompletionEventData := RandomRunCompletionEventData()
+			stubbedFilterFunc := func(_ []common.PipelineComponent, _ []pipelineshub.OutputArtifact) []common.Artifact {
+				return []common.Artifact{}
+			}
+
+			_, err := ResourceArtifactsEventProcessor{filter: stubbedFilterFunc}.ToRunCompletionEvent(&runCompletionEventData, nil, nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })
@@ -150,72 +194,12 @@ var _ = Context("filter", func() {
 	})
 })
 
-var _ = Context("extractResourceArtifacts", func() {
-	var ctx = logr.NewContext(context.Background(), logr.Discard())
-	When("neither run configuration or run name namespace passed", func() {
-		It("should return an error", func() {
-			_, err := extractResourceArtifacts(ctx, fake.NewClientBuilder().Build(), nil, nil)
-			Expect(err).To(HaveOccurred())
+func stubbedFilterFunc(_ []common.PipelineComponent, outputArtifacts []pipelineshub.OutputArtifact) []common.Artifact {
+	filteredArtifacts := []common.Artifact{}
+	for _, artifact := range outputArtifacts {
+		filteredArtifacts = append(filteredArtifacts, common.Artifact{
+			Name: artifact.Name,
 		})
-	})
-
-	When("run configuration passed but resource not available", func() {
-		It("should return an error", func() {
-			rcName := &common.NamespacedName{
-				Namespace: "rc-namespace",
-				Name:      "rc-name",
-			}
-			_, err := extractResourceArtifacts(ctx, fake.NewClientBuilder().WithScheme(schemeWithCRDs()).Build(), rcName, nil)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	When("run configuration passed and no run name namespace", func() {
-		It("should return run configuration artifacts", func() {
-			rc := pipelineshub.RandomRunConfiguration(common.RandomNamespacedName())
-			rcName := &common.NamespacedName{
-				Namespace: rc.Namespace,
-				Name:      rc.Name,
-			}
-			fakeClient := fake.NewClientBuilder().WithScheme(schemeWithCRDs()).WithObjects(rc).Build()
-			outputArtifacts, err := extractResourceArtifacts(ctx, fakeClient, rcName, nil)
-			Expect(err).NotTo(HaveOccurred())
-			checkOutputArtifacts(outputArtifacts, rc.Spec.Run.Artifacts)
-		})
-	})
-
-	When("run passed and no run configuration", func() {
-		It("should return run artifacts", func() {
-			run := pipelineshub.RandomRun(common.RandomNamespacedName())
-			rName := &common.NamespacedName{
-				Namespace: run.Namespace,
-				Name:      run.Name,
-			}
-			fakeClient := fake.NewClientBuilder().WithScheme(schemeWithCRDs()).WithObjects(run).Build()
-			outputArtifacts, err := extractResourceArtifacts(ctx, fakeClient, nil, rName)
-			Expect(err).NotTo(HaveOccurred())
-			checkOutputArtifacts(outputArtifacts, run.Spec.Artifacts)
-		})
-	})
-
-	When("both run configuration and run passed", func() {
-		It("should return run configuration artifacts", func() {
-			rc := pipelineshub.RandomRunConfiguration(common.RandomNamespacedName())
-			run := pipelineshub.RandomRun(common.RandomNamespacedName())
-			rName := &common.NamespacedName{
-				Namespace: run.Namespace,
-				Name:      run.Name,
-			}
-			rcName := &common.NamespacedName{
-				Namespace: rc.Namespace,
-				Name:      rc.Name,
-			}
-
-			fakeClient := fake.NewClientBuilder().WithScheme(schemeWithCRDs()).WithObjects(rc, run).Build()
-			outputArtifacts, err := extractResourceArtifacts(ctx, fakeClient, rcName, rName)
-			Expect(err).NotTo(HaveOccurred())
-
-			checkOutputArtifacts(outputArtifacts, rc.Spec.Run.Artifacts)
-		})
-	})
-})
+	}
+	return filteredArtifacts
+}

--- a/controllers/webhook/runcompletion_event_handler.go
+++ b/controllers/webhook/runcompletion_event_handler.go
@@ -5,5 +5,5 @@ import (
 )
 
 type RunCompletionEventHandler interface {
-	Handle(event common.RunCompletionEvent) error
+	Handle(event common.RunCompletionEvent) EventError
 }

--- a/controllers/webhook/runcompletion_event_handler.go
+++ b/controllers/webhook/runcompletion_event_handler.go
@@ -1,9 +1,10 @@
 package webhook
 
 import (
+	"context"
 	"github.com/sky-uk/kfp-operator/argo/common"
 )
 
 type RunCompletionEventHandler interface {
-	Handle(event common.RunCompletionEvent) EventError
+	Handle(ctx context.Context, event common.RunCompletionEvent) EventError
 }

--- a/controllers/webhook/runcompletion_event_trigger.go
+++ b/controllers/webhook/runcompletion_event_trigger.go
@@ -20,7 +20,7 @@ type RunCompletionEventTrigger struct {
 	ctx               context.Context
 }
 
-func NewRuntimeCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint) RunCompletionEventTrigger {
+func NewRunCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint) RunCompletionEventTrigger {
 	logger := log.FromContext(ctx)
 
 	conn, err := grpc.NewClient(endpoint.URL(), grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/controllers/webhook/runcompletion_event_trigger.go
+++ b/controllers/webhook/runcompletion_event_trigger.go
@@ -45,13 +45,17 @@ func NewRunCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint)
 	}
 }
 
-func (rcet RunCompletionEventTrigger) Handle(event common.RunCompletionEvent) error {
+func (rcet RunCompletionEventTrigger) Handle(event common.RunCompletionEvent) EventError {
 	runCompletionEvent, err := RunCompletionEventToProto(event)
 	if err != nil {
-		return err
+		return &InvalidEvent{err.Error()}
 	}
 	_, err = rcet.Client.ProcessEventFeed(rcet.ctx, runCompletionEvent)
-	return err
+	if err != nil {
+		return &FatalError{err.Error()}
+	}
+
+	return nil
 }
 
 func RunCompletionEventToProto(event common.RunCompletionEvent) (*pb.RunCompletionEvent, error) {
@@ -84,7 +88,7 @@ func RunCompletionEventToProto(event common.RunCompletionEvent) (*pb.RunCompleti
 		Status:                statusToProto(event.Status),
 	}
 
-	return &runCompletionEvent, err
+	return &runCompletionEvent, nil
 }
 
 func artifactToProto(commonArtifacts []common.Artifact) []*pb.Artifact {

--- a/controllers/webhook/runcompletion_event_trigger.go
+++ b/controllers/webhook/runcompletion_event_trigger.go
@@ -17,7 +17,6 @@ type RunCompletionEventTrigger struct {
 	EndPoint          config.Endpoint
 	Client            pb.RunCompletionEventTriggerClient
 	ConnectionHandler func() error
-	ctx               context.Context
 }
 
 func NewRunCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint) RunCompletionEventTrigger {
@@ -41,16 +40,15 @@ func NewRunCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint)
 			}
 			return nil
 		},
-		ctx: ctx,
 	}
 }
 
-func (rcet RunCompletionEventTrigger) Handle(event common.RunCompletionEvent) EventError {
+func (rcet RunCompletionEventTrigger) Handle(ctx context.Context, event common.RunCompletionEvent) EventError {
 	runCompletionEvent, err := RunCompletionEventToProto(event)
 	if err != nil {
 		return &InvalidEvent{err.Error()}
 	}
-	_, err = rcet.Client.ProcessEventFeed(rcet.ctx, runCompletionEvent)
+	_, err = rcet.Client.ProcessEventFeed(ctx, runCompletionEvent)
 	if err != nil {
 		return &FatalError{err.Error()}
 	}

--- a/controllers/webhook/runcompletion_event_trigger_unit_test.go
+++ b/controllers/webhook/runcompletion_event_trigger_unit_test.go
@@ -63,7 +63,7 @@ var _ = Context("Handle", func() {
 			}
 
 			err := trigger.Handle(rce)
-			Expect(err).To(Equal(testError))
+			Expect(err).To(Equal(&FatalError{testError.Error()}))
 		})
 	})
 })

--- a/controllers/webhook/runcompletion_event_trigger_unit_test.go
+++ b/controllers/webhook/runcompletion_event_trigger_unit_test.go
@@ -5,6 +5,8 @@ package webhook
 import (
 	"context"
 	"errors"
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,6 +25,9 @@ func (pef ProcessEventFeedFunc) ProcessEventFeed(ctx context.Context, in *pb.Run
 
 var _ = Context("Handle", func() {
 	When("called", func() {
+		logger, _ := common.NewLogger(zapcore.DebugLevel)
+		ctx := logr.NewContext(context.Background(), logger)
+
 		rce := RandomRunCompletionEventData().ToRunCompletionEvent()
 		protoRce, _ := RunCompletionEventToProto(rce)
 
@@ -42,7 +47,7 @@ var _ = Context("Handle", func() {
 				ConnectionHandler: func() error { return nil },
 			}
 
-			err := trigger.Handle(rce)
+			err := trigger.Handle(ctx, rce)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -62,7 +67,7 @@ var _ = Context("Handle", func() {
 				ConnectionHandler: func() error { return nil },
 			}
 
-			err := trigger.Handle(rce)
+			err := trigger.Handle(ctx, rce)
 			Expect(err).To(Equal(&FatalError{testError.Error()}))
 		})
 	})

--- a/controllers/webhook/runcompletion_feed.go
+++ b/controllers/webhook/runcompletion_feed.go
@@ -36,6 +36,7 @@ func NewRunCompletionFeed(
 	eventProcessor := NewResourceArtifactsEventProcessor()
 	return RunCompletionFeed{
 		ctx:            ctx,
+		client:         client,
 		eventProcessor: eventProcessor,
 		eventHandlers:  handlers,
 	}

--- a/controllers/webhook/runcompletion_feed_decoupled_test.go
+++ b/controllers/webhook/runcompletion_feed_decoupled_test.go
@@ -56,10 +56,9 @@ func (m MockRCEHandler) Handle(_ context.Context, event common.RunCompletionEven
 func schemeWithCRDs() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
-	groupVersion := schema.GroupVersion{Group: "pipelines.kubeflow.org", Version: "v1beta1"}
-	scheme.AddKnownTypes(groupVersion, &pipelineshub.RunConfiguration{}, &pipelineshub.Run{})
+	scheme.AddKnownTypes(pipelineshub.GroupVersion, &pipelineshub.RunConfiguration{}, &pipelineshub.Run{})
 
-	metav1.AddToGroupVersion(scheme, groupVersion)
+	metav1.AddToGroupVersion(scheme, pipelineshub.GroupVersion)
 	return scheme
 }
 

--- a/controllers/webhook/runcompletion_feed_decoupled_test.go
+++ b/controllers/webhook/runcompletion_feed_decoupled_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sky-uk/kfp-operator/argo/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/controllers/webhook/runcompletion_feed_unit_test.go
+++ b/controllers/webhook/runcompletion_feed_unit_test.go
@@ -45,14 +45,14 @@ var _ = Context("getRequestBody", func() {
 var _ = Context("extractRunCompletionEventData", func() {
 	logger, _ := common.NewLogger(zapcore.DebugLevel)
 	ctx := logr.NewContext(context.Background(), logger)
-	rcf := RunCompletionFeed{ctx: ctx}
+	rcf := RunCompletionFeed{}
 
 	When("passed a valid request", func() {
 		It("returns RunCompletionEventData", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("{\"hello\":\"world\"}")))
 			Expect(err).NotTo(HaveOccurred())
 
-			eventData, err := rcf.extractRunCompletionEventData(req)
+			eventData, err := rcf.extractRunCompletionEventData(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(eventData).To(Equal(&common.RunCompletionEventData{}))
@@ -63,7 +63,7 @@ var _ = Context("extractRunCompletionEventData", func() {
 		It("returns an error", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("")))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEventData(req)
+			_, err = rcf.extractRunCompletionEventData(ctx, req)
 			Expect(err.Error()).To(Equal("request body is empty"))
 		})
 	})
@@ -72,7 +72,7 @@ var _ = Context("extractRunCompletionEventData", func() {
 		It("returns an error", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("hello world")))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEventData(req)
+			_, err = rcf.extractRunCompletionEventData(ctx, req)
 			Expect(err.Error()).To(Equal("invalid character 'h' looking for beginning of value"))
 		})
 	})

--- a/controllers/webhook/runcompletion_feed_unit_test.go
+++ b/controllers/webhook/runcompletion_feed_unit_test.go
@@ -5,7 +5,6 @@ package webhook
 import (
 	"bytes"
 	"context"
-	"errors"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,69 +42,37 @@ var _ = Context("getRequestBody", func() {
 	})
 })
 
-var _ = Context("extractRunCompletionEvent", func() {
+var _ = Context("extractRunCompletionEventData", func() {
 	logger, _ := common.NewLogger(zapcore.DebugLevel)
 	ctx := logr.NewContext(context.Background(), logger)
 	rcf := RunCompletionFeed{ctx: ctx}
 
-	When("valid request", func() {
-		It("returns event data in raw json and headers", func() {
-			processor := StubbedEventProcessor{
-				returnedRunCompletionEvent: &common.RunCompletionEvent{},
-				expectedError:              nil,
-			}
-			rcf.eventProcessor = processor
-
+	When("passed a valid request", func() {
+		It("returns RunCompletionEventData", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("{\"hello\":\"world\"}")))
 			Expect(err).NotTo(HaveOccurred())
 
-			event, err := rcf.extractRunCompletionEvent(req)
+			eventData, err := rcf.extractRunCompletionEventData(req)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(event).To(Equal(processor.returnedRunCompletionEvent))
-		})
-
-		It("returns error on event processor error", func() {
-			processor := StubbedEventProcessor{
-				returnedRunCompletionEvent: &common.RunCompletionEvent{},
-				expectedError:              errors.New("an error occurred"),
-			}
-			rcf.eventProcessor = processor
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("{\"hello\":\"world\"}")))
-			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEvent(req)
-			Expect(err).To(MatchError("an error occurred"))
-		})
-
-		It("returns error on event processor return empty event", func() {
-			processor := StubbedEventProcessor{
-				returnedRunCompletionEvent: nil,
-				expectedError:              nil,
-			}
-			rcf.eventProcessor = processor
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("{\"hello\":\"world\"}")))
-			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEvent(req)
-			Expect(err).To(MatchError("event data is empty"))
+			Expect(eventData).To(Equal(&common.RunCompletionEventData{}))
 		})
 	})
 
-	When("empty body passed", func() {
+	When("passed a request with empty body", func() {
 		It("returns an error", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("")))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEvent(req)
+			_, err = rcf.extractRunCompletionEventData(req)
 			Expect(err.Error()).To(Equal("request body is empty"))
 		})
 	})
 
-	When("invalid body passed", func() {
+	When("passed a request with invalid body", func() {
 		It("returns an error", func() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/events", bytes.NewReader([]byte("hello world")))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = rcf.extractRunCompletionEvent(req)
+			_, err = rcf.extractRunCompletionEventData(req)
 			Expect(err.Error()).To(Equal("invalid character 'h' looking for beginning of value"))
 		})
 	})

--- a/controllers/webhook/status_updater.go
+++ b/controllers/webhook/status_updater.go
@@ -95,7 +95,6 @@ func (su StatusUpdater) completeRun(event argocommon.RunCompletionEvent) error {
 				"Action",
 				"Get",
 			)
-			return nil
 		}
 		return err
 	}
@@ -156,7 +155,6 @@ func (su StatusUpdater) completeRunConfiguration(
 				"Action",
 				"Get",
 			)
-			return nil
 		}
 		return err
 	}

--- a/controllers/webhook/status_updater.go
+++ b/controllers/webhook/status_updater.go
@@ -48,15 +48,13 @@ func NewStatusUpdater(ctx context.Context, scheme *runtime.Scheme) (StatusUpdate
 }
 
 func (su StatusUpdater) Handle(ctx context.Context, event argocommon.RunCompletionEvent) EventError {
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithValues("RunId", event.RunId)
 
 	if event.RunName != nil {
 		if err := su.completeRun(ctx, event); err != nil {
 			if errors.IsNotFound(err) {
 				logger.Info(
 					"RunCompletionEvent's Run was not found. Skipping.",
-					"RunId",
-					event.RunId,
 					"RunName",
 					event.RunName,
 					"Action",
@@ -72,8 +70,6 @@ func (su StatusUpdater) Handle(ctx context.Context, event argocommon.RunCompleti
 			if errors.IsNotFound(err) {
 				logger.Info(
 					"RunCompletionEvent's RunConfiguration was not found. Skipping.",
-					"RunId",
-					event.RunId,
 					"RunConfigurationName",
 					event.RunConfigurationName,
 					"Action",

--- a/controllers/webhook/status_updater_unit_test.go
+++ b/controllers/webhook/status_updater_unit_test.go
@@ -44,7 +44,7 @@ var _ = Context("Handle", func() {
 				WithScheme(scheme).
 				WithStatusSubresource(&pipelineshub.Run{}).
 				Build()
-			updater = StatusUpdater{ctx, client}
+			updater = StatusUpdater{client}
 		})
 
 		When("Run resource is found", func() {
@@ -52,7 +52,7 @@ var _ = Context("Handle", func() {
 				err = client.Create(context.Background(), &run)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = client.Get(ctx, run.GetNamespacedName(), &run)
@@ -64,7 +64,7 @@ var _ = Context("Handle", func() {
 
 		When("Run resource is not found", func() {
 			It("should return a MissingResourceError", func() {
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				var expectedErr *MissingResourceError
 				Expect(errors.As(err, &expectedErr)).To(BeTrue())
 			})
@@ -77,7 +77,7 @@ var _ = Context("Handle", func() {
 
 				expectedState := run.Status.CompletionState
 				rce.RunName.Namespace = ""
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = client.Get(ctx, run.GetNamespacedName(), &run)
@@ -90,10 +90,10 @@ var _ = Context("Handle", func() {
 		When("k8s client operation fails", func() {
 			It("should return error", func() {
 				client = fake.NewClientBuilder().Build()
-				updater = StatusUpdater{ctx, client}
+				updater = StatusUpdater{client}
 				name := common.RandomNamespacedName()
 				rce.RunName = &name
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -109,7 +109,7 @@ var _ = Context("Handle", func() {
 				WithScheme(scheme).
 				WithStatusSubresource(&pipelineshub.RunConfiguration{}).
 				Build()
-			updater = StatusUpdater{ctx, client}
+			updater = StatusUpdater{client}
 
 			rce.Status = common.RunCompletionStatuses.Succeeded
 
@@ -124,7 +124,7 @@ var _ = Context("Handle", func() {
 				err = client.Create(context.Background(), &rc)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = client.Get(ctx, rc.GetNamespacedName(), &rc)
@@ -141,7 +141,7 @@ var _ = Context("Handle", func() {
 				expectedProviderId := rc.Status.LatestRuns.Succeeded.ProviderId
 				expectedArtifacts := rc.Status.LatestRuns.Succeeded.Artifacts
 
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				var expectedErr *MissingResourceError
 				Expect(errors.As(err, &expectedErr)).To(BeTrue())
 
@@ -159,7 +159,7 @@ var _ = Context("Handle", func() {
 				expectedArtifacts := rc.Status.LatestRuns.Succeeded.Artifacts
 
 				rce.Status = common.RunCompletionStatuses.Failed
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(rc.Status.LatestRuns.Succeeded.ProviderId).
@@ -179,7 +179,7 @@ var _ = Context("Handle", func() {
 				rce.Status = common.RunCompletionStatuses.Failed
 				err = client.Create(context.Background(), &rc)
 
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(rc.Status.LatestRuns.Succeeded.ProviderId).
@@ -193,10 +193,10 @@ var _ = Context("Handle", func() {
 		When("k8s client operation fails", func() {
 			It("should return error", func() {
 				client = fake.NewClientBuilder().Build()
-				updater = StatusUpdater{ctx, client}
+				updater = StatusUpdater{client}
 				name := common.RandomNamespacedName()
 				rce.RunConfigurationName = &name
-				err = updater.Handle(rce)
+				err = updater.Handle(ctx, rce)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/controllers/webhook/test_utils.go
+++ b/controllers/webhook/test_utils.go
@@ -3,22 +3,23 @@
 package webhook
 
 import (
-	"context"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
+	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/argo/common"
 )
 
 type StubbedEventProcessor struct {
 	expectedRunCompletionEventData *common.RunCompletionEventData
 	returnedRunCompletionEvent     *common.RunCompletionEvent
-	expectedError                  error
+	expectedError                  EventError
 }
 
-func (sep StubbedEventProcessor) ToRunCompletionEvent(_ context.Context, passedData common.RunCompletionEventData) (*common.RunCompletionEvent, error) {
+func (sep StubbedEventProcessor) ToRunCompletionEvent(eventData *common.RunCompletionEventData, runConfiguration *pipelineshub.RunConfiguration, run *pipelineshub.Run) (*common.RunCompletionEvent, EventError) {
 	if sep.expectedRunCompletionEventData != nil {
-		Expect(passedData).To(Equal(*sep.expectedRunCompletionEventData))
+		Expect(eventData).To(Equal(sep.expectedRunCompletionEventData))
 	}
+
 	return sep.returnedRunCompletionEvent, sep.expectedError
 }
 

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func main() {
 	handlers := apis.Map(
 		ctrlConfig.Spec.RunCompletionFeed.Endpoints,
 		func(endpoint config.Endpoint) webhook.RunCompletionEventHandler {
-			return webhook.NewRuntimeCompletionEventTrigger(ctx, endpoint)
+			return webhook.NewRunCompletionEventTrigger(ctx, endpoint)
 		},
 	)
 	statusUpdater, err := webhook.NewStatusUpdater(ctx, scheme)

--- a/main.go
+++ b/main.go
@@ -223,12 +223,11 @@ func main() {
 	}
 	handlers = append(handlers, statusUpdater)
 	rcf := webhook.NewRunCompletionFeed(
-		ctx,
 		client.NonCached,
 		handlers,
 	)
 	go func() {
-		err = rcf.Start(ctrlConfig.Spec.RunCompletionFeed.Port)
+		err = rcf.Start(ctx, ctrlConfig.Spec.RunCompletionFeed.Port)
 		if err != nil {
 			setupLog.Error(err, "problem starting run completion feed")
 			os.Exit(1)

--- a/provider-service/base/pkg/stream_message.go
+++ b/provider-service/base/pkg/stream_message.go
@@ -3,8 +3,9 @@ package pkg
 import _ "github.com/sky-uk/kfp-operator/argo/common"
 
 type OnCompleteHandlers struct {
-	OnSuccessHandler func()
-	OnFailureHandler func()
+	OnSuccessHandler              func()
+	OnRecoverableFailureHandler   func()
+	OnUnrecoverableFailureHandler func()
 }
 
 func (onc OnCompleteHandlers) OnSuccess() {
@@ -13,9 +14,15 @@ func (onc OnCompleteHandlers) OnSuccess() {
 	}
 }
 
-func (onc OnCompleteHandlers) OnFailure() {
-	if onc.OnFailureHandler != nil {
-		onc.OnFailureHandler()
+func (onc OnCompleteHandlers) OnRecoverableFailure() {
+	if onc.OnRecoverableFailureHandler != nil {
+		onc.OnRecoverableFailureHandler()
+	}
+}
+
+func (onc OnCompleteHandlers) OnUnrecoverableFailure() {
+	if onc.OnUnrecoverableFailureHandler != nil {
+		onc.OnUnrecoverableFailureHandler()
 	}
 }
 

--- a/provider-service/base/pkg/streams/sinks/webhook_sink.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink.go
@@ -12,16 +12,15 @@ import (
 )
 
 type WebhookSink struct {
-	ctx             context.Context
 	client          *resty.Client
 	operatorWebhook string
 	in              chan StreamMessage[*common.RunCompletionEventData]
 }
 
 func NewWebhookSink(ctx context.Context, client *resty.Client, operatorWebhook string, inChan chan StreamMessage[*common.RunCompletionEventData]) *WebhookSink {
-	webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: operatorWebhook, in: inChan}
+	webhookSink := &WebhookSink{client: client, operatorWebhook: operatorWebhook, in: inChan}
 
-	go webhookSink.SendEvents()
+	go webhookSink.SendEvents(ctx)
 
 	return webhookSink
 }
@@ -30,8 +29,8 @@ func (hws WebhookSink) In() chan<- StreamMessage[*common.RunCompletionEventData]
 	return hws.in
 }
 
-func (hws WebhookSink) SendEvents() {
-	logger := common.LoggerFromContext(hws.ctx)
+func (hws WebhookSink) SendEvents(ctx context.Context) {
+	logger := common.LoggerFromContext(ctx)
 	for message := range hws.in {
 		if message.Message != nil {
 			err, response := hws.send(*message.Message)

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_decoupled_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_decoupled_test.go
@@ -37,7 +37,7 @@ func createContextWithLogger(logger logr.Logger) (ctx context.Context, cancel co
 type StubRCEHandler struct {
 }
 
-func (m StubRCEHandler) Handle(_ common.RunCompletionEvent) webhook.EventError {
+func (m StubRCEHandler) Handle(_ context.Context, _ common.RunCompletionEvent) webhook.EventError {
 	return nil
 }
 
@@ -81,12 +81,11 @@ var _ = Context("Webhook Sink", Ordered, func() {
 		handlers = append(handlers, stubHandler)
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rc).Build()
 		rcf := webhook.NewRunCompletionFeed(
-			ctx,
 			fakeClient,
 			handlers,
 		)
 		go func() {
-			err = rcf.Start(port)
+			err = rcf.Start(ctx, port)
 			if err != nil {
 				logger.Error(err, "problem starting run completion feed")
 				panic(err)

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_decoupled_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_decoupled_test.go
@@ -37,7 +37,7 @@ func createContextWithLogger(logger logr.Logger) (ctx context.Context, cancel co
 type StubRCEHandler struct {
 }
 
-func (m StubRCEHandler) Handle(_ common.RunCompletionEvent) error {
+func (m StubRCEHandler) Handle(_ common.RunCompletionEvent) webhook.EventError {
 	return nil
 }
 

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
@@ -49,9 +49,9 @@ var _ = Context("SendEvents", func() {
 			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(http.StatusOK, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
-			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+			webhookSink := &WebhookSink{client: client, operatorWebhook: webhookUrl, in: in}
 
-			go webhookSink.SendEvents()
+			go webhookSink.SendEvents(ctx)
 
 			streamMessage := StreamMessage[*common.RunCompletionEventData]{
 				Message:            &runCompletionEventData,
@@ -73,9 +73,9 @@ var _ = Context("SendEvents", func() {
 			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(recoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
-			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+			webhookSink := &WebhookSink{client: client, operatorWebhook: webhookUrl, in: in}
 
-			go webhookSink.SendEvents()
+			go webhookSink.SendEvents(ctx)
 
 			streamMessage := StreamMessage[*common.RunCompletionEventData]{
 				Message:            &runCompletionEventData,
@@ -97,9 +97,9 @@ var _ = Context("SendEvents", func() {
 			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(unrecoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
-			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+			webhookSink := &WebhookSink{client: client, operatorWebhook: webhookUrl, in: in}
 
-			go webhookSink.SendEvents()
+			go webhookSink.SendEvents(ctx)
 
 			streamMessage := StreamMessage[*common.RunCompletionEventData]{
 				Message:            &runCompletionEventData,

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
@@ -46,7 +46,7 @@ var _ = Context("SendEvents", func() {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
-			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(http.StatusOK, ""))
+			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(http.StatusOK, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
 			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
@@ -70,7 +70,7 @@ var _ = Context("SendEvents", func() {
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
 			recoverableResponseCode := http.StatusInternalServerError
-			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(recoverableResponseCode, ""))
+			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(recoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
 			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
@@ -83,7 +83,7 @@ var _ = Context("SendEvents", func() {
 			}
 			in <- streamMessage
 
-			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", webhookUrl)] }).Should(Equal(1))
+			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("%s %s", http.MethodPost, webhookUrl)] }).Should(Equal(1))
 			Eventually(handlerCall).Should(Receive(Equal("recoverable_failure_called")))
 		})
 	})
@@ -94,7 +94,7 @@ var _ = Context("SendEvents", func() {
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
 			unrecoverableResponseCode := http.StatusGone
-			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(unrecoverableResponseCode, ""))
+			httpmock.RegisterResponder(http.MethodPost, webhookUrl, httpmock.NewStringResponder(unrecoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
 			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
@@ -107,7 +107,7 @@ var _ = Context("SendEvents", func() {
 			}
 			in <- streamMessage
 
-			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", webhookUrl)] }).Should(Equal(1))
+			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("%s %s", http.MethodPost, webhookUrl)] }).Should(Equal(1))
 			Eventually(handlerCall).Should(Receive(Equal("unrecoverable_failure_called")))
 		})
 	})

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	resty "github.com/go-resty/resty/v2"
+	"github.com/go-resty/resty/v2"
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,7 +69,7 @@ var _ = Context("SendEvents", func() {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
-			recoverableResponseCode := 500
+			recoverableResponseCode := http.StatusInternalServerError
 			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(recoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
@@ -93,7 +93,7 @@ var _ = Context("SendEvents", func() {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
-			unrecoverableResponseCode := 410
+			unrecoverableResponseCode := http.StatusGone
 			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(unrecoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])

--- a/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
+++ b/provider-service/base/pkg/streams/sinks/webhook_sink_unit_test.go
@@ -5,6 +5,9 @@ package sinks
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"testing"
+
 	"github.com/go-logr/logr"
 	resty "github.com/go-resty/resty/v2"
 	"github.com/jarcoal/httpmock"
@@ -13,7 +16,6 @@ import (
 	"github.com/sky-uk/kfp-operator/argo/common"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg"
 	"go.uber.org/zap/zapcore"
-	"testing"
 )
 
 func TestSinksUnitSuite(t *testing.T) {
@@ -31,20 +33,23 @@ var _ = Context("SendEvents", func() {
 		OnSuccessHandler: func() {
 			handlerCall <- "success_called"
 		},
-		OnFailureHandler: func() {
-			handlerCall <- "failure_called"
+		OnRecoverableFailureHandler: func() {
+			handlerCall <- "recoverable_failure_called"
+		},
+		OnUnrecoverableFailureHandler: func() {
+			handlerCall <- "unrecoverable_failure_called"
 		},
 	}
 
-	When("webhook sink receives a valid StreamMessage", func() {
-		It("sends RunCompletionEventData to the webhook successfully and triggers the message OnSuccessHandler", func() {
+	When("receives an http OK response code after sending a message to the webhook server", func() {
+		It("should call the message's OnSuccessHandler", func() {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
-			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(200, ""))
+			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(http.StatusOK, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
-			webhookSink := &WebhookSink{context: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
 
 			go webhookSink.SendEvents()
 
@@ -59,16 +64,16 @@ var _ = Context("SendEvents", func() {
 		})
 	})
 
-	When("webhook sink receives an invalid StreamMessage", func() {
-		It("should call its `OnFailureHandler` function", func() {
+	When("receives a recoverable error response from webhook server", func() {
+		It("should call the message's OnRecoverableFailureHandler", func() {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			webhookUrl := "/operator-webhook"
-			someNon200ResponseCode := 500
-			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(someNon200ResponseCode, ""))
+			recoverableResponseCode := 500
+			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(recoverableResponseCode, ""))
 
 			in := make(chan StreamMessage[*common.RunCompletionEventData])
-			webhookSink := &WebhookSink{context: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
 
 			go webhookSink.SendEvents()
 
@@ -79,7 +84,31 @@ var _ = Context("SendEvents", func() {
 			in <- streamMessage
 
 			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", webhookUrl)] }).Should(Equal(1))
-			Eventually(handlerCall).Should(Receive(Equal("failure_called")))
+			Eventually(handlerCall).Should(Receive(Equal("recoverable_failure_called")))
+		})
+	})
+
+	When("receives an unrecoverable error response from the webhook server", func() {
+		It("should call the message's OnUnrecoverableFailureHandler", func() {
+			client := resty.New()
+			httpmock.ActivateNonDefault(client.GetClient())
+			webhookUrl := "/operator-webhook"
+			unrecoverableResponseCode := 410
+			httpmock.RegisterResponder("POST", webhookUrl, httpmock.NewStringResponder(unrecoverableResponseCode, ""))
+
+			in := make(chan StreamMessage[*common.RunCompletionEventData])
+			webhookSink := &WebhookSink{ctx: ctx, client: client, operatorWebhook: webhookUrl, in: in}
+
+			go webhookSink.SendEvents()
+
+			streamMessage := StreamMessage[*common.RunCompletionEventData]{
+				Message:            &runCompletionEventData,
+				OnCompleteHandlers: onCompHandlers,
+			}
+			in <- streamMessage
+
+			Eventually(func() int { return httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", webhookUrl)] }).Should(Equal(1))
+			Eventually(handlerCall).Should(Receive(Equal("unrecoverable_failure_called")))
 		})
 	})
 })

--- a/provider-service/base/pkg/streams/sources/pub_sub_source.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source.go
@@ -96,8 +96,6 @@ func (pss *PubSubSource) subscribe(ctx context.Context, runsSubscription *pubsub
 			pss.Logger.Info("stopped reading from pubsub")
 			return
 		}
-
-		msg.Nack()
 	})
 
 	if err != nil {

--- a/provider-service/base/pkg/streams/sources/pub_sub_source.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source.go
@@ -87,14 +87,17 @@ func (pss *PubSubSource) subscribe(ctx context.Context, runsSubscription *pubsub
 		case pss.out <- StreamMessage[string]{
 			Message: pipelineJobId,
 			OnCompleteHandlers: OnCompleteHandlers{
-				OnSuccessHandler: func() { msg.Ack() },
-				OnFailureHandler: func() { msg.Nack() },
+				OnSuccessHandler:              func() { msg.Ack() },
+				OnRecoverableFailureHandler:   func() { msg.Nack() },
+				OnUnrecoverableFailureHandler: func() { msg.Ack() },
 			},
 		}:
 		case <-ctx.Done():
 			pss.Logger.Info("stopped reading from pubsub")
 			return
 		}
+
+		msg.Nack()
 	})
 
 	if err != nil {

--- a/provider-service/base/pkg/streams/sources/pub_sub_source_integration_test.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source_integration_test.go
@@ -24,6 +24,8 @@ const (
 	pubsubSubscriptionName = "some_subscription"
 	pubsubProject          = "some_project"
 	pubsubHost             = "localhost:8085"
+	maxDeliveryAttempts    = 5
+	retryTimeout           = time.Second
 )
 
 func TestSourcesIntegrationSuite(t *testing.T) {
@@ -123,7 +125,44 @@ var _ = Context("Pub sub source", Ordered, func() {
 				sendMessage(ctx, topic, pipelineId, jsonMessage)
 
 				msg := <-source.Out()
+				msg.OnSuccess()
 				Expect(msg.Message).To(Equal(pipelineId))
+
+				time.Sleep(retryTimeout * 2)
+
+				select {
+				case _ = <-source.Out():
+					Fail("second message received")
+				default:
+					Succeed()
+				}
+			})
+		})
+
+		When("a streamed message is valid but fails upstream with a unrecoverable error", func() {
+			It("should be ack'd", func() {
+				pipelineId := "valid_message_unrecoverable_error_ack_check"
+
+				topic, _, _ := createClientTopicSubscription(ctx, pipelineId, pipelineId)
+				source := createPubSubSource(ctx, pipelineId)
+
+				message := LogEntry{
+					Resource: Resource{
+						Labels: map[string]string{
+							PipelineJobLabel: pipelineId,
+						}},
+				}
+
+				jsonMessage, err := json.Marshal(message)
+				Expect(err).NotTo(HaveOccurred())
+
+				sendMessage(ctx, topic, pipelineId, jsonMessage)
+
+				msg := <-source.Out()
+				msg.OnUnrecoverableFailureHandler()
+				Expect(msg.Message).To(Equal(pipelineId))
+
+				time.Sleep(retryTimeout)
 
 				select {
 				case _ = <-source.Out():
@@ -136,7 +175,7 @@ var _ = Context("Pub sub source", Ordered, func() {
 
 		When("a streamed message is valid but fails upstream with a recoverable error", func() {
 			It("should be nack'd", func() {
-				pipelineId := "valid_message_nack_check"
+				pipelineId := "valid_message_recoverable_error_nack_check"
 
 				topic, _, deadletterSub := createClientTopicSubscription(ctx, pipelineId, pipelineId)
 				source := createPubSubSource(appCtx, pipelineId)
@@ -151,31 +190,36 @@ var _ = Context("Pub sub source", Ordered, func() {
 				jsonMessage, err := json.Marshal(message)
 				Expect(err).NotTo(HaveOccurred())
 
-				deadMessages := false
+				deadletterOut := make(chan *pubsub.Message, 1)
 				go func() {
 					_ = deadletterSub.Receive(ctx, func(ctx context.Context, message *pubsub.Message) {
 						Expect(message.Data).To(Equal(jsonMessage))
-						deadMessages = true
+						deadletterOut <- message
 						return
 					})
 				}()
 
 				sendMessage(ctx, topic, pipelineId, jsonMessage)
 
-				timeout := 2 * time.Second
 				counter := 0
-				for i := 0; i < 6; i++ {
+				for i := 0; i <= maxDeliveryAttempts; i++ {
 					select {
 					case msg := <-source.Out():
+						counter++
 						msg.OnRecoverableFailure()
-						counter = counter + 1
-					case <-time.After(timeout):
+					case <-time.After(retryTimeout * (maxDeliveryAttempts + 1)):
 						break
 					}
 				}
 
-				Expect(counter).To(Equal(5))
-				Expect(deadMessages).To(BeTrue())
+				Expect(counter).To(Equal(maxDeliveryAttempts))
+
+				select {
+				case msg := <-deadletterOut:
+					Expect(msg.Data).To(Equal(jsonMessage))
+				case <-time.After(10 * time.Second):
+					Fail("dead letter message not received")
+				}
 			})
 		})
 
@@ -192,28 +236,29 @@ var _ = Context("Pub sub source", Ordered, func() {
 				jsonMessage, err := json.Marshal(message)
 				Expect(err).NotTo(HaveOccurred())
 
-				deadMessages := false
+				deadletterOut := make(chan *pubsub.Message, 1)
 				go func() {
 					_ = deadletterSub.Receive(ctx, func(ctx context.Context, message *pubsub.Message) {
-						deadMessages = true
-						Expect(message.Data).To(Equal(jsonMessage))
+						deadletterOut <- message
 						return
 					})
 				}()
 
 				sendMessage(ctx, topic, pipelineId, jsonMessage)
 
-				time.Sleep(2 * time.Second)
-				appCancel()
-
-				Expect(deadMessages).To(BeTrue())
+				select {
+				case msg := <-deadletterOut:
+					Expect(msg.Data).To(Equal(jsonMessage))
+				case <-time.After(10 * time.Second):
+					Fail("dead letter message not received")
+				}
 			})
 		})
 	})
 })
 
 func createContextWithLogger(logger logr.Logger) (ctx context.Context, cancel context.CancelFunc) {
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), time.Duration(5000)*time.Millisecond)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), time.Duration(10000)*time.Millisecond)
 	ctxWithLogger := logr.NewContext(ctxWithTimeout, logger)
 	return ctxWithLogger, cancel
 }
@@ -237,7 +282,14 @@ func createTopicIfNotExists(ctx context.Context, client *pubsub.Client, topicNam
 	return topic
 }
 
-func createSubIfNotExists(ctx context.Context, client *pubsub.Client, subscriptionName string, topic *pubsub.Topic, deadLetterPol *pubsub.DeadLetterPolicy) *pubsub.Subscription {
+func createSubIfNotExists(
+	ctx context.Context,
+	client *pubsub.Client,
+	subscriptionName string,
+	topic *pubsub.Topic,
+	deadLetterPol *pubsub.DeadLetterPolicy,
+	retryPolicy *pubsub.RetryPolicy,
+) *pubsub.Subscription {
 	subscription := client.Subscription(subscriptionName)
 	subscriptionExists, err := subscription.Exists(ctx)
 
@@ -245,6 +297,7 @@ func createSubIfNotExists(ctx context.Context, client *pubsub.Client, subscripti
 		subscription, err = client.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{
 			DeadLetterPolicy: deadLetterPol,
 			Topic:            topic,
+			RetryPolicy:      retryPolicy,
 		})
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -261,10 +314,14 @@ func createClientTopicSubscription(ctx context.Context, topicName string, subscr
 
 	subscription := createSubIfNotExists(ctx, client, subscriptionName, topic, &pubsub.DeadLetterPolicy{
 		DeadLetterTopic:     deadLetterTopic.String(),
-		MaxDeliveryAttempts: 5,
-	})
+		MaxDeliveryAttempts: maxDeliveryAttempts,
+	},
+		&pubsub.RetryPolicy{
+			MinimumBackoff: retryTimeout,
+			MaximumBackoff: retryTimeout,
+		})
 
-	deadSubscription := createSubIfNotExists(ctx, client, subscriptionName+"-deadletter", deadLetterTopic, nil)
+	deadSubscription := createSubIfNotExists(ctx, client, subscriptionName+"-deadletter", deadLetterTopic, nil, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 	topics = append(topics, topic, deadLetterTopic)

--- a/provider-service/base/pkg/streams/sources/workflow_source.go
+++ b/provider-service/base/pkg/streams/sources/workflow_source.go
@@ -124,7 +124,7 @@ func (ws *WorkflowSource) start(ctx context.Context, namespace string) error {
 						return
 					}
 				},
-				OnFailureHandler: func() {},
+				OnRecoverableFailureHandler: func() {},
 			},
 		}:
 		case <-ctx.Done():

--- a/provider-service/kfp/go.work.sum
+++ b/provider-service/kfp/go.work.sum
@@ -540,9 +540,11 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 h1:WtGNWLvXpe
 github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
 github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
+github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -788,6 +790,7 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=

--- a/provider-service/kfp/internal/event/event_decoupled_test.go
+++ b/provider-service/kfp/internal/event/event_decoupled_test.go
@@ -104,7 +104,7 @@ func WithTestContext(fun func(context.Context)) {
 	client := resty.New()
 	httpmock.ActivateNonDefault(client.GetClient())
 	httpmock.RegisterResponder(
-		"POST",
+		http.MethodPost,
 		webhookUrl,
 		func(req *http.Request) (*http.Response, error) {
 			numberOfEvents++

--- a/provider-service/kfp/internal/event/event_flow.go
+++ b/provider-service/kfp/internal/event/event_flow.go
@@ -18,7 +18,6 @@ type EventFlow struct {
 	MetadataStore  client.MetadataStore
 	KfpApi         client.KfpApi
 	Logger         logr.Logger
-	context        context.Context
 	in             chan StreamMessage[*unstructured.Unstructured]
 	out            chan StreamMessage[*common.RunCompletionEventData]
 	errorOut       chan error
@@ -78,20 +77,19 @@ func NewEventFlow(ctx context.Context, config config.KfpProviderConfig, kfpApi c
 		MetadataStore:  metadataStore,
 		KfpApi:         kfpApi,
 		Logger:         logger,
-		context:        ctx,
 		in:             make(chan StreamMessage[*unstructured.Unstructured]),
 		out:            make(chan StreamMessage[*common.RunCompletionEventData]),
 		errorOut:       make(chan error),
 	}
 
-	go flow.subscribeAndConvert()
+	go flow.subscribeAndConvert(ctx)
 
 	return flow, nil
 }
 
-func (ef *EventFlow) subscribeAndConvert() {
+func (ef *EventFlow) subscribeAndConvert(ctx context.Context) {
 	for msg := range ef.in {
-		runCompletionEvent, err := ef.toRunCompletionEventData(msg)
+		runCompletionEvent, err := ef.toRunCompletionEventData(ctx, msg)
 		if err != nil {
 			msg.OnRecoverableFailureHandler()
 			ef.errorOut <- err
@@ -101,8 +99,8 @@ func (ef *EventFlow) subscribeAndConvert() {
 	}
 }
 
-func (ef *EventFlow) toRunCompletionEventData(message StreamMessage[*unstructured.Unstructured]) (StreamMessage[*common.RunCompletionEventData], error) {
-	runCompletionEventData, err := ef.eventForWorkflow(ef.context, message.Message)
+func (ef *EventFlow) toRunCompletionEventData(ctx context.Context, message StreamMessage[*unstructured.Unstructured]) (StreamMessage[*common.RunCompletionEventData], error) {
+	runCompletionEventData, err := ef.eventForWorkflow(ctx, message.Message)
 	if err != nil {
 		message.OnRecoverableFailureHandler()
 		return StreamMessage[*common.RunCompletionEventData]{}, err

--- a/provider-service/kfp/internal/event/event_flow.go
+++ b/provider-service/kfp/internal/event/event_flow.go
@@ -93,7 +93,7 @@ func (ef *EventFlow) subscribeAndConvert() {
 	for msg := range ef.in {
 		runCompletionEvent, err := ef.toRunCompletionEventData(msg)
 		if err != nil {
-			msg.OnFailureHandler()
+			msg.OnRecoverableFailureHandler()
 			ef.errorOut <- err
 		} else {
 			ef.out <- runCompletionEvent
@@ -104,7 +104,7 @@ func (ef *EventFlow) subscribeAndConvert() {
 func (ef *EventFlow) toRunCompletionEventData(message StreamMessage[*unstructured.Unstructured]) (StreamMessage[*common.RunCompletionEventData], error) {
 	runCompletionEventData, err := ef.eventForWorkflow(ef.context, message.Message)
 	if err != nil {
-		message.OnFailureHandler()
+		message.OnRecoverableFailureHandler()
 		return StreamMessage[*common.RunCompletionEventData]{}, err
 	}
 	return StreamMessage[*common.RunCompletionEventData]{

--- a/provider-service/stub/go.work.sum
+++ b/provider-service/stub/go.work.sum
@@ -701,6 +701,7 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/minio/md5-simd v1.1.0 h1:QPfiOqlZH+Cj9teu0t9b1nTBfPbyTl16Of5MeuShdK4=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=

--- a/provider-service/vai/go.work.sum
+++ b/provider-service/vai/go.work.sum
@@ -1697,7 +1697,6 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/provider-service/vai/go.work.sum
+++ b/provider-service/vai/go.work.sum
@@ -1697,6 +1697,7 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/provider-service/vai/internal/runcompletion/event_flow.go
+++ b/provider-service/vai/internal/runcompletion/event_flow.go
@@ -90,7 +90,7 @@ func (vef *EventFlow) Start() {
 			if err != nil {
 				if status.Code(err) == codes.NotFound {
 					logger.Info("pipeline job not found", "run-id", msg.Message)
-					msg.OnSuccessHandler()
+					msg.OnUnrecoverableFailureHandler()
 					vef.errorOut <- err
 				} else {
 					logger.Info("error retrieving job", "run-id", msg.Message)

--- a/provider-service/vai/internal/runcompletion/event_flow.go
+++ b/provider-service/vai/internal/runcompletion/event_flow.go
@@ -86,7 +86,7 @@ func (vef *EventFlow) Start() {
 		logger := common.LoggerFromContext(vef.context)
 		for msg := range vef.in {
 			logger.Info("in VAI flow - received message", "message", msg.Message)
-			runCompletionEvent, err := vef.runCompletionEventDataForRun(msg.Message)
+			runCompletionEventData, err := vef.runCompletionEventDataForRun(msg.Message)
 			if err != nil {
 				if status.Code(err) == codes.NotFound {
 					logger.Info("pipeline job not found", "run-id", msg.Message)
@@ -94,12 +94,12 @@ func (vef *EventFlow) Start() {
 					vef.errorOut <- err
 				} else {
 					logger.Info("error retrieving job", "run-id", msg.Message)
-					msg.OnFailureHandler()
+					msg.OnRecoverableFailureHandler()
 					vef.errorOut <- err
 				}
 			} else {
 				vef.out <- StreamMessage[*common.RunCompletionEventData]{
-					Message:            runCompletionEvent,
+					Message:            runCompletionEventData,
 					OnCompleteHandlers: msg.OnCompleteHandlers,
 				}
 			}

--- a/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
@@ -70,7 +70,7 @@ var _ = Context("VaiEventingServer", func() {
 			OnSuccessHandler: func() {
 				handlerCall <- "success_called"
 			},
-			OnFailureHandler: func() {
+			OnRecoverableFailureHandler: func() {
 				handlerCall <- "failure_called"
 			},
 		}

--- a/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
@@ -70,8 +70,11 @@ var _ = Context("VaiEventingServer", func() {
 			OnSuccessHandler: func() {
 				handlerCall <- "success_called"
 			},
+			OnUnrecoverableFailureHandler: func() {
+				handlerCall <- "unrecoverable_failure_called"
+			},
 			OnRecoverableFailureHandler: func() {
-				handlerCall <- "failure_called"
+				handlerCall <- "recoverable_failure_called"
 			},
 		}
 	})
@@ -505,7 +508,7 @@ var _ = Context("VaiEventingServer", func() {
 
 				eventingFlow.in <- StreamMessage[string]{Message: runId, OnCompleteHandlers: onCompHandlers}
 
-				Eventually(handlerCall).Should(Receive(Equal("success_called")))
+				Eventually(handlerCall).Should(Receive(Equal("unrecoverable_failure_called")))
 				Eventually(errChan).Should(Receive(Equal(expectedErr)))
 			})
 		})
@@ -525,7 +528,7 @@ var _ = Context("VaiEventingServer", func() {
 
 				eventingFlow.in <- StreamMessage[string]{Message: runId, OnCompleteHandlers: onCompHandlers}
 
-				Eventually(handlerCall).Should(Receive(Equal("failure_called")))
+				Eventually(handlerCall).Should(Receive(Equal("recoverable_failure_called")))
 				Eventually(errChan).Should(Receive(Equal(expectedErr)))
 			})
 		})


### PR DESCRIPTION
Closes #493 

## Solution Overview

### Webhook returns 410 for missing resources

If the webhook (run completion feed http server) cannot find a resource (`Run` or `RunConfiguration`) for an event, it returns a `410` http code, indicating the resource is gone and not coming back (e.g. it's been deleted or was never in the cluster in the first place).

### Pub/Sub messages get ACKed on 410 failures

The current setup for how messages get handled in the Pub/Sub source is:
- Success: `ACK`
- Failure: `NACK`

This PR changes this setup to:
- Success: `ACK`
- Unrecoverable failure: `ACK`
- Recoverable failure: `NACK`

The only unrecoverable failure we're introducing is the `410` case so, for now, Pub/Sub messaged get `ACK`ed in the case of success or `410` and `NACK`ed otherwise. This means that Pub/Sub won't resend the message if a resource is missing, but it will in all other failure scenarios.

## Tasks

 - [ ] ~~Does the constant retry loop issue exist with the kfp provider which uses the workflow source too? And if yes, should we then implement the same behaviour there?~~
   This work is done on the shared webhook sink component so this applies to both providers
- [x] Deploy and test manually