### PR TITLE
Handle Pipeline hub ComputeHash returning nil

### DIFF
--- a/apis/pipelines/hub/pipeline_types.go
+++ b/apis/pipelines/hub/pipeline_types.go
@@ -70,13 +70,8 @@ func (ps Pipeline) ComputeHash() []byte {
 	// For the default framework, include beamArgs in the hash using the same format as spoke versions to ensure consistency.
 	beamArgsList := []apis.NamedValue{}
 	if isFallbackFramework && pipeline.Spec.Framework.Parameters["beamArgs"] != nil {
-		beamArgs := map[string]string{}
-		if err := json.Unmarshal(pipeline.Spec.Framework.Parameters["beamArgs"].Raw, &beamArgs); err != nil {
+		if err := json.Unmarshal(pipeline.Spec.Framework.Parameters["beamArgs"].Raw, &beamArgsList); err != nil {
 			return nil
-		}
-
-		for key, value := range beamArgs {
-			beamArgsList = append(beamArgsList, apis.NamedValue{Name: key, Value: value})
 		}
 
 		delete(pipeline.Spec.Framework.Parameters, "beamArgs")
@@ -100,7 +95,11 @@ func (ps Pipeline) ComputeHash() []byte {
 }
 
 func (ps Pipeline) ComputeVersion() string {
-	hash := ps.ComputeHash()[0:3]
+	computeHash := ps.ComputeHash()
+	if computeHash == nil {
+		return ""
+	}
+	hash := computeHash[0:3]
 	ref, err := ParseNormalizedNamed(ps.Spec.Image)
 
 	if err == nil {

--- a/apis/test/cross_version_pipeline_hash_test.go
+++ b/apis/test/cross_version_pipeline_hash_test.go
@@ -3,7 +3,7 @@
 package test
 
 import (
-	"fmt"
+	"encoding/json"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
@@ -43,6 +43,13 @@ var _ = Context("Pipeline Hash", Ordered, func() {
 
 	BeforeEach(
 		func() {
+			tfxComponentsJson, err := json.Marshal(tfxComponentsValue)
+			Expect(err).To(Not(HaveOccurred()))
+
+			beamArgs := []apis.NamedValue{{Name: beamArgsKey, Value: beamArgsValue}}
+			beamArgsJson, err := json.Marshal(beamArgs)
+			Expect(err).To(Not(HaveOccurred()))
+
 			beta1Pipeline = v1beta1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -61,10 +68,10 @@ var _ = Context("Pipeline Hash", Ordered, func() {
 						Name: v1beta1.FallbackFramework,
 						Parameters: map[string]*apiextensionsv1.JSON{
 							"components": {
-								Raw: []byte(fmt.Sprintf(`"%s"`, tfxComponentsValue)),
+								Raw: tfxComponentsJson,
 							},
 							"beamArgs": {
-								Raw: []byte(fmt.Sprintf(`{"%s":"%s"}`, beamArgsKey, beamArgsValue)),
+								Raw: beamArgsJson,
 							},
 						},
 					},


### PR DESCRIPTION
In compute version we have started to return nil in the short term whilst handling the version upgrade to v1beta1 and not wanting to trigger pipeline compiles for all deployed pipelines. With an invalid resource it is possible to cause the nil to be returned which at the moment would cause a crash loop backoff of the controller manager.

With this change the manager doesn't crash.

Also added some extra tests around the compute hash function for pipeline.
