### PR TITLE
Fix run completion event trigger service not showing per-request logging

### DIFF
--- a/controllers/webhook/runcompletion_event_trigger.go
+++ b/controllers/webhook/runcompletion_event_trigger.go
@@ -23,11 +23,11 @@ func NewRunCompletionEventTrigger(ctx context.Context, endpoint config.Endpoint)
 	logger := log.FromContext(ctx)
 
 	conn, err := grpc.NewClient(endpoint.URL(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	logger.Info("RunCompletionEventTrigger client connected to", "endpoint", endpoint.URL())
 	if err != nil {
 		logger.Error(err, "Error creating grpc client")
 	}
+
+	logger.Info("RunCompletionEventTrigger client connected to", "endpoint", endpoint.URL())
 
 	client := pb.NewRunCompletionEventTriggerClient(conn)
 

--- a/triggers/run-completion-event-trigger/cmd/main.go
+++ b/triggers/run-completion-event-trigger/cmd/main.go
@@ -66,8 +66,7 @@ func unaryLoggerInterceptor(baseLogger logr.Logger) grpc.UnaryServerInterceptor 
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp any, err error) {
-		logger := baseLogger.WithValues("grpc_method", info.FullMethod)
-		ctx = logr.NewContext(ctx, logger)
+		ctx = logr.NewContext(ctx, baseLogger)
 
 		return handler(ctx, req)
 	}

--- a/triggers/run-completion-event-trigger/cmd/main.go
+++ b/triggers/run-completion-event-trigger/cmd/main.go
@@ -45,7 +45,10 @@ func main() {
 
 	natsPublisher := publisher.NewNatsPublisher(ctx, nc, config.NATSConfig.Subject)
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(
+		grpc.UnaryInterceptor(unaryLoggerInterceptor(logger)),
+	)
+
 	pb.RegisterRunCompletionEventTriggerServer(s, &server.Server{Config: config, Publisher: natsPublisher})
 
 	logger.Info("Listening at", "host", config.ServerConfig.Host, "port", config.ServerConfig.Port)
@@ -54,4 +57,18 @@ func main() {
 		panic(err)
 	}
 
+}
+
+func unaryLoggerInterceptor(baseLogger logr.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		logger := baseLogger.WithValues("grpc_method", info.FullMethod)
+		ctx = logr.NewContext(ctx, logger)
+
+		return handler(ctx, req)
+	}
 }


### PR DESCRIPTION
Closes #626

Fix run completion event trigger service not showing per-request logging due to a regression introduced in https://github.com/sky-uk/kfp-operator/pull/594.
In that previous change, the top level context (which had the logger) was no longer being passed into the server, which was using it on a per request basis. This is because contexts should be derived on a per request basis, however when deriving the logger from the new per-request context, this broke logging since that new context did not have a logger.

In this change: introduce a unary server interceptor that will still use a new context per quest in line with golang best practices, but this time it will attach the top level logger into the context which restores logging.
