### PR TITLE
Move all context fields out of structs in providers

### DIFF
--- a/provider-service/base/pkg/server/metrics_server_decoupled_test.go
+++ b/provider-service/base/pkg/server/metrics_server_decoupled_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 type MetricsTestContext struct {
-	ctx      context.Context
 	Addr     net.Addr
 	shutdown func()
 }
@@ -33,7 +32,7 @@ func NewMetricsTestContext() *MetricsTestContext {
 
 	metricsAddr := listener.Addr()
 
-	return &MetricsTestContext{ctx: ctx, Addr: metricsAddr, shutdown: shutdown}
+	return &MetricsTestContext{Addr: metricsAddr, shutdown: shutdown}
 }
 
 func TestMetricsServerDecoupledSuite(t *testing.T) {

--- a/provider-service/base/pkg/server/resource/experiment.go
+++ b/provider-service/base/pkg/server/resource/experiment.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Experiment struct {
-	Ctx      context.Context
 	Provider ExperimentProvider
 }
 
@@ -16,15 +15,15 @@ func (*Experiment) Type() string {
 	return "experiment"
 }
 
-func (e *Experiment) Create(body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(e.Ctx)
+func (e *Experiment) Create(ctx context.Context, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	ed := ExperimentDefinition{}
 	if err := json.Unmarshal(body, &ed); err != nil {
 		logger.Error(err, "Failed to unmarshal ExperimentDefinition while creating Experiment")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	id, err := e.Provider.CreateExperiment(ed)
+	id, err := e.Provider.CreateExperiment(ctx, ed)
 	if err != nil {
 		logger.Error(err, "CreateExperiment failed")
 		return ResponseBody{}, err
@@ -36,15 +35,15 @@ func (e *Experiment) Create(body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (e *Experiment) Update(id string, body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(e.Ctx)
+func (e *Experiment) Update(ctx context.Context, id string, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	ed := ExperimentDefinition{}
 	if err := json.Unmarshal(body, &ed); err != nil {
 		logger.Error(err, "Failed to unmarshal ExperimentDefinition while updating Experiment")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	respId, err := e.Provider.UpdateExperiment(ed, id)
+	respId, err := e.Provider.UpdateExperiment(ctx, ed, id)
 	if err != nil {
 		logger.Error(err, "UpdateExperiment failed", "id", id)
 		return ResponseBody{}, err
@@ -56,9 +55,9 @@ func (e *Experiment) Update(id string, body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (e *Experiment) Delete(id string) error {
-	logger := common.LoggerFromContext(e.Ctx)
-	if err := e.Provider.DeleteExperiment(id); err != nil {
+func (e *Experiment) Delete(ctx context.Context, id string) error {
+	logger := common.LoggerFromContext(ctx)
+	if err := e.Provider.DeleteExperiment(ctx, id); err != nil {
 		logger.Error(err, "DeleteExperiment failed", "id", id)
 		return err
 	}

--- a/provider-service/base/pkg/server/resource/pipeline.go
+++ b/provider-service/base/pkg/server/resource/pipeline.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Pipeline struct {
-	Ctx      context.Context
 	Provider PipelineProvider
 }
 
@@ -16,15 +15,15 @@ func (*Pipeline) Type() string {
 	return "pipeline"
 }
 
-func (p *Pipeline) Create(body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(p.Ctx)
+func (p *Pipeline) Create(ctx context.Context, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	pdw := PipelineDefinitionWrapper{}
 	if err := json.Unmarshal(body, &pdw); err != nil {
 		logger.Error(err, "Failed to unmarshal PipelineDefinitionWrapper while creating Pipeline")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	id, err := p.Provider.CreatePipeline(pdw)
+	id, err := p.Provider.CreatePipeline(ctx, pdw)
 	if err != nil {
 		logger.Error(err, "CreatePipeline failed")
 		return ResponseBody{}, err
@@ -36,15 +35,15 @@ func (p *Pipeline) Create(body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (p *Pipeline) Update(id string, body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(p.Ctx)
+func (p *Pipeline) Update(ctx context.Context, id string, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	pdw := PipelineDefinitionWrapper{}
 	if err := json.Unmarshal(body, &pdw); err != nil {
 		logger.Error(err, "Failed to unmarshal PipelineDefinitionWrapper while updating Pipeline")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	respId, err := p.Provider.UpdatePipeline(pdw, id)
+	respId, err := p.Provider.UpdatePipeline(ctx, pdw, id)
 	if err != nil {
 		logger.Error(err, "UpdatePipeline failed", "id", id)
 		return ResponseBody{}, err
@@ -56,9 +55,9 @@ func (p *Pipeline) Update(id string, body []byte) (ResponseBody, error) {
 	}, err
 }
 
-func (p *Pipeline) Delete(id string) error {
-	logger := common.LoggerFromContext(p.Ctx)
-	if err := p.Provider.DeletePipeline(id); err != nil {
+func (p *Pipeline) Delete(ctx context.Context, id string) error {
+	logger := common.LoggerFromContext(ctx)
+	if err := p.Provider.DeletePipeline(ctx, id); err != nil {
 		logger.Error(err, "DeletePipeline failed", "id", id)
 		return err
 	}

--- a/provider-service/base/pkg/server/resource/provider.go
+++ b/provider-service/base/pkg/server/resource/provider.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,26 +68,26 @@ type Provider interface {
 }
 
 type PipelineProvider interface {
-	CreatePipeline(pd PipelineDefinitionWrapper) (string, error)
-	UpdatePipeline(pd PipelineDefinitionWrapper, id string) (string, error)
-	DeletePipeline(id string) error
+	CreatePipeline(ctx context.Context, ppd PipelineDefinitionWrapper) (string, error)
+	UpdatePipeline(ctx context.Context, ppd PipelineDefinitionWrapper, id string) (string, error)
+	DeletePipeline(ctx context.Context, id string) error
 }
 
 type RunProvider interface {
-	CreateRun(rd RunDefinition) (string, error)
-	DeleteRun(id string) error
+	CreateRun(ctx context.Context, rd RunDefinition) (string, error)
+	DeleteRun(ctx context.Context, id string) error
 }
 
 type RunScheduleProvider interface {
-	CreateRunSchedule(rsd RunScheduleDefinition) (string, error)
-	UpdateRunSchedule(rsd RunScheduleDefinition, id string) (string, error)
-	DeleteRunSchedule(id string) error
+	CreateRunSchedule(ctx context.Context, rsd RunScheduleDefinition) (string, error)
+	UpdateRunSchedule(ctx context.Context, rsd RunScheduleDefinition, id string) (string, error)
+	DeleteRunSchedule(ctx context.Context, id string) error
 }
 
 type ExperimentProvider interface {
-	CreateExperiment(ed ExperimentDefinition) (string, error)
-	UpdateExperiment(ed ExperimentDefinition, id string) (string, error)
-	DeleteExperiment(id string) error
+	CreateExperiment(ctx context.Context, ed ExperimentDefinition) (string, error)
+	UpdateExperiment(ctx context.Context, ed ExperimentDefinition, id string) (string, error)
+	DeleteExperiment(ctx context.Context, id string) error
 }
 
 type UserError struct {

--- a/provider-service/base/pkg/server/resource/resource.go
+++ b/provider-service/base/pkg/server/resource/resource.go
@@ -1,10 +1,12 @@
 package resource
 
+import "context"
+
 type HttpHandledResource interface {
 	Type() string
-	Create(body []byte) (ResponseBody, error)
-	Update(id string, body []byte) (ResponseBody, error)
-	Delete(id string) error
+	Create(ctx context.Context, body []byte) (ResponseBody, error)
+	Update(ctx context.Context, id string, body []byte) (ResponseBody, error)
+	Delete(ctx context.Context, id string) error
 }
 
 type ResponseBody struct {

--- a/provider-service/base/pkg/server/resource/run.go
+++ b/provider-service/base/pkg/server/resource/run.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Run struct {
-	Ctx      context.Context
 	Provider RunProvider
 }
 
@@ -16,8 +15,8 @@ func (*Run) Type() string {
 	return "run"
 }
 
-func (r *Run) Create(body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(r.Ctx)
+func (r *Run) Create(ctx context.Context, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	rd := RunDefinition{}
 
 	if err := json.Unmarshal(body, &rd); err != nil {
@@ -25,7 +24,7 @@ func (r *Run) Create(body []byte) (ResponseBody, error) {
 		return ResponseBody{}, &UserError{err}
 	}
 
-	id, err := r.Provider.CreateRun(rd)
+	id, err := r.Provider.CreateRun(ctx, rd)
 	if err != nil {
 		logger.Error(err, "CreateRun failed")
 		return ResponseBody{}, err
@@ -37,13 +36,13 @@ func (r *Run) Create(body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (r *Run) Update(_ string, _ []byte) (ResponseBody, error) {
+func (r *Run) Update(_ context.Context, _ string, _ []byte) (ResponseBody, error) {
 	return ResponseBody{}, &UnimplementedError{Method: "Update", ResourceType: r.Type()}
 }
 
-func (r *Run) Delete(id string) error {
-	logger := common.LoggerFromContext(r.Ctx)
-	if err := r.Provider.DeleteRun(id); err != nil {
+func (r *Run) Delete(ctx context.Context, id string) error {
+	logger := common.LoggerFromContext(ctx)
+	if err := r.Provider.DeleteRun(ctx, id); err != nil {
 		logger.Error(err, "DeleteRun failed", "id", id)
 		return err
 	}

--- a/provider-service/base/pkg/server/resource/runschedule.go
+++ b/provider-service/base/pkg/server/resource/runschedule.go
@@ -8,7 +8,6 @@ import (
 )
 
 type RunSchedule struct {
-	Ctx      context.Context
 	Provider RunScheduleProvider
 }
 
@@ -16,15 +15,15 @@ func (*RunSchedule) Type() string {
 	return "runschedule"
 }
 
-func (rs *RunSchedule) Create(body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(rs.Ctx)
+func (rs *RunSchedule) Create(ctx context.Context, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	rsd := RunScheduleDefinition{}
 	if err := json.Unmarshal(body, &rsd); err != nil {
 		logger.Error(err, "Failed to unmarshal RunScheduleDefinition while creating RunSchedule")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	id, err := rs.Provider.CreateRunSchedule(rsd)
+	id, err := rs.Provider.CreateRunSchedule(ctx, rsd)
 	if err != nil {
 		logger.Error(err, "CreateRunSchedule failed")
 		return ResponseBody{}, err
@@ -36,15 +35,15 @@ func (rs *RunSchedule) Create(body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (rs *RunSchedule) Update(id string, body []byte) (ResponseBody, error) {
-	logger := common.LoggerFromContext(rs.Ctx)
+func (rs *RunSchedule) Update(ctx context.Context, id string, body []byte) (ResponseBody, error) {
+	logger := common.LoggerFromContext(ctx)
 	rsd := RunScheduleDefinition{}
 	if err := json.Unmarshal(body, &rsd); err != nil {
 		logger.Error(err, "Failed to unmarshal RunScheduleDefinition while updating RunSchedule")
 		return ResponseBody{}, &UserError{err}
 	}
 
-	respId, err := rs.Provider.UpdateRunSchedule(rsd, id)
+	respId, err := rs.Provider.UpdateRunSchedule(ctx, rsd, id)
 	if err != nil {
 		logger.Error(err, "UpdateRunSchedule failed", "id", id)
 		return ResponseBody{}, err
@@ -56,9 +55,9 @@ func (rs *RunSchedule) Update(id string, body []byte) (ResponseBody, error) {
 	}, nil
 }
 
-func (rs *RunSchedule) Delete(id string) error {
-	logger := common.LoggerFromContext(rs.Ctx)
-	if err := rs.Provider.DeleteRunSchedule(id); err != nil {
+func (rs *RunSchedule) Delete(ctx context.Context, id string) error {
+	logger := common.LoggerFromContext(ctx)
+	if err := rs.Provider.DeleteRunSchedule(ctx, id); err != nil {
 		logger.Error(err, "DeleteRunSchedule failed", "id", id)
 		return err
 	}

--- a/provider-service/base/pkg/server/resource/runschedule_test.go
+++ b/provider-service/base/pkg/server/resource/runschedule_test.go
@@ -16,11 +16,14 @@ var _ = Describe("RunSchedule", Ordered, func() {
 	var (
 		mockProvider MockRunScheduleProvider
 		rs           RunSchedule
+		ctx          = context.Background()
 	)
+
+	ignoreCtx := mock.Anything
 
 	BeforeEach(func() {
 		mockProvider = MockRunScheduleProvider{}
-		rs = RunSchedule{Ctx: context.Background(), Provider: &mockProvider}
+		rs = RunSchedule{Provider: &mockProvider}
 	})
 
 	Context("Create", func() {
@@ -32,8 +35,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				id := "some-id"
-				mockProvider.On("CreateRunSchedule", rsd).Return(id, nil)
-				response, err := rs.Create(jsonRunSchedule)
+				mockProvider.On("CreateRunSchedule", ignoreCtx, rsd).Return(id, nil)
+				response, err := rs.Create(ctx, jsonRunSchedule)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response).To(Equal(ResponseBody{Id: id}))
@@ -43,7 +46,7 @@ var _ = Describe("RunSchedule", Ordered, func() {
 		When("invalid json is passed", func() {
 			It("errors", func() {
 				invalidJson := []byte(`/n`)
-				response, err := rs.Create(invalidJson)
+				response, err := rs.Create(ctx, invalidJson)
 
 				var expectedErr *UserError
 				Expect(errors.As(err, &expectedErr)).To(BeTrue())
@@ -59,8 +62,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedErr := errors.New("some-error")
-				mockProvider.On("CreateRunSchedule", rsd).Return("", expectedErr)
-				response, err := rs.Create(jsonRunSchedule)
+				mockProvider.On("CreateRunSchedule", ignoreCtx, rsd).Return("", expectedErr)
+				response, err := rs.Create(ctx, jsonRunSchedule)
 
 				Expect(err).To(Equal(expectedErr))
 				Expect(response).To(Equal(ResponseBody{}))
@@ -78,8 +81,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 
 				id := "some-id"
 				updatedId := "some-update-id"
-				mockProvider.On("UpdateRunSchedule", rsd, id).Return(updatedId, nil)
-				resp, err := rs.Update(id, jsonRunSchedule)
+				mockProvider.On("UpdateRunSchedule", ignoreCtx, rsd, id).Return(updatedId, nil)
+				resp, err := rs.Update(ctx, id, jsonRunSchedule)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(Equal(ResponseBody{Id: updatedId}))
@@ -89,7 +92,7 @@ var _ = Describe("RunSchedule", Ordered, func() {
 		When("invalid json is passed", func() {
 			It("errors", func() {
 				invalidJson := []byte(`/n`)
-				resp, err := rs.Update("some-id", invalidJson)
+				resp, err := rs.Update(ctx, "some-id", invalidJson)
 
 				var expectedErr *UserError
 				Expect(errors.As(err, &expectedErr)).To(BeTrue())
@@ -106,8 +109,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 
 				expectedErr := errors.New("some-error")
 				id := "some-id"
-				mockProvider.On("UpdateRunSchedule", rsd, id).Return("", expectedErr)
-				resp, err := rs.Update(id, jsonExperiment)
+				mockProvider.On("UpdateRunSchedule", ignoreCtx, rsd, id).Return("", expectedErr)
+				resp, err := rs.Update(ctx, id, jsonExperiment)
 
 				Expect(err).To(Equal(expectedErr))
 				Expect(resp).To(Equal(ResponseBody{}))
@@ -119,8 +122,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 		When("valid id is passed and provider operations succeed", func() {
 			It("return no error", func() {
 				id := "some-id"
-				mockProvider.On("DeleteRunSchedule", id).Return(nil)
-				err := rs.Delete(id)
+				mockProvider.On("DeleteRunSchedule", ignoreCtx, id).Return(nil)
+				err := rs.Delete(ctx, id)
 
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -130,8 +133,8 @@ var _ = Describe("RunSchedule", Ordered, func() {
 			It("errors", func() {
 				id := "some-id"
 				expectedErr := errors.New("some-error")
-				mockProvider.On("DeleteRunSchedule", id).Return(expectedErr)
-				err := rs.Delete(id)
+				mockProvider.On("DeleteRunSchedule", ignoreCtx, id).Return(expectedErr)
+				err := rs.Delete(ctx, id)
 
 				Expect(err).To(Equal(expectedErr))
 			})
@@ -144,21 +147,23 @@ type MockRunScheduleProvider struct {
 }
 
 func (m *MockRunScheduleProvider) CreateRunSchedule(
+	ctx context.Context,
 	rsd RunScheduleDefinition,
 ) (string, error) {
-	args := m.Called(rsd)
+	args := m.Called(ctx, rsd)
 	return args.String(0), args.Error(1)
 }
 
 func (m *MockRunScheduleProvider) UpdateRunSchedule(
+	ctx context.Context,
 	rsd RunScheduleDefinition,
 	id string,
 ) (string, error) {
-	args := m.Called(rsd, id)
+	args := m.Called(ctx, rsd, id)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockRunScheduleProvider) DeleteRunSchedule(rsd string) error {
-	args := m.Called(rsd)
+func (m *MockRunScheduleProvider) DeleteRunSchedule(ctx context.Context, rsd string) error {
+	args := m.Called(ctx, rsd)
 	return args.Error(0)
 }

--- a/provider-service/base/pkg/streams/sinks/error_sink.go
+++ b/provider-service/base/pkg/streams/sinks/error_sink.go
@@ -6,14 +6,13 @@ import (
 )
 
 type ErrorSink struct {
-	context context.Context
-	in      chan error
+	in chan error
 }
 
 func NewErrorSink(ctx context.Context, inChan chan error) *ErrorSink {
-	errorSink := &ErrorSink{context: ctx, in: inChan}
+	errorSink := &ErrorSink{in: inChan}
 
-	go errorSink.Log()
+	go errorSink.Log(ctx)
 
 	return errorSink
 }
@@ -22,8 +21,8 @@ func (es ErrorSink) In() chan<- error {
 	return es.in
 }
 
-func (es ErrorSink) Log() {
-	logger := common.LoggerFromContext(es.context)
+func (es ErrorSink) Log(ctx context.Context) {
+	logger := common.LoggerFromContext(ctx)
 	for err := range es.in {
 		logger.Error(err, "failed to handle event")
 	}

--- a/provider-service/kfp/cmd/main.go
+++ b/provider-service/kfp/cmd/main.go
@@ -59,7 +59,7 @@ func main() {
 }
 
 func runServer(ctx context.Context, kfpConfig *kfpConfig.KfpProviderConfig, baseConfig *baseConfig.Config) {
-	provider, err := kfp.NewKfpProvider(ctx, kfpConfig)
+	provider, err := kfp.NewKfpProvider(kfpConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/provider-service/kfp/internal/mocks/experiment_service.go
+++ b/provider-service/kfp/internal/mocks/experiment_service.go
@@ -11,23 +11,26 @@ type MockExperimentService struct {
 }
 
 func (m *MockExperimentService) CreateExperiment(
-	ctx context.Context,
+	_ context.Context,
 	experiment common.NamespacedName,
 	description string,
 ) (string, error) {
-	args := m.Called(ctx, experiment, description)
+	args := m.Called(experiment, description)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockExperimentService) DeleteExperiment(ctx context.Context, id string) error {
-	args := m.Called(ctx, id)
+func (m *MockExperimentService) DeleteExperiment(
+	_ context.Context,
+	id string,
+) error {
+	args := m.Called(id)
 	return args.Error(0)
 }
 
 func (m *MockExperimentService) ExperimentIdByName(
-	ctx context.Context,
+	_ context.Context,
 	experiment common.NamespacedName,
 ) (string, error) {
-	args := m.Called(ctx, experiment)
+	args := m.Called(experiment)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/mocks/experiment_service.go
+++ b/provider-service/kfp/internal/mocks/experiment_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/stretchr/testify/mock"
 )
@@ -10,21 +11,23 @@ type MockExperimentService struct {
 }
 
 func (m *MockExperimentService) CreateExperiment(
+	ctx context.Context,
 	experiment common.NamespacedName,
 	description string,
 ) (string, error) {
-	args := m.Called(experiment, description)
+	args := m.Called(ctx, experiment, description)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockExperimentService) DeleteExperiment(id string) error {
-	args := m.Called(id)
+func (m *MockExperimentService) DeleteExperiment(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 func (m *MockExperimentService) ExperimentIdByName(
+	ctx context.Context,
 	experiment common.NamespacedName,
 ) (string, error) {
-	args := m.Called(experiment)
+	args := m.Called(ctx, experiment)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/mocks/job_service.go
+++ b/provider-service/kfp/internal/mocks/job_service.go
@@ -11,22 +11,22 @@ type MockJobService struct {
 }
 
 func (m *MockJobService) CreateJob(
-	ctx context.Context,
+	_ context.Context,
 	rsd resource.RunScheduleDefinition,
 	pipelineId string,
 	pipelineVersionId string,
 	experimentId string,
 ) (string, error) {
-	args := m.Called(ctx, rsd, pipelineId, pipelineVersionId, experimentId)
+	args := m.Called(rsd, pipelineId, pipelineVersionId, experimentId)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockJobService) GetJob(ctx context.Context, id string) (string, error) {
-	args := m.Called(ctx, id)
+func (m *MockJobService) GetJob(_ context.Context, id string) (string, error) {
+	args := m.Called(id)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockJobService) DeleteJob(ctx context.Context, id string) error {
-	args := m.Called(ctx, id)
+func (m *MockJobService) DeleteJob(_ context.Context, id string) error {
+	args := m.Called(id)
 	return args.Error(0)
 }

--- a/provider-service/kfp/internal/mocks/job_service.go
+++ b/provider-service/kfp/internal/mocks/job_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
 	"github.com/stretchr/testify/mock"
 )
@@ -9,21 +10,23 @@ type MockJobService struct {
 	mock.Mock
 }
 
-func (m *MockJobService) CreateJob(rsd resource.RunScheduleDefinition,
+func (m *MockJobService) CreateJob(
+	ctx context.Context,
+	rsd resource.RunScheduleDefinition,
 	pipelineId string,
 	pipelineVersionId string,
 	experimentId string,
 ) (string, error) {
-	args := m.Called(rsd, pipelineId, pipelineVersionId, experimentId)
+	args := m.Called(ctx, rsd, pipelineId, pipelineVersionId, experimentId)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockJobService) GetJob(id string) (string, error) {
-	args := m.Called(id)
+func (m *MockJobService) GetJob(ctx context.Context, id string) (string, error) {
+	args := m.Called(ctx, id)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockJobService) DeleteJob(id string) error {
-	args := m.Called(id)
+func (m *MockJobService) DeleteJob(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }

--- a/provider-service/kfp/internal/mocks/pipeline_service.go
+++ b/provider-service/kfp/internal/mocks/pipeline_service.go
@@ -9,24 +9,27 @@ type MockPipelineService struct {
 	mock.Mock
 }
 
-func (m *MockPipelineService) DeletePipeline(ctx context.Context, id string) error {
-	args := m.Called(ctx, id)
+func (m *MockPipelineService) DeletePipeline(
+	_ context.Context,
+	id string,
+) error {
+	args := m.Called(id)
 	return args.Error(0)
 }
 
 func (m *MockPipelineService) PipelineIdForName(
-	ctx context.Context,
+	_ context.Context,
 	pipelineName string,
 ) (string, error) {
-	args := m.Called(ctx, pipelineName)
+	args := m.Called(pipelineName)
 	return args.String(0), args.Error(1)
 }
 
 func (m *MockPipelineService) PipelineVersionIdForName(
-	ctx context.Context,
+	_ context.Context,
 	versionName string,
 	pipelineId string,
 ) (string, error) {
-	args := m.Called(ctx, versionName, pipelineId)
+	args := m.Called(versionName, pipelineId)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/mocks/pipeline_service.go
+++ b/provider-service/kfp/internal/mocks/pipeline_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -8,22 +9,24 @@ type MockPipelineService struct {
 	mock.Mock
 }
 
-func (m *MockPipelineService) DeletePipeline(id string) error {
-	args := m.Called(id)
+func (m *MockPipelineService) DeletePipeline(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 func (m *MockPipelineService) PipelineIdForName(
+	ctx context.Context,
 	pipelineName string,
 ) (string, error) {
-	args := m.Called(pipelineName)
+	args := m.Called(ctx, pipelineName)
 	return args.String(0), args.Error(1)
 }
 
 func (m *MockPipelineService) PipelineVersionIdForName(
+	ctx context.Context,
 	versionName string,
 	pipelineId string,
 ) (string, error) {
-	args := m.Called(versionName, pipelineId)
+	args := m.Called(ctx, versionName, pipelineId)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/mocks/pipeline_upload_service.go
+++ b/provider-service/kfp/internal/mocks/pipeline_upload_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -9,18 +10,20 @@ type MockPipelineUploadService struct {
 }
 
 func (m *MockPipelineUploadService) UploadPipeline(
+	ctx context.Context,
 	content []byte,
 	pipelineName string,
 ) (string, error) {
-	args := m.Called(content, pipelineName)
+	args := m.Called(ctx, content, pipelineName)
 	return args.String(0), args.Error(1)
 }
 
 func (m *MockPipelineUploadService) UploadPipelineVersion(
+	ctx context.Context,
 	id string,
 	content []byte,
 	version string,
 ) error {
-	args := m.Called(id, content, version)
+	args := m.Called(ctx, id, content, version)
 	return args.Error(0)
 }

--- a/provider-service/kfp/internal/mocks/pipeline_upload_service.go
+++ b/provider-service/kfp/internal/mocks/pipeline_upload_service.go
@@ -10,20 +10,20 @@ type MockPipelineUploadService struct {
 }
 
 func (m *MockPipelineUploadService) UploadPipeline(
-	ctx context.Context,
+	_ context.Context,
 	content []byte,
 	pipelineName string,
 ) (string, error) {
-	args := m.Called(ctx, content, pipelineName)
+	args := m.Called(content, pipelineName)
 	return args.String(0), args.Error(1)
 }
 
 func (m *MockPipelineUploadService) UploadPipelineVersion(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 	content []byte,
 	version string,
 ) error {
-	args := m.Called(ctx, id, content, version)
+	args := m.Called(id, content, version)
 	return args.Error(0)
 }

--- a/provider-service/kfp/internal/mocks/run_service.go
+++ b/provider-service/kfp/internal/mocks/run_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
 	"github.com/stretchr/testify/mock"
 )
@@ -10,11 +11,12 @@ type MockRunService struct {
 }
 
 func (m *MockRunService) CreateRun(
+	ctx context.Context,
 	rd resource.RunDefinition,
 	pipelineId string,
 	pipelineVersionId string,
 	experimentId string,
 ) (string, error) {
-	args := m.Called(rd, pipelineId, pipelineVersionId, experimentId)
+	args := m.Called(ctx, rd, pipelineId, pipelineVersionId, experimentId)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/mocks/run_service.go
+++ b/provider-service/kfp/internal/mocks/run_service.go
@@ -11,12 +11,12 @@ type MockRunService struct {
 }
 
 func (m *MockRunService) CreateRun(
-	ctx context.Context,
+	_ context.Context,
 	rd resource.RunDefinition,
 	pipelineId string,
 	pipelineVersionId string,
 	experimentId string,
 ) (string, error) {
-	args := m.Called(ctx, rd, pipelineId, pipelineVersionId, experimentId)
+	args := m.Called(rd, pipelineId, pipelineVersionId, experimentId)
 	return args.String(0), args.Error(1)
 }

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -22,12 +22,12 @@ var _ = Describe("ExperimentService", func() {
 			Name:      "name",
 			Namespace: "namespace",
 		}
+		ctx = context.Background()
 	)
 
 	BeforeEach(func() {
 		mockExperimentServiceClient = mocks.MockExperimentServiceClient{}
 		experimentService = &DefaultExperimentService{
-			context.Background(),
 			&mockExperimentServiceClient,
 		}
 	})
@@ -44,7 +44,7 @@ var _ = Describe("ExperimentService", func() {
 					},
 				},
 			).Return(&go_client.Experiment{Id: expectedId}, nil)
-			res, err := experimentService.CreateExperiment(nsn, "description")
+			res, err := experimentService.CreateExperiment(ctx, nsn, "description")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(expectedId))
@@ -55,7 +55,7 @@ var _ = Describe("ExperimentService", func() {
 				invalidNsn := common.NamespacedName{
 					Namespace: "namespace",
 				}
-				res, err := experimentService.CreateExperiment(invalidNsn, "foo")
+				res, err := experimentService.CreateExperiment(ctx, invalidNsn, "foo")
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -73,7 +73,7 @@ var _ = Describe("ExperimentService", func() {
 						},
 					},
 				).Return(nil, errors.New("failed"))
-				res, err := experimentService.CreateExperiment(nsn, "description")
+				res, err := experimentService.CreateExperiment(ctx, nsn, "description")
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -90,7 +90,7 @@ var _ = Describe("ExperimentService", func() {
 					Id: id,
 				},
 			).Return(nil)
-			err := experimentService.DeleteExperiment(id)
+			err := experimentService.DeleteExperiment(ctx, id)
 
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -104,7 +104,7 @@ var _ = Describe("ExperimentService", func() {
 						Id: id,
 					},
 				).Return(errors.New("failed"))
-				err := experimentService.DeleteExperiment(id)
+				err := experimentService.DeleteExperiment(ctx, id)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -124,7 +124,7 @@ var _ = Describe("ExperimentService", func() {
 					Filter: *util.ByNameFilter("namespace-name"),
 				},
 			).Return(&expectedResult, nil)
-			res, err := experimentService.ExperimentIdByName(nsn)
+			res, err := experimentService.ExperimentIdByName(ctx, nsn)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("one"))
@@ -135,7 +135,7 @@ var _ = Describe("ExperimentService", func() {
 				invalidNsn := common.NamespacedName{
 					Namespace: "namespace",
 				}
-				res, err := experimentService.ExperimentIdByName(invalidNsn)
+				res, err := experimentService.ExperimentIdByName(ctx, invalidNsn)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -150,7 +150,7 @@ var _ = Describe("ExperimentService", func() {
 						Filter: *util.ByNameFilter("namespace-name"),
 					},
 				).Return(nil, errors.New("failed"))
-				res, err := experimentService.ExperimentIdByName(nsn)
+				res, err := experimentService.ExperimentIdByName(ctx, nsn)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -168,7 +168,7 @@ var _ = Describe("ExperimentService", func() {
 						Filter: *util.ByNameFilter("namespace-name"),
 					},
 				).Return(&expectedResult, nil)
-				res, err := experimentService.ExperimentIdByName(nsn)
+				res, err := experimentService.ExperimentIdByName(ctx, nsn)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -189,7 +189,7 @@ var _ = Describe("ExperimentService", func() {
 						Filter: *util.ByNameFilter("namespace-name"),
 					},
 				).Return(&expectedResult, nil)
-				res, err := experimentService.ExperimentIdByName(nsn)
+				res, err := experimentService.ExperimentIdByName(ctx, nsn)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())

--- a/provider-service/kfp/internal/provider/job_service.go
+++ b/provider-service/kfp/internal/provider/job_service.go
@@ -20,21 +20,21 @@ import (
 
 type JobService interface {
 	CreateJob(
+		ctx context.Context,
 		rsd baseResource.RunScheduleDefinition,
 		pipelineId string,
 		pipelineVersionId string,
 		experimentId string,
 	) (string, error)
-	GetJob(id string) (string, error)
-	DeleteJob(id string) error
+	GetJob(ctx context.Context, id string) (string, error)
+	DeleteJob(ctx context.Context, id string) error
 }
 
 type DefaultJobService struct {
-	ctx    context.Context
 	client client.JobServiceClient
 }
 
-func NewJobService(ctx context.Context, conn *grpc.ClientConn) (JobService, error) {
+func NewJobService(conn *grpc.ClientConn) (JobService, error) {
 	if conn == nil {
 		return nil, fmt.Errorf(
 			"no gRPC connection was provided to start job service",
@@ -42,13 +42,13 @@ func NewJobService(ctx context.Context, conn *grpc.ClientConn) (JobService, erro
 	}
 
 	return &DefaultJobService{
-		ctx:    ctx,
 		client: go_client.NewJobServiceClient(conn),
 	}, nil
 }
 
 // CreateJob creates a job and returns the job result id.
 func (js *DefaultJobService) CreateJob(
+	ctx context.Context,
 	rsd baseResource.RunScheduleDefinition,
 	pipelineId string,
 	pipelineVersionId string,
@@ -84,7 +84,7 @@ func (js *DefaultJobService) CreateJob(
 		return "", err
 	}
 
-	job, err := js.client.CreateJob(js.ctx, &go_client.CreateJobRequest{
+	job, err := js.client.CreateJob(ctx, &go_client.CreateJobRequest{
 		Job: &go_client.Job{
 			Id:          "",
 			Name:        jobName,
@@ -125,8 +125,8 @@ func (js *DefaultJobService) CreateJob(
 }
 
 // GetJob takes a job id and returns a job description.
-func (js *DefaultJobService) GetJob(id string) (string, error) {
-	job, err := js.client.GetJob(js.ctx, &go_client.GetJobRequest{Id: id})
+func (js *DefaultJobService) GetJob(ctx context.Context, id string) (string, error) {
+	job, err := js.client.GetJob(ctx, &go_client.GetJobRequest{Id: id})
 	if err != nil {
 		return "", err
 	}
@@ -135,8 +135,8 @@ func (js *DefaultJobService) GetJob(id string) (string, error) {
 }
 
 // DeleteJob deletes a job by job id. Does not error if there is no such job id.
-func (js *DefaultJobService) DeleteJob(id string) error {
-	_, err := js.client.DeleteJob(js.ctx, &go_client.DeleteJobRequest{Id: id})
+func (js *DefaultJobService) DeleteJob(ctx context.Context, id string) error {
+	_, err := js.client.DeleteJob(ctx, &go_client.DeleteJobRequest{Id: id})
 	if err != nil {
 		st, ok := status.FromError(err)
 		if ok {

--- a/provider-service/kfp/internal/provider/job_service_test.go
+++ b/provider-service/kfp/internal/provider/job_service_test.go
@@ -25,6 +25,7 @@ var _ = Describe("DefaultJobService", func() {
 		mockJobServiceClient mocks.MockJobServiceClient
 		jobService           DefaultJobService
 		rsd                  baseResource.RunScheduleDefinition
+		ctx                  = context.Background()
 	)
 
 	const (
@@ -37,7 +38,6 @@ var _ = Describe("DefaultJobService", func() {
 	BeforeEach(func() {
 		mockJobServiceClient = mocks.MockJobServiceClient{}
 		jobService = DefaultJobService{
-			context.Background(),
 			&mockJobServiceClient,
 		}
 		rsd = testutil.RandomRunScheduleDefinition()
@@ -108,6 +108,7 @@ var _ = Describe("DefaultJobService", func() {
 				},
 			).Return(&go_client.Job{Id: expectedId}, nil)
 			res, err := jobService.CreateJob(
+				ctx,
 				rsd,
 				pipelineId,
 				pipelineVersionId,
@@ -122,6 +123,7 @@ var _ = Describe("DefaultJobService", func() {
 			It("should return error", func() {
 				rsd.Name.Name = ""
 				res, err := jobService.CreateJob(
+					ctx,
 					rsd,
 					pipelineId,
 					pipelineVersionId,
@@ -137,6 +139,7 @@ var _ = Describe("DefaultJobService", func() {
 			It("should return error", func() {
 				rsd.Schedule.CronExpression = "invalid-cron"
 				res, err := jobService.CreateJob(
+					ctx,
 					rsd,
 					pipelineId,
 					pipelineVersionId,
@@ -155,6 +158,7 @@ var _ = Describe("DefaultJobService", func() {
 					mock.Anything,
 				).Return(nil, errors.New("failed"))
 				res, err := jobService.CreateJob(
+					ctx,
 					rsd,
 					pipelineId,
 					pipelineVersionId,
@@ -175,7 +179,7 @@ var _ = Describe("DefaultJobService", func() {
 				&go_client.Job{Description: desc},
 				nil,
 			)
-			res, err := jobService.GetJob(jobId)
+			res, err := jobService.GetJob(ctx, jobId)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(desc))
@@ -188,7 +192,7 @@ var _ = Describe("DefaultJobService", func() {
 					nil,
 					errors.New("failed"),
 				)
-				res, err := jobService.GetJob(jobId)
+				res, err := jobService.GetJob(ctx, jobId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -200,7 +204,7 @@ var _ = Describe("DefaultJobService", func() {
 		It("should not error if job is deleted", func() {
 			expectedReq := &go_client.DeleteJobRequest{Id: jobId}
 			mockJobServiceClient.On("DeleteJob", expectedReq).Return(nil)
-			err := jobService.DeleteJob(jobId)
+			err := jobService.DeleteJob(ctx, jobId)
 
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -211,7 +215,7 @@ var _ = Describe("DefaultJobService", func() {
 				mockJobServiceClient.On("DeleteJob", expectedReq).Return(
 					status.Error(codes.NotFound, "not found"),
 				)
-				err := jobService.DeleteJob(jobId)
+				err := jobService.DeleteJob(ctx, jobId)
 
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -223,7 +227,7 @@ var _ = Describe("DefaultJobService", func() {
 				mockJobServiceClient.On("DeleteJob", expectedReq).Return(
 					status.Error(codes.Canceled, "not found"),
 				)
-				err := jobService.DeleteJob(jobId)
+				err := jobService.DeleteJob(ctx, jobId)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -234,7 +238,7 @@ var _ = Describe("DefaultJobService", func() {
 				mockJobServiceClient.On("DeleteJob", expectedReq).Return(
 					errors.New("failed"),
 				)
-				err := jobService.DeleteJob(jobId)
+				err := jobService.DeleteJob(ctx, jobId)
 
 				Expect(err).To(HaveOccurred())
 			})

--- a/provider-service/kfp/internal/provider/pipeline_service.go
+++ b/provider-service/kfp/internal/provider/pipeline_service.go
@@ -13,18 +13,16 @@ import (
 )
 
 type PipelineService interface {
-	DeletePipeline(id string) error
-	PipelineIdForName(pipelineName string) (string, error)
-	PipelineVersionIdForName(versionName string, pipelineId string) (string, error)
+	DeletePipeline(ctx context.Context, id string) error
+	PipelineIdForName(ctx context.Context, pipelineName string) (string, error)
+	PipelineVersionIdForName(ctx context.Context, versionName string, pipelineId string) (string, error)
 }
 
 type DefaultPipelineService struct {
-	ctx    context.Context
 	client client.PipelineServiceClient
 }
 
 func NewPipelineService(
-	ctx context.Context,
 	conn *grpc.ClientConn,
 ) (PipelineService, error) {
 	if conn == nil {
@@ -34,16 +32,15 @@ func NewPipelineService(
 	}
 
 	return &DefaultPipelineService{
-		ctx:    ctx,
 		client: go_client.NewPipelineServiceClient(conn),
 	}, nil
 }
 
 // DeletePipeline delete a pipline by pipeline id. Does no error if there is no
 // such pipeline id.
-func (ps *DefaultPipelineService) DeletePipeline(id string) error {
+func (ps *DefaultPipelineService) DeletePipeline(ctx context.Context, id string) error {
 	_, err := ps.client.DeletePipeline(
-		ps.ctx,
+		ctx,
 		&go_client.DeletePipelineRequest{
 			Id: id,
 		},
@@ -68,10 +65,11 @@ func (ps *DefaultPipelineService) DeletePipeline(id string) error {
 // PipelineIdForName gets the pipeline id corresponding to the pipeline name.
 // Expects to find exactly one such pipeline.
 func (ps *DefaultPipelineService) PipelineIdForName(
+	ctx context.Context,
 	pipelineName string,
 ) (string, error) {
 	res, err := ps.client.ListPipelines(
-		ps.ctx,
+		ctx,
 		&go_client.ListPipelinesRequest{
 			Filter: *util.ByNameFilter(pipelineName),
 		},
@@ -90,11 +88,12 @@ func (ps *DefaultPipelineService) PipelineIdForName(
 // PipelineVersionIdForName gets the pipeline version corresponding to the
 // pipeline id. Expects to find exactly one such pipeline.
 func (ps *DefaultPipelineService) PipelineVersionIdForName(
+	ctx context.Context,
 	versionName string,
 	pipelineId string,
 ) (string, error) {
 	res, err := ps.client.ListPipelineVersions(
-		ps.ctx,
+		ctx,
 		&go_client.ListPipelineVersionsRequest{
 			ResourceKey: &go_client.ResourceKey{
 				Id: pipelineId,

--- a/provider-service/kfp/internal/provider/pipeline_service_test.go
+++ b/provider-service/kfp/internal/provider/pipeline_service_test.go
@@ -25,12 +25,12 @@ var _ = Describe("PipelineService", func() {
 	var (
 		mockPipelineServiceClient mocks.MockPipelineServiceClient
 		pipelineService           PipelineService
+		ctx                       = context.Background()
 	)
 
 	BeforeEach(func() {
 		mockPipelineServiceClient = mocks.MockPipelineServiceClient{}
 		pipelineService = &DefaultPipelineService{
-			context.Background(),
 			&mockPipelineServiceClient,
 		}
 	})
@@ -44,7 +44,7 @@ var _ = Describe("PipelineService", func() {
 				},
 			).Return(nil)
 
-			err := pipelineService.DeletePipeline(pipelineId)
+			err := pipelineService.DeletePipeline(ctx, pipelineId)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -57,7 +57,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(status.Errorf(codes.NotFound, "resource not found"))
 
-				err := pipelineService.DeletePipeline(pipelineId)
+				err := pipelineService.DeletePipeline(ctx, pipelineId)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -71,7 +71,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(status.Errorf(codes.Canceled, "resource not found"))
 
-				err := pipelineService.DeletePipeline(pipelineId)
+				err := pipelineService.DeletePipeline(ctx, pipelineId)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -85,7 +85,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(errors.New("failed"))
 
-				err := pipelineService.DeletePipeline(pipelineId)
+				err := pipelineService.DeletePipeline(ctx, pipelineId)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -105,7 +105,7 @@ var _ = Describe("PipelineService", func() {
 				},
 			).Return(&expectedResult, nil)
 
-			res, err := pipelineService.PipelineIdForName(pipelineId)
+			res, err := pipelineService.PipelineIdForName(ctx, pipelineId)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(pipelineId))
@@ -120,7 +120,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(nil, errors.New("failed"))
 
-				res, err := pipelineService.PipelineIdForName(pipelineId)
+				res, err := pipelineService.PipelineIdForName(ctx, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -139,7 +139,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(&expectedResult, nil)
 
-				res, err := pipelineService.PipelineIdForName(pipelineId)
+				res, err := pipelineService.PipelineIdForName(ctx, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -161,7 +161,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(&expectedResult, nil)
 
-				res, err := pipelineService.PipelineIdForName(pipelineId)
+				res, err := pipelineService.PipelineIdForName(ctx, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -186,7 +186,7 @@ var _ = Describe("PipelineService", func() {
 				},
 			).Return(&expectedResult, nil)
 
-			res, err := pipelineService.PipelineVersionIdForName(versionName, pipelineId)
+			res, err := pipelineService.PipelineVersionIdForName(ctx, versionName, pipelineId)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(versionId))
@@ -204,7 +204,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(nil, errors.New("failed"))
 
-				res, err := pipelineService.PipelineVersionIdForName(versionName, pipelineId)
+				res, err := pipelineService.PipelineVersionIdForName(ctx, versionName, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -226,7 +226,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(&expectedResult, nil)
 
-				res, err := pipelineService.PipelineVersionIdForName(versionName, pipelineId)
+				res, err := pipelineService.PipelineVersionIdForName(ctx, versionName, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())
@@ -251,7 +251,7 @@ var _ = Describe("PipelineService", func() {
 					},
 				).Return(&expectedResult, nil)
 
-				res, err := pipelineService.PipelineVersionIdForName(versionName, pipelineId)
+				res, err := pipelineService.PipelineVersionIdForName(ctx, versionName, pipelineId)
 
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeEmpty())

--- a/provider-service/kfp/internal/provider/pipeline_upload_service.go
+++ b/provider-service/kfp/internal/provider/pipeline_upload_service.go
@@ -14,11 +14,13 @@ import (
 
 type PipelineUploadService interface {
 	UploadPipeline(
+		ctx context.Context,
 		content []byte,
 		pipelineName string,
 	) (string, error)
 
 	UploadPipelineVersion(
+		ctx context.Context,
 		id string,
 		content []byte,
 		version string,
@@ -26,7 +28,6 @@ type PipelineUploadService interface {
 }
 
 type DefaultPipelineUploadService struct {
-	ctx context.Context
 	// There is no gRPC client equivalent to the http client. The gRPC pipeline
 	// service has similar methods (CreatePipeline, CreatePipelineVersion), but
 	// require a URL to an already uploaded file rather than actually uploading
@@ -37,7 +38,6 @@ type DefaultPipelineUploadService struct {
 const uploadPipelineFilePath string = "resource.json"
 
 func NewPipelineUploadService(
-	ctx context.Context,
 	restKfpApiUrl string,
 ) (*DefaultPipelineUploadService, error) {
 	apiUrl, err := url.Parse(restKfpApiUrl)
@@ -55,7 +55,6 @@ func NewPipelineUploadService(
 	).PipelineUploadService
 
 	return &DefaultPipelineUploadService{
-		ctx:                   ctx,
 		pipelineUploadService: pipelineUploadService,
 	}, nil
 }
@@ -65,6 +64,7 @@ func NewPipelineUploadService(
 // pipelineFilePath file extension and content data time must align and be
 // recognized by pipeline_upload_service.
 func (us *DefaultPipelineUploadService) UploadPipeline(
+	ctx context.Context,
 	content []byte,
 	pipelineName string,
 ) (string, error) {
@@ -74,7 +74,7 @@ func (us *DefaultPipelineUploadService) UploadPipeline(
 		&pipeline_upload_service.UploadPipelineParams{
 			Name:       &pipelineName,
 			Uploadfile: uploadFile,
-			Context:    us.ctx,
+			Context:    ctx,
 		},
 		nil,
 	)
@@ -90,6 +90,7 @@ func (us *DefaultPipelineUploadService) UploadPipeline(
 // pipelineFilePath file extension and content data time must align and be
 // recognized by pipeline_upload_service.
 func (us *DefaultPipelineUploadService) UploadPipelineVersion(
+	ctx context.Context,
 	id string,
 	content []byte,
 	version string,
@@ -101,7 +102,7 @@ func (us *DefaultPipelineUploadService) UploadPipelineVersion(
 			Name:       &version,
 			Pipelineid: &id,
 			Uploadfile: uploadFile,
-			Context:    us.ctx,
+			Context:    ctx,
 		},
 		nil,
 	)

--- a/provider-service/kfp/internal/provider/pipeline_upload_service_test.go
+++ b/provider-service/kfp/internal/provider/pipeline_upload_service_test.go
@@ -23,12 +23,12 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 		content      = []byte{86}
 		pipelineName = "pipeline-name"
 		uploadFile   = runtime.NamedReader(uploadPipelineFilePath, bytes.NewReader(content))
+		ctx          = context.Background()
 	)
 
 	BeforeEach(func() {
 		mockPipelineUploadServiceClient = mocks.MockPipelineUploadServiceClient{}
 		pipelineUploadService = DefaultPipelineUploadService{
-			context.Background(),
 			&mockPipelineUploadServiceClient,
 		}
 	})
@@ -39,7 +39,7 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 				expectedReq := &pipeline_upload_service.UploadPipelineParams{
 					Name:       &pipelineName,
 					Uploadfile: uploadFile,
-					Context:    pipelineUploadService.ctx,
+					Context:    ctx,
 				}
 				expectedId := "expected-id"
 				mockPipelineUploadServiceClient.On(
@@ -54,6 +54,7 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 					nil,
 				)
 				result, err := pipelineUploadService.UploadPipeline(
+					ctx,
 					content,
 					pipelineName,
 				)
@@ -68,13 +69,14 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 				expectedReq := &pipeline_upload_service.UploadPipelineParams{
 					Name:       &pipelineName,
 					Uploadfile: uploadFile,
-					Context:    pipelineUploadService.ctx,
+					Context:    ctx,
 				}
 				mockPipelineUploadServiceClient.On(
 					"UploadPipeline",
 					expectedReq,
 				).Return(nil, errors.New("failed"))
 				result, err := pipelineUploadService.UploadPipeline(
+					ctx,
 					content,
 					pipelineName,
 				)
@@ -96,7 +98,7 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 					Name:       &version,
 					Pipelineid: &id,
 					Uploadfile: uploadFile,
-					Context:    pipelineUploadService.ctx,
+					Context:    ctx,
 				}
 				mockPipelineUploadServiceClient.On(
 					"UploadPipelineVersion",
@@ -108,6 +110,7 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 					nil,
 				)
 				err := pipelineUploadService.UploadPipelineVersion(
+					ctx,
 					id,
 					content,
 					version,
@@ -123,13 +126,14 @@ var _ = Describe("DefaultPipelineUploadService", func() {
 					Name:       &version,
 					Pipelineid: &id,
 					Uploadfile: uploadFile,
-					Context:    pipelineUploadService.ctx,
+					Context:    ctx,
 				}
 				mockPipelineUploadServiceClient.On(
 					"UploadPipelineVersion",
 					expectedReq,
 				).Return(nil, errors.New("failed"))
 				err := pipelineUploadService.UploadPipelineVersion(
+					ctx,
 					id,
 					content,
 					version,

--- a/provider-service/kfp/internal/provider/provider_test.go
+++ b/provider-service/kfp/internal/provider/provider_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/testutil"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/config"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/mocks"
-	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("Provider", func() {
@@ -23,8 +22,6 @@ var _ = Describe("Provider", func() {
 		mockJobService            mocks.MockJobService
 		ctx                       = context.Background()
 	)
-
-	const ignoreCtx = mock.Anything
 
 	BeforeEach(func() {
 		mockPipelineService = mocks.MockPipelineService{}
@@ -57,10 +54,10 @@ var _ = Describe("Provider", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			It("should return run id if run is created", func() {
-				mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-				mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-				mockExperimentService.On("ExperimentIdByName", ignoreCtx, rd.ExperimentName).Return(experimentId, nil)
-				mockRunService.On("CreateRun", ignoreCtx, rd, pipelineId, pipelineVersionId, experimentId).Return(runId, nil)
+				mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+				mockPipelineService.On("PipelineVersionIdForName", rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+				mockExperimentService.On("ExperimentIdByName", rd.ExperimentName).Return(experimentId, nil)
+				mockRunService.On("CreateRun", rd, pipelineId, pipelineVersionId, experimentId).Return(runId, nil)
 				result, err := provider.CreateRun(ctx, rd)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -81,7 +78,7 @@ var _ = Describe("Provider", func() {
 			When("pipeline service PipelineIdForName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return("", expectedErr)
 					result, err := provider.CreateRun(ctx, rd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -92,8 +89,8 @@ var _ = Describe("Provider", func() {
 			When("pipeline service PipelineVersionIdForName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rd.PipelineVersion, pipelineId).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rd.PipelineVersion, pipelineId).Return("", expectedErr)
 					result, err := provider.CreateRun(ctx, rd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -104,9 +101,9 @@ var _ = Describe("Provider", func() {
 			When("experiment service ExperimentIdByName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-					mockExperimentService.On("ExperimentIdByName", ignoreCtx, rd.ExperimentName).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+					mockExperimentService.On("ExperimentIdByName", rd.ExperimentName).Return("", expectedErr)
 					result, err := provider.CreateRun(ctx, rd)
 
 					Expect(err).To(HaveOccurred())
@@ -117,10 +114,10 @@ var _ = Describe("Provider", func() {
 			When("run service CreateRun errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-					mockExperimentService.On("ExperimentIdByName", ignoreCtx, rd.ExperimentName).Return(experimentId, nil)
-					mockRunService.On("CreateRun", ignoreCtx, rd, pipelineId, pipelineVersionId, experimentId).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+					mockExperimentService.On("ExperimentIdByName", rd.ExperimentName).Return(experimentId, nil)
+					mockRunService.On("CreateRun", rd, pipelineId, pipelineVersionId, experimentId).Return("", expectedErr)
 					result, err := provider.CreateRun(ctx, rd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -140,8 +137,8 @@ var _ = Describe("Provider", func() {
 
 		Context("CreatePipeline", func() {
 			It("should return id if pipeline is created", func() {
-				mockPipelineUploadService.On("UploadPipeline", ignoreCtx, []byte{}, nsnStr).Return(id, nil)
-				mockPipelineUploadService.On("UploadPipelineVersion", ignoreCtx, id, []byte{}, version).Return(nil)
+				mockPipelineUploadService.On("UploadPipeline", []byte{}, nsnStr).Return(id, nil)
+				mockPipelineUploadService.On("UploadPipelineVersion", id, []byte{}, version).Return(nil)
 				result, err := provider.CreatePipeline(ctx, pdw)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -159,7 +156,7 @@ var _ = Describe("Provider", func() {
 
 			It("should return err if UploadPipeline fails", func() {
 				expectedErr := errors.New("failed")
-				mockPipelineUploadService.On("UploadPipeline", ignoreCtx, []byte{}, nsnStr).Return("", expectedErr)
+				mockPipelineUploadService.On("UploadPipeline", []byte{}, nsnStr).Return("", expectedErr)
 				result, err := provider.CreatePipeline(ctx, pdw)
 
 				Expect(err).To(Equal(expectedErr))
@@ -168,8 +165,8 @@ var _ = Describe("Provider", func() {
 
 			It("should return err if UpdatePipelineVersion fails", func() {
 				expectedErr := errors.New("failed")
-				mockPipelineUploadService.On("UploadPipeline", ignoreCtx, []byte{}, nsnStr).Return(id, nil)
-				mockPipelineUploadService.On("UploadPipelineVersion", ignoreCtx, id, []byte{}, version).Return(expectedErr)
+				mockPipelineUploadService.On("UploadPipeline", []byte{}, nsnStr).Return(id, nil)
+				mockPipelineUploadService.On("UploadPipelineVersion", id, []byte{}, version).Return(expectedErr)
 				result, err := provider.CreatePipeline(ctx, pdw)
 
 				Expect(err).To(Equal(expectedErr))
@@ -179,7 +176,7 @@ var _ = Describe("Provider", func() {
 
 		Context("UpdatePipeline", func() {
 			It("should return id if pipeline is updated", func() {
-				mockPipelineUploadService.On("UploadPipelineVersion", ignoreCtx, id, []byte{}, version).Return(nil)
+				mockPipelineUploadService.On("UploadPipelineVersion", id, []byte{}, version).Return(nil)
 				result, err := provider.UpdatePipeline(ctx, pdw, id)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -189,7 +186,7 @@ var _ = Describe("Provider", func() {
 			When("pipeline upload service errors", func() {
 				It("should return empty id and err", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineUploadService.On("UploadPipelineVersion", ignoreCtx, id, []byte{}, version).Return(expectedErr)
+					mockPipelineUploadService.On("UploadPipelineVersion", id, []byte{}, version).Return(expectedErr)
 					result, err := provider.UpdatePipeline(ctx, pdw, id)
 
 					Expect(err).To(Equal(expectedErr))
@@ -201,7 +198,7 @@ var _ = Describe("Provider", func() {
 
 		Context("DeletePipeline", func() {
 			It("should not error", func() {
-				mockPipelineService.On("DeletePipeline", ignoreCtx, id).Return(nil)
+				mockPipelineService.On("DeletePipeline", id).Return(nil)
 
 				Expect(provider.DeletePipeline(ctx, id)).To(Succeed())
 			})
@@ -209,7 +206,7 @@ var _ = Describe("Provider", func() {
 			When("pipeline service errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("DeletePipeline", ignoreCtx, id).Return(expectedErr)
+					mockPipelineService.On("DeletePipeline", id).Return(expectedErr)
 					err := provider.DeletePipeline(ctx, id)
 
 					Expect(err).To(Equal(expectedErr))
@@ -232,10 +229,10 @@ var _ = Describe("Provider", func() {
 
 		Context("CreateRunSchedule", func() {
 			It("should return job id if run schedule is created", func() {
-				mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-				mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-				mockExperimentService.On("ExperimentIdByName", ignoreCtx, rsd.ExperimentName).Return(experimentId, nil)
-				mockJobService.On("CreateJob", ignoreCtx, rsd, pipelineId, pipelineVersionId, experimentId).Return(jobId, nil)
+				mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+				mockPipelineService.On("PipelineVersionIdForName", rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+				mockExperimentService.On("ExperimentIdByName", rsd.ExperimentName).Return(experimentId, nil)
+				mockJobService.On("CreateJob", rsd, pipelineId, pipelineVersionId, experimentId).Return(jobId, nil)
 				result, err := provider.CreateRunSchedule(ctx, rsd)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -256,7 +253,7 @@ var _ = Describe("Provider", func() {
 			When("pipeline service PipelineIdForName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return("", expectedErr)
 					result, err := provider.CreateRunSchedule(ctx, rsd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -267,8 +264,8 @@ var _ = Describe("Provider", func() {
 			When("pipeline service PipelineVersionIdForName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rsd.PipelineVersion, pipelineId).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rsd.PipelineVersion, pipelineId).Return("", expectedErr)
 					result, err := provider.CreateRunSchedule(ctx, rsd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -279,9 +276,9 @@ var _ = Describe("Provider", func() {
 			When("experiment service ExperimentIdByName errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-					mockExperimentService.On("ExperimentIdByName", ignoreCtx, rsd.ExperimentName).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+					mockExperimentService.On("ExperimentIdByName", rsd.ExperimentName).Return("", expectedErr)
 					result, err := provider.CreateRunSchedule(ctx, rsd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -292,10 +289,10 @@ var _ = Describe("Provider", func() {
 			When("job service CreateJob errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-					mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-					mockExperimentService.On("ExperimentIdByName", ignoreCtx, rsd.ExperimentName).Return(experimentId, nil)
-					mockJobService.On("CreateJob", ignoreCtx, rsd, pipelineId, pipelineVersionId, experimentId).Return("", expectedErr)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+					mockPipelineService.On("PipelineVersionIdForName", rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+					mockExperimentService.On("ExperimentIdByName", rsd.ExperimentName).Return(experimentId, nil)
+					mockJobService.On("CreateJob", rsd, pipelineId, pipelineVersionId, experimentId).Return("", expectedErr)
 					result, err := provider.CreateRunSchedule(ctx, rsd)
 
 					Expect(err).To(Equal(expectedErr))
@@ -306,11 +303,11 @@ var _ = Describe("Provider", func() {
 
 		Context("UpdateRunSchedule", func() {
 			It("should return job id if run schedule is updated", func() {
-				mockJobService.On("DeleteJob", ignoreCtx, jobId).Return(nil)
-				mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return(pipelineId, nil)
-				mockPipelineService.On("PipelineVersionIdForName", ignoreCtx, rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
-				mockExperimentService.On("ExperimentIdByName", ignoreCtx, rsd.ExperimentName).Return(experimentId, nil)
-				mockJobService.On("CreateJob", ignoreCtx, rsd, pipelineId, pipelineVersionId, experimentId).Return(jobId, nil)
+				mockJobService.On("DeleteJob", jobId).Return(nil)
+				mockPipelineService.On("PipelineIdForName", nsnStr).Return(pipelineId, nil)
+				mockPipelineService.On("PipelineVersionIdForName", rsd.PipelineVersion, pipelineId).Return(pipelineVersionId, nil)
+				mockExperimentService.On("ExperimentIdByName", rsd.ExperimentName).Return(experimentId, nil)
+				mockJobService.On("CreateJob", rsd, pipelineId, pipelineVersionId, experimentId).Return(jobId, nil)
 				result, err := provider.UpdateRunSchedule(ctx, rsd, jobId)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -320,7 +317,7 @@ var _ = Describe("Provider", func() {
 			When("DeleteRunSchedule errors", func() {
 				It("should return error and retain the id", func() {
 					expectedErr := errors.New("failed")
-					mockJobService.On("DeleteJob", ignoreCtx, jobId).Return(expectedErr)
+					mockJobService.On("DeleteJob", jobId).Return(expectedErr)
 					result, err := provider.UpdateRunSchedule(ctx, rsd, jobId)
 
 					Expect(err).To(Equal(expectedErr))
@@ -331,8 +328,8 @@ var _ = Describe("Provider", func() {
 			When("CreateRunSchedule errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockJobService.On("DeleteJob", ignoreCtx, jobId).Return(nil)
-					mockPipelineService.On("PipelineIdForName", ignoreCtx, nsnStr).Return("", expectedErr)
+					mockJobService.On("DeleteJob", jobId).Return(nil)
+					mockPipelineService.On("PipelineIdForName", nsnStr).Return("", expectedErr)
 					result, err := provider.UpdateRunSchedule(ctx, rsd, jobId)
 
 					Expect(err).To(Equal(expectedErr))
@@ -343,7 +340,7 @@ var _ = Describe("Provider", func() {
 
 		Context("DeleteRunSchedule", func() {
 			It("should not error", func() {
-				mockJobService.On("DeleteJob", ignoreCtx, jobId).Return(nil)
+				mockJobService.On("DeleteJob", jobId).Return(nil)
 
 				Expect(provider.DeleteRunSchedule(ctx, jobId)).To(Succeed())
 			})
@@ -351,7 +348,7 @@ var _ = Describe("Provider", func() {
 			When("job service errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockJobService.On("DeleteJob", ignoreCtx, jobId).Return(expectedErr)
+					mockJobService.On("DeleteJob", jobId).Return(expectedErr)
 					err := provider.DeleteRunSchedule(ctx, jobId)
 
 					Expect(err).To(Equal(expectedErr))
@@ -366,7 +363,7 @@ var _ = Describe("Provider", func() {
 
 		Context("CreateExperiment", func() {
 			It("should return id if experiment is created", func() {
-				mockExperimentService.On("CreateExperiment", ignoreCtx, experiment.Name, experiment.Description).Return(id, nil)
+				mockExperimentService.On("CreateExperiment", experiment.Name, experiment.Description).Return(id, nil)
 				result, err := provider.CreateExperiment(ctx, experiment)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -376,7 +373,7 @@ var _ = Describe("Provider", func() {
 			When("experiment service CreateExperiment errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockExperimentService.On("CreateExperiment", ignoreCtx, experiment.Name, experiment.Description).Return("", expectedErr)
+					mockExperimentService.On("CreateExperiment", experiment.Name, experiment.Description).Return("", expectedErr)
 					result, err := provider.CreateExperiment(ctx, experiment)
 
 					Expect(err).To(Equal(expectedErr))
@@ -387,8 +384,8 @@ var _ = Describe("Provider", func() {
 
 		Context("UpdateExperiment", func() {
 			It("should return id if experiment is updated", func() {
-				mockExperimentService.On("DeleteExperiment", ignoreCtx, id).Return(nil)
-				mockExperimentService.On("CreateExperiment", ignoreCtx, experiment.Name, experiment.Description).Return(id, nil)
+				mockExperimentService.On("DeleteExperiment", id).Return(nil)
+				mockExperimentService.On("CreateExperiment", experiment.Name, experiment.Description).Return(id, nil)
 				result, err := provider.UpdateExperiment(ctx, experiment, id)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -398,7 +395,7 @@ var _ = Describe("Provider", func() {
 			When("DeleteExperiment errors", func() {
 				It("should return error and retain the id", func() {
 					expectedErr := errors.New("failed")
-					mockExperimentService.On("DeleteExperiment", ignoreCtx, id).Return(expectedErr)
+					mockExperimentService.On("DeleteExperiment", id).Return(expectedErr)
 					result, err := provider.UpdateExperiment(ctx, experiment, id)
 
 					Expect(err).To(Equal(expectedErr))
@@ -409,8 +406,8 @@ var _ = Describe("Provider", func() {
 			When("CreateExperiment errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockExperimentService.On("DeleteExperiment", ignoreCtx, id).Return(nil)
-					mockExperimentService.On("CreateExperiment", ignoreCtx, experiment.Name, experiment.Description).Return("", expectedErr)
+					mockExperimentService.On("DeleteExperiment", id).Return(nil)
+					mockExperimentService.On("CreateExperiment", experiment.Name, experiment.Description).Return("", expectedErr)
 					result, err := provider.UpdateExperiment(ctx, experiment, id)
 
 					Expect(err).To(Equal(expectedErr))
@@ -421,7 +418,7 @@ var _ = Describe("Provider", func() {
 
 		Context("DeleteExperiment", func() {
 			It("should not error", func() {
-				mockExperimentService.On("DeleteExperiment", ignoreCtx, id).Return(nil)
+				mockExperimentService.On("DeleteExperiment", id).Return(nil)
 
 				Expect(provider.DeleteExperiment(ctx, id)).To(Succeed())
 			})
@@ -429,7 +426,7 @@ var _ = Describe("Provider", func() {
 			When("experiment service errors", func() {
 				It("should return error", func() {
 					expectedErr := errors.New("failed")
-					mockExperimentService.On("DeleteExperiment", ignoreCtx, id).Return(expectedErr)
+					mockExperimentService.On("DeleteExperiment", id).Return(expectedErr)
 					err := provider.DeleteExperiment(ctx, id)
 
 					Expect(err).To(Equal(expectedErr))

--- a/provider-service/kfp/internal/provider/run_service.go
+++ b/provider-service/kfp/internal/provider/run_service.go
@@ -17,6 +17,7 @@ import (
 
 type RunService interface {
 	CreateRun(
+		ctx context.Context,
 		rd baseResource.RunDefinition,
 		pipelineId string,
 		pipelineVersionId string,
@@ -25,12 +26,10 @@ type RunService interface {
 }
 
 type DefaultRunService struct {
-	ctx    context.Context
 	client client.RunServiceClient
 }
 
 func NewRunService(
-	ctx context.Context,
 	conn *grpc.ClientConn,
 ) (RunService, error) {
 	if conn == nil {
@@ -40,13 +39,13 @@ func NewRunService(
 	}
 
 	return &DefaultRunService{
-		ctx:    ctx,
 		client: go_client.NewRunServiceClient(conn),
 	}, nil
 }
 
 // CreateRun creates a run and returns the generated run id.
 func (drs DefaultRunService) CreateRun(
+	ctx context.Context,
 	rd baseResource.RunDefinition,
 	pipelineId string,
 	pipelineVersionId string,
@@ -77,7 +76,7 @@ func (drs DefaultRunService) CreateRun(
 		return "", err
 	}
 
-	run, err := drs.client.CreateRun(drs.ctx, &go_client.CreateRunRequest{
+	run, err := drs.client.CreateRun(ctx, &go_client.CreateRunRequest{
 		Run: &go_client.Run{
 			Name:        name,
 			Description: string(runAsDescription),

--- a/provider-service/kfp/internal/provider/run_service_test.go
+++ b/provider-service/kfp/internal/provider/run_service_test.go
@@ -26,6 +26,7 @@ var _ = Describe("RunService", func() {
 		mockRunServiceClient mocks.MockRunServiceClient
 		runService           RunService
 		rd                   = testutil.RandomRunDefinition()
+		ctx                  = context.Background()
 	)
 
 	rd.Name.Name = "runName"
@@ -95,7 +96,6 @@ var _ = Describe("RunService", func() {
 		func() {
 			mockRunServiceClient = mocks.MockRunServiceClient{}
 			runService = DefaultRunService{
-				ctx:    context.Background(),
 				client: &mockRunServiceClient,
 			}
 		},
@@ -109,6 +109,7 @@ var _ = Describe("RunService", func() {
 				nil,
 			)
 			runId, err := runService.CreateRun(
+				ctx,
 				rd,
 				pipelineId,
 				pipelineVersionId,
@@ -124,6 +125,7 @@ var _ = Describe("RunService", func() {
 				rdCopy := rd
 				rdCopy.Name.Name = ""
 				runId, err := runService.CreateRun(
+					ctx,
 					rdCopy,
 					pipelineId,
 					pipelineVersionId,
@@ -140,6 +142,7 @@ var _ = Describe("RunService", func() {
 				expectedErr := errors.New("error")
 				mockRunServiceClient.On("CreateRun", expectedReq).Return(nil, expectedErr)
 				runId, err := runService.CreateRun(
+					ctx,
 					rd,
 					pipelineId,
 					pipelineVersionId,

--- a/provider-service/stub/cmd/main.go
+++ b/provider-service/stub/cmd/main.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	ctx := logr.NewContext(context.Background(), logger)
-	provider := provider.New(logger)
+	stubProvider := provider.New(logger)
 	cfg, err := baseConfig.LoadConfig(
 		baseConfig.Config{
 			Server: baseConfig.Server{
@@ -34,7 +34,7 @@ func main() {
 		panic(err)
 	}
 
-	if err = server.Start(ctx, *cfg, provider); err != nil {
+	if err = server.Start(ctx, *cfg, stubProvider); err != nil {
 		panic(err)
 	}
 

--- a/provider-service/stub/internal/provider/provider.go
+++ b/provider-service/stub/internal/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -17,6 +18,7 @@ func New(logger logr.Logger) resource.Provider {
 }
 
 func (p *StubProvider) CreatePipeline(
+	_ context.Context,
 	pdw resource.PipelineDefinitionWrapper,
 ) (string, error) {
 	if strings.EqualFold(pdw.PipelineDefinition.Name.Name, CreatePipelineFail) {
@@ -27,7 +29,8 @@ func (p *StubProvider) CreatePipeline(
 }
 
 func (p *StubProvider) UpdatePipeline(
-	pdw resource.PipelineDefinitionWrapper,
+	_ context.Context,
+	_ resource.PipelineDefinitionWrapper,
 	id string,
 ) (string, error) {
 	if strings.EqualFold(id, UpdatePipelineFail) {
@@ -37,7 +40,7 @@ func (p *StubProvider) UpdatePipeline(
 	}
 }
 
-func (p *StubProvider) DeletePipeline(id string) error {
+func (p *StubProvider) DeletePipeline(_ context.Context, id string) error {
 	if strings.EqualFold(id, DeletePipelineFail) {
 		return &DeletePipelineError{}
 	} else {
@@ -46,6 +49,7 @@ func (p *StubProvider) DeletePipeline(id string) error {
 }
 
 func (p *StubProvider) CreateRun(
+	_ context.Context,
 	rd resource.RunDefinition,
 ) (string, error) {
 	if strings.EqualFold(rd.Name.Name, CreateRunFail) {
@@ -55,7 +59,7 @@ func (p *StubProvider) CreateRun(
 	}
 }
 
-func (p *StubProvider) DeleteRun(id string) error {
+func (p *StubProvider) DeleteRun(_ context.Context, id string) error {
 	if strings.EqualFold(id, DeleteRunFail) {
 		return &DeleteRunError{}
 	} else {
@@ -64,6 +68,7 @@ func (p *StubProvider) DeleteRun(id string) error {
 }
 
 func (p *StubProvider) CreateRunSchedule(
+	_ context.Context,
 	rsd resource.RunScheduleDefinition,
 ) (string, error) {
 	if strings.EqualFold(rsd.Name.Name, CreateRunScheduleFail) {
@@ -74,8 +79,9 @@ func (p *StubProvider) CreateRunSchedule(
 }
 
 func (p *StubProvider) UpdateRunSchedule(
+	_ context.Context,
 	rsd resource.RunScheduleDefinition,
-	id string,
+	_ string,
 ) (string, error) {
 	if strings.EqualFold(rsd.Name.Name, UpdateRunScheduleFail) {
 		return "", &UpdateRunScheduleError{}
@@ -84,7 +90,7 @@ func (p *StubProvider) UpdateRunSchedule(
 	}
 }
 
-func (p *StubProvider) DeleteRunSchedule(id string) error {
+func (p *StubProvider) DeleteRunSchedule(_ context.Context, id string) error {
 	if strings.EqualFold(id, DeleteRunScheduledFail) {
 		return &DeleteRunScheduleError{}
 	} else {
@@ -93,6 +99,7 @@ func (p *StubProvider) DeleteRunSchedule(id string) error {
 }
 
 func (p *StubProvider) CreateExperiment(
+	_ context.Context,
 	ed resource.ExperimentDefinition,
 ) (string, error) {
 	if strings.EqualFold(ed.Name.Name, CreateExperimentFail) {
@@ -103,8 +110,9 @@ func (p *StubProvider) CreateExperiment(
 }
 
 func (p *StubProvider) UpdateExperiment(
+	_ context.Context,
 	ed resource.ExperimentDefinition,
-	id string,
+	_ string,
 ) (string, error) {
 	if strings.EqualFold(ed.Name.Name, UpdateExperimentFail) {
 		return "", &UpdateExperimentError{}
@@ -113,7 +121,7 @@ func (p *StubProvider) UpdateExperiment(
 	}
 }
 
-func (p *StubProvider) DeleteExperiment(id string) error {
+func (p *StubProvider) DeleteExperiment(_ context.Context, id string) error {
 	if strings.EqualFold(id, DeleteExperimentFail) {
 		return &DeleteExperimentError{}
 	} else {

--- a/provider-service/vai/cmd/main.go
+++ b/provider-service/vai/cmd/main.go
@@ -81,10 +81,10 @@ func runEventing(ctx context.Context, logger logr.Logger, baseConfig *baseConfig
 	}
 	go handleErrorInSourceOperations(source)
 
-	flow := runcompletion.NewEventFlow(ctx, providerConfig, pipelineJobClient)
+	flow := runcompletion.NewEventFlow(providerConfig, pipelineJobClient)
 
 	go func() {
-		flow.Start()
+		flow.Start(ctx)
 	}()
 
 	sink := sinks.NewWebhookSink(ctx, resty.New(), baseConfig.OperatorWebhook, make(chan StreamMessage[*common.RunCompletionEventData]))

--- a/provider-service/vai/internal/mocks/file_handler.go
+++ b/provider-service/vai/internal/mocks/file_handler.go
@@ -7,18 +7,18 @@ import (
 
 type MockFileHandler struct{ mock.Mock }
 
-func (m *MockFileHandler) Write(ctx context.Context, p []byte, bucket string, filePath string) error {
-	args := m.Called(ctx, p, bucket, filePath)
+func (m *MockFileHandler) Write(_ context.Context, p []byte, bucket string, filePath string) error {
+	args := m.Called(p, bucket, filePath)
 	return args.Error(0)
 }
 
-func (m *MockFileHandler) Delete(ctx context.Context, id string, bucket string) error {
-	args := m.Called(ctx, id, bucket)
+func (m *MockFileHandler) Delete(_ context.Context, id string, bucket string) error {
+	args := m.Called(id, bucket)
 	return args.Error(0)
 }
 
-func (m *MockFileHandler) Read(ctx context.Context, bucket string, filePath string) (map[string]any, error) {
-	args := m.Called(ctx, bucket, filePath)
+func (m *MockFileHandler) Read(_ context.Context, bucket string, filePath string) (map[string]any, error) {
+	args := m.Called(bucket, filePath)
 	var data map[string]any
 	if arg0 := args.Get(0); arg0 != nil {
 		data = arg0.(map[string]any)

--- a/provider-service/vai/internal/mocks/file_handler.go
+++ b/provider-service/vai/internal/mocks/file_handler.go
@@ -1,21 +1,24 @@
 package mocks
 
-import "github.com/stretchr/testify/mock"
+import (
+	"context"
+	"github.com/stretchr/testify/mock"
+)
 
 type MockFileHandler struct{ mock.Mock }
 
-func (m *MockFileHandler) Write(p []byte, bucket string, filePath string) error {
-	args := m.Called(p, bucket, filePath)
+func (m *MockFileHandler) Write(ctx context.Context, p []byte, bucket string, filePath string) error {
+	args := m.Called(ctx, p, bucket, filePath)
 	return args.Error(0)
 }
 
-func (m *MockFileHandler) Delete(id string, bucket string) error {
-	args := m.Called(id, bucket)
+func (m *MockFileHandler) Delete(ctx context.Context, id string, bucket string) error {
+	args := m.Called(ctx, id, bucket)
 	return args.Error(0)
 }
 
-func (m *MockFileHandler) Read(bucket string, filePath string) (map[string]any, error) {
-	args := m.Called(bucket, filePath)
+func (m *MockFileHandler) Read(ctx context.Context, bucket string, filePath string) (map[string]any, error) {
+	args := m.Called(ctx, bucket, filePath)
 	var data map[string]any
 	if arg0 := args.Get(0); arg0 != nil {
 		data = arg0.(map[string]any)

--- a/provider-service/vai/internal/provider/file_handler.go
+++ b/provider-service/vai/internal/provider/file_handler.go
@@ -14,13 +14,12 @@ import (
 )
 
 type FileHandler interface {
-	Write(content []byte, bucket string, filePath string) error
-	Delete(id string, bucket string) error
-	Read(bucket string, filePath string) (map[string]any, error)
+	Write(ctx context.Context, content []byte, bucket string, filePath string) error
+	Delete(ctx context.Context, id string, bucket string) error
+	Read(ctx context.Context, bucket string, filePath string) (map[string]any, error)
 }
 
 type GcsFileHandler struct {
-	ctx       context.Context
 	gcsClient storage.Client
 }
 
@@ -44,17 +43,18 @@ func NewGcsFileHandler(
 		return GcsFileHandler{}, err
 	}
 
-	return GcsFileHandler{ctx: ctx, gcsClient: *client}, nil
+	return GcsFileHandler{gcsClient: *client}, nil
 }
 
 // Write writes bytes into the location inferred by GCS bucket name and
 // file path (relative to GCS bucket location).
 func (g *GcsFileHandler) Write(
+	ctx context.Context,
 	content []byte,
 	bucket string,
 	filePath string,
 ) error {
-	writer := g.gcsClient.Bucket(bucket).Object(filePath).NewWriter(g.ctx)
+	writer := g.gcsClient.Bucket(bucket).Object(filePath).NewWriter(ctx)
 
 	_, err := io.Writer(writer).Write(content)
 	if err != nil {
@@ -67,10 +67,10 @@ func (g *GcsFileHandler) Write(
 }
 
 // Delete deletes all files inferred by the GCS bucket name and id.
-func (g *GcsFileHandler) Delete(id string, bucket string) error {
+func (g *GcsFileHandler) Delete(ctx context.Context, id string, bucket string) error {
 	query := &storage.Query{Prefix: fmt.Sprintf("%s/", id)}
 
-	it := g.gcsClient.Bucket(bucket).Objects(g.ctx, query)
+	it := g.gcsClient.Bucket(bucket).Objects(ctx, query)
 	for {
 		attrs, err := it.Next()
 		if errors.Is(err, iterator.Done) {
@@ -80,7 +80,7 @@ func (g *GcsFileHandler) Delete(id string, bucket string) error {
 			return err
 		}
 
-		err = g.gcsClient.Bucket(bucket).Object(attrs.Name).Delete(g.ctx)
+		err = g.gcsClient.Bucket(bucket).Object(attrs.Name).Delete(ctx)
 		if err != nil {
 			return err
 		}
@@ -91,10 +91,11 @@ func (g *GcsFileHandler) Delete(id string, bucket string) error {
 // Read reads and returns the unmarshalled from the location inferred by the
 // GCS bucket name and file path.
 func (g *GcsFileHandler) Read(
+	ctx context.Context,
 	bucket string,
 	filePath string,
 ) (map[string]any, error) {
-	reader, err := g.gcsClient.Bucket(bucket).Object(filePath).NewReader(g.ctx)
+	reader, err := g.gcsClient.Bucket(bucket).Object(filePath).NewReader(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/provider-service/vai/internal/provider/provider_test.go
+++ b/provider-service/vai/internal/provider/provider_test.go
@@ -30,8 +30,6 @@ var _ = Describe("Provider", func() {
 		ctx                = context.Background()
 	)
 
-	ignoreCtx := mock.Anything
-
 	BeforeEach(func() {
 		mockFileHandler = mocks.MockFileHandler{}
 		mockPipelineClient = mocks.MockPipelineJobClient{}
@@ -53,7 +51,6 @@ var _ = Describe("Provider", func() {
 			It("should return the pipeline ID", func() {
 				mockFileHandler.On(
 					"Write",
-					ignoreCtx,
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
@@ -73,7 +70,6 @@ var _ = Describe("Provider", func() {
 			It("return an error when the file handler write fails", func() {
 				mockFileHandler.On(
 					"Write",
-					ignoreCtx,
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
@@ -94,7 +90,6 @@ var _ = Describe("Provider", func() {
 				pdw := testutil.RandomPipelineDefinitionWrapper()
 				mockFileHandler.On(
 					"Write",
-					ignoreCtx,
 					mock.MatchedBy(func(j json.RawMessage) bool {
 						return bytes.Equal(j, pdw.CompiledPipeline)
 					}),
@@ -119,7 +114,6 @@ var _ = Describe("Provider", func() {
 				pdw := testutil.RandomPipelineDefinitionWrapper()
 				mockFileHandler.On(
 					"Write",
-					ignoreCtx,
 					mock.Anything,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
@@ -139,7 +133,6 @@ var _ = Describe("Provider", func() {
 				id := "id"
 				mockFileHandler.On(
 					"Delete",
-					ignoreCtx,
 					id,
 					vaiProvider.config.Parameters.PipelineBucket,
 				).Return(nil)
@@ -150,7 +143,6 @@ var _ = Describe("Provider", func() {
 			It("return an error when the file handler delete fails", func() {
 				mockFileHandler.On(
 					"Delete",
-					ignoreCtx,
 					"pipelineId",
 					vaiProvider.config.Parameters.PipelineBucket,
 				).Return(errors.New("failed"))
@@ -168,7 +160,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					fmt.Sprintf(
 						"%s/%s/%s",
@@ -197,7 +188,6 @@ var _ = Describe("Provider", func() {
 				rd := testutil.RandomRunDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, errors.New("failed"))
@@ -211,7 +201,6 @@ var _ = Describe("Provider", func() {
 				rd := testutil.RandomRunDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -227,7 +216,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -244,7 +232,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -267,7 +254,6 @@ var _ = Describe("Provider", func() {
 				schedule := aiplatformpb.Schedule{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					fmt.Sprintf(
 						"%s/%s/%s",
@@ -302,7 +288,6 @@ var _ = Describe("Provider", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, errors.New("failed"))
@@ -316,7 +301,6 @@ var _ = Describe("Provider", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -332,7 +316,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -349,7 +332,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -373,7 +355,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -402,7 +383,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					fmt.Sprintf(
 						"%s/%s/%s",
@@ -442,7 +422,6 @@ var _ = Describe("Provider", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, errors.New("failed"))
@@ -456,7 +435,6 @@ var _ = Describe("Provider", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -472,7 +450,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -489,7 +466,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)
@@ -513,7 +489,6 @@ var _ = Describe("Provider", func() {
 				pj := aiplatformpb.PipelineJob{}
 				mockFileHandler.On(
 					"Read",
-					ignoreCtx,
 					vaiProvider.config.Parameters.PipelineBucket,
 					mock.Anything,
 				).Return(map[string]any{}, nil)


### PR DESCRIPTION
Closes #623 

## Tasks
- Removed all context fields within structs and moves them to be parameters passed through where necessary. [This addresses issues outlined in the official go documentation](https://go.dev/blog/context-and-structs)
- Use the http request's context as part of defining each http handler function

- [x] Documentation updated
