### PR TITLE
Limit dependabot to only raise pull requests for direct dependencies and patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directories: 
+    directories:
     - "/"
     - "/common"
     - "/docs-gen"
@@ -18,3 +18,6 @@ updates:
     - "/provider-service/stub"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+        update-type: "version-update:semver-patch"


### PR DESCRIPTION
Closes #582

Limit dependabot to only raise pull requests for direct dependencies, and only target patch versions for now because most minor upgrades still require a go version upgrade (1.22.x -> 1.23.x), which is something that cannot be done yet.

