### PR TITLE
Set dependabot rebase-strategy to `disabled`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     - "/provider-service/stub"
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"
     allow:
     - dependency-type: "direct"
     ignore:


### PR DESCRIPTION
Closes #617

Set dependabot rebase-strategy to `disabled` to prevent a large number of pipelines being run every time something is merged.