### PR TITLE
Add new provider label to vai provider - including namespace and name

### DIFF
--- a/provider-service/vai/cmd/main.go
+++ b/provider-service/vai/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 }
 
 func runServer(ctx context.Context, vaiConfig *vaiConfig.VAIProviderConfig, baseConfig *baseConfig.Config) {
-	provider, err := vai.NewVAIProvider(ctx, vaiConfig)
+	provider, err := vai.NewVAIProvider(ctx, vaiConfig, baseConfig.Pod.Namespace)
 	if err != nil {
 		panic(err)
 	}

--- a/provider-service/vai/internal/label/label.go
+++ b/provider-service/vai/internal/label/label.go
@@ -2,6 +2,7 @@ package label
 
 const (
 	ProviderName              = "provider-name"
+	ProviderNamespace         = "provider-namespace"
 	PipelineName              = "pipeline-name"
 	PipelineNamespace         = "pipeline-namespace"
 	PipelineVersion           = "pipeline-version"

--- a/provider-service/vai/internal/label/label.go
+++ b/provider-service/vai/internal/label/label.go
@@ -1,6 +1,7 @@
 package label
 
 const (
+	ProviderName              = "provider-name"
 	PipelineName              = "pipeline-name"
 	PipelineNamespace         = "pipeline-namespace"
 	PipelineVersion           = "pipeline-version"

--- a/provider-service/vai/internal/provider/label_gen.go
+++ b/provider-service/vai/internal/provider/label_gen.go
@@ -21,6 +21,7 @@ type DefaultLabelGen struct {
 // which run configuration it originated from.
 func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
 	var labels map[string]string
+
 	switch v := value.(type) {
 	case resource.RunDefinition:
 		labels = lg.runLabelsFromRunDefinition(v)
@@ -34,9 +35,9 @@ func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
 			resource.RunScheduleDefinition{},
 		)
 	}
+
 	labels[label.ProviderName] = lg.providerName.Name
 	labels[label.ProviderNamespace] = lg.providerName.Namespace
-
 	return labels, nil
 }
 

--- a/provider-service/vai/internal/provider/label_gen.go
+++ b/provider-service/vai/internal/provider/label_gen.go
@@ -13,16 +13,23 @@ type LabelGen interface {
 	GenerateLabels(value any) (map[string]string, error)
 }
 
-type DefaultLabelGen struct{}
+type DefaultLabelGen struct {
+	providerName common.NamespacedName
+}
 
 // GenerateLabels generates labels for vertex ai runs and schedules to show
 // which run configuration it originated from.
 func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
+	pNameStr, err := lg.providerName.String()
+	if err != nil {
+		return nil, err
+	}
+	var labels map[string]string
 	switch v := value.(type) {
 	case resource.RunDefinition:
-		return lg.runLabelsFromRunDefinition(v), nil
+		labels = lg.runLabelsFromRunDefinition(v)
 	case resource.RunScheduleDefinition:
-		return lg.runLabelsFromSchedule(v), nil
+		labels = lg.runLabelsFromSchedule(v)
 	default:
 		return nil, fmt.Errorf(
 			"Unexpected definition received [%T], expected %T or %T",
@@ -31,6 +38,8 @@ func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
 			resource.RunScheduleDefinition{},
 		)
 	}
+	labels[label.ProviderName] = pNameStr
+	return labels, nil
 }
 
 func (lg DefaultLabelGen) runLabelsFromPipeline(

--- a/provider-service/vai/internal/provider/label_gen.go
+++ b/provider-service/vai/internal/provider/label_gen.go
@@ -20,10 +20,6 @@ type DefaultLabelGen struct {
 // GenerateLabels generates labels for vertex ai runs and schedules to show
 // which run configuration it originated from.
 func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
-	pNameStr, err := lg.providerName.String()
-	if err != nil {
-		return nil, err
-	}
 	var labels map[string]string
 	switch v := value.(type) {
 	case resource.RunDefinition:
@@ -38,7 +34,9 @@ func (lg DefaultLabelGen) GenerateLabels(value any) (map[string]string, error) {
 			resource.RunScheduleDefinition{},
 		)
 	}
-	labels[label.ProviderName] = pNameStr
+	labels[label.ProviderName] = lg.providerName.Name
+	labels[label.ProviderNamespace] = lg.providerName.Namespace
+
 	return labels, nil
 }
 

--- a/provider-service/vai/internal/provider/label_gen_test.go
+++ b/provider-service/vai/internal/provider/label_gen_test.go
@@ -15,9 +15,6 @@ var _ = Describe("DefaultLabelGen", func() {
 		providerName: common.NamespacedName{Name: "test-provider", Namespace: "test-namespace"},
 	}
 
-	testProviderNameStr, err := lg.providerName.String()
-	Expect(err).ToNot(HaveOccurred())
-
 	Context("GenerateLabels", func() {
 		When("value is not RunDefinition or RunScheduleDefinition", func() {
 			It("should return error", func() {
@@ -35,7 +32,8 @@ var _ = Describe("DefaultLabelGen", func() {
 				rl, err := lg.GenerateLabels(rd)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
+				Expect(rl[label.ProviderName]).To(Equal(lg.providerName.Name))
+				Expect(rl[label.ProviderNamespace]).To(Equal(lg.providerName.Namespace))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -52,7 +50,8 @@ var _ = Describe("DefaultLabelGen", func() {
 				rl, err := lg.GenerateLabels(rd)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
+				Expect(rl[label.ProviderName]).To(Equal(lg.providerName.Name))
+				Expect(rl[label.ProviderNamespace]).To(Equal(lg.providerName.Namespace))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -69,7 +68,8 @@ var _ = Describe("DefaultLabelGen", func() {
 				rl, err := lg.GenerateLabels(rd)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
+				Expect(rl[label.ProviderName]).To(Equal(lg.providerName.Name))
+				Expect(rl[label.ProviderNamespace]).To(Equal(lg.providerName.Namespace))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -98,7 +98,8 @@ var _ = Describe("DefaultLabelGen", func() {
 				rl, err := lg.GenerateLabels(rsd)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
+				Expect(rl[label.ProviderName]).To(Equal(lg.providerName.Name))
+				Expect(rl[label.ProviderNamespace]).To(Equal(lg.providerName.Namespace))
 				Expect(rl[label.PipelineName]).To(Equal(rsd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rsd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rsd.PipelineVersion))
@@ -113,7 +114,8 @@ var _ = Describe("DefaultLabelGen", func() {
 				rl, err := lg.GenerateLabels(rsd)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
+				Expect(rl[label.ProviderName]).To(Equal(lg.providerName.Name))
+				Expect(rl[label.ProviderNamespace]).To(Equal(lg.providerName.Namespace))
 				Expect(rl[label.PipelineName]).To(Equal(rsd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rsd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rsd.PipelineVersion))

--- a/provider-service/vai/internal/provider/label_gen_test.go
+++ b/provider-service/vai/internal/provider/label_gen_test.go
@@ -11,25 +11,14 @@ import (
 )
 
 var _ = Describe("DefaultLabelGen", func() {
-	var lg = DefaultLabelGen{}
+	var lg = DefaultLabelGen{
+		providerName: common.NamespacedName{Name: "test-provider", Namespace: "test-namespace"},
+	}
+
+	testProviderNameStr, err := lg.providerName.String()
+	Expect(err).ToNot(HaveOccurred())
 
 	Context("GenerateLabels", func() {
-		When("value is RunDefinition", func() {
-			It("should not error", func() {
-				rd := testutil.RandomRunDefinition()
-				_, err := lg.GenerateLabels(rd)
-
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-		When("value is RunScheduleDefinition", func() {
-			It("should not error", func() {
-				rsd := testutil.RandomRunScheduleDefinition()
-				_, err := lg.GenerateLabels(rsd)
-
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
 		When("value is not RunDefinition or RunScheduleDefinition", func() {
 			It("should return error", func() {
 				_, err := lg.GenerateLabels(0)
@@ -39,12 +28,14 @@ var _ = Describe("DefaultLabelGen", func() {
 		})
 	})
 
-	Context("runLabelsFromRunDefinition", func() {
+	Context("GenerateLabels - runLabelsFromRunDefinition", func() {
 		When("RunConfigurationName and RunName is present", func() {
 			It("generates run labels with RunConfigurationName and RunName", func() {
 				rd := testutil.RandomRunDefinition()
-				rl := lg.runLabelsFromRunDefinition(rd)
+				rl, err := lg.GenerateLabels(rd)
+				Expect(err).ToNot(HaveOccurred())
 
+				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -58,8 +49,10 @@ var _ = Describe("DefaultLabelGen", func() {
 			It("generates run labels with RunName", func() {
 				rd := testutil.RandomRunDefinition()
 				rd.RunConfigurationName = common.NamespacedName{}
-				rl := lg.runLabelsFromRunDefinition(rd)
+				rl, err := lg.GenerateLabels(rd)
+				Expect(err).ToNot(HaveOccurred())
 
+				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -73,8 +66,10 @@ var _ = Describe("DefaultLabelGen", func() {
 			It("generates run labels with RunName", func() {
 				rd := testutil.RandomRunDefinition()
 				rd.Name = common.NamespacedName{}
-				rl := lg.runLabelsFromRunDefinition(rd)
+				rl, err := lg.GenerateLabels(rd)
+				Expect(err).ToNot(HaveOccurred())
 
+				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
 				Expect(rl[label.PipelineName]).To(Equal(rd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rd.PipelineVersion))
@@ -84,6 +79,9 @@ var _ = Describe("DefaultLabelGen", func() {
 				Expect(rl).NotTo(HaveKey(label.RunNamespace))
 			})
 		})
+	})
+
+	Context("runLabelsFromRunDefinition", func() {
 		It("replaces fullstops with dashes in pipelineVersion", func() {
 			rd := testutil.RandomRunDefinition()
 			rd.PipelineVersion = "0.4.0"
@@ -93,12 +91,14 @@ var _ = Describe("DefaultLabelGen", func() {
 		})
 	})
 
-	Context("runLabelsFromSchedule", func() {
+	Context("GenerateLabels - runLabelsFromSchedule", func() {
 		When("RunConfigurationName is present", func() {
 			It("generates run labels with RunConfiguration name and namespace", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
-				rl := lg.runLabelsFromSchedule(rsd)
+				rl, err := lg.GenerateLabels(rsd)
+				Expect(err).ToNot(HaveOccurred())
 
+				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
 				Expect(rl[label.PipelineName]).To(Equal(rsd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rsd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rsd.PipelineVersion))
@@ -110,8 +110,10 @@ var _ = Describe("DefaultLabelGen", func() {
 			It("generates run labels without RunConfiguration name and namespace", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				rsd.RunConfigurationName = common.NamespacedName{}
-				rl := lg.runLabelsFromSchedule(rsd)
+				rl, err := lg.GenerateLabels(rsd)
+				Expect(err).ToNot(HaveOccurred())
 
+				Expect(rl[label.ProviderName]).To(Equal(testProviderNameStr))
 				Expect(rl[label.PipelineName]).To(Equal(rsd.PipelineName.Name))
 				Expect(rl[label.PipelineNamespace]).To(Equal(rsd.PipelineName.Namespace))
 				Expect(rl[label.PipelineVersion]).To(Equal(rsd.PipelineVersion))
@@ -119,7 +121,9 @@ var _ = Describe("DefaultLabelGen", func() {
 				Expect(rl).NotTo(HaveKey(label.RunConfigurationNamespace))
 			})
 		})
+	})
 
+	Context("runLabelsFromSchedule", func() {
 		It("replaces fullstops with dashes in pipelineVersion", func() {
 			rd := testutil.RandomRunDefinition()
 			rd.PipelineVersion = "0.4.0"

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -30,6 +30,7 @@ type VAIProvider struct {
 func NewVAIProvider(
 	ctx context.Context,
 	config *config.VAIProviderConfig,
+	namespace string,
 ) (*VAIProvider, error) {
 	fh, err := NewGcsFileHandler(ctx, config.Parameters.GcsEndpoint)
 	if err != nil {
@@ -61,7 +62,7 @@ func NewVAIProvider(
 			serviceAccount:      config.Parameters.VaiJobServiceAccount,
 			pipelineRootStorage: config.PipelineRootStorage,
 			pipelineBucket:      config.Parameters.PipelineBucket,
-			labelGen:            DefaultLabelGen{},
+			labelGen:            DefaultLabelGen{providerName: common.NamespacedName{Name: config.Name, Namespace: namespace}},
 		},
 		jobEnricher: DefaultJobEnricher{pipelineSchemaHandler: DefaultPipelineSchemaHandler{
 			schema2Handler:   Schema2Handler{},


### PR DESCRIPTION
Closes #618 .

Adds extra labels when submitting resources to VAI, detailing which provider the resource was submitted from. This will be useful when dealing with multiple providers, as you will be able to filter logs and route logs using the provider label. 

## Tasks
- [x] add new provider-name label to submitted vai jobs
