### PR TITLE
Correct the update-type setting of dependabot to be under the ignore field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,4 @@ updates:
     groups:
       only-patches:
         update-types:
-        - "version-update:semver-patch"
+        - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,8 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-type: "direct"
-        update-type: "version-update:semver-patch"
+    - dependency-type: "direct"
+    groups:
+      only-patches:
+        update-types:
+        - "version-update:semver-patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,8 @@ updates:
       interval: "weekly"
     allow:
     - dependency-type: "direct"
-    groups:
-      only-patches:
-        update-types:
-        - "patch"
+    ignore:
+    - dependency-name: "*"
+      update-types:
+      - "version-update:semver-minor"
+      - "version-update:semver-major"


### PR DESCRIPTION
Closes #582

As per the [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--), correct the update-type (invalid) setting of dependabot to be under the ignore field and call it correctly (update-types)