### PR TITLE
Ignore runconfiguration reconcile condition LastTransitionTime

### DIFF
--- a/apis/conditions.go
+++ b/apis/conditions.go
@@ -68,7 +68,6 @@ func (conditions Conditions) MergeIntoConditions(condition metav1.Condition) Con
 	if existingCondition.Reason != condition.Reason ||
 		existingCondition.Status != condition.Status ||
 		existingCondition.ObservedGeneration != condition.ObservedGeneration ||
-		existingCondition.LastTransitionTime != condition.LastTransitionTime ||
 		existingCondition.Message != condition.Message {
 		conditionsAsMap[condition.Type] = condition
 	}

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -14,9 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
@@ -311,10 +309,7 @@ func (r *RunConfigurationReconciler) reconciliationRequestsForRunConfiguration(
 func (r *RunConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runConfiguration := &pipelineshub.RunConfiguration{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(
-			runConfiguration,
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		)
+		For(runConfiguration)
 
 	controllerBuilder, err := r.DependingOnPipelineReconciler.setupWithManager(
 		mgr,

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -14,7 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
@@ -309,7 +311,10 @@ func (r *RunConfigurationReconciler) reconciliationRequestsForRunConfiguration(
 func (r *RunConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runConfiguration := &pipelineshub.RunConfiguration{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(runConfiguration)
+		For(
+			runConfiguration,
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
 
 	controllerBuilder, err := r.DependingOnPipelineReconciler.setupWithManager(
 		mgr,


### PR DESCRIPTION
Closes #625

The run configuration controller will sometimes get stuck in an infinite loop of reconciling a resource. This happens when a `Condition.LastTransitionTime` is being set by `SetSynchronizationState` and then immediately being compared with the in memory resource, which by definition will be different. This triggers a reconcile; in particular `MergeConditionsInto` is checking `LastTransitionTime` changes.

This change will remove `LastTransitionTime` from `MergeConditionsInto`, which means the controller will not reconcile just because that field was set.