### PR TITLE
Use default prometheus registry in Run Completion Event Trigger

### DIFF
--- a/triggers/run-completion-event-trigger/cmd/main.go
+++ b/triggers/run-completion-event-trigger/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	natsPublisher := publisher.NewNatsPublisher(ctx, nc, config.NATSConfig.Subject)
 
-	reg, srvMetrics := server.NewPrometheusRegistryAndServerMetrics()
+	srvMetrics := server.NewPrometheusRegistryAndServerMetrics()
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -82,7 +82,7 @@ func main() {
 		panic(err)
 	}
 
-	metricsSrv := server.NewMetricsServer(config.MetricsConfig.ToAddr(), reg)
+	metricsSrv := server.NewMetricsServer(config.MetricsConfig.ToAddr())
 
 	var waitGroup sync.WaitGroup
 

--- a/triggers/run-completion-event-trigger/cmd/main.go
+++ b/triggers/run-completion-event-trigger/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	natsPublisher := publisher.NewNatsPublisher(ctx, nc, config.NATSConfig.Subject)
 
-	srvMetrics := server.NewPrometheusRegistryAndServerMetrics()
+	srvMetrics := server.NewServerMetrics()
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(

--- a/triggers/run-completion-event-trigger/internal/server/metrics_server.go
+++ b/triggers/run-completion-event-trigger/internal/server/metrics_server.go
@@ -26,9 +26,9 @@ func NewMetricsServer(
 	}
 }
 
-// NewPrometheusRegistryAndServerMetrics creates new ServerMetrics using
-// go-grpc-middleware and registers it to a prometheus registry.
-func NewPrometheusRegistryAndServerMetrics() *grpcprom.ServerMetrics {
+// NewServerMetrics creates new ServerMetrics using
+// go-grpc-middleware and registers it to the default prometheus registry.
+func NewServerMetrics() *grpcprom.ServerMetrics {
 	srvMetrics := grpcprom.NewServerMetrics()
 
 	prometheus.MustRegister(srvMetrics)

--- a/triggers/run-completion-event-trigger/internal/server/metrics_server.go
+++ b/triggers/run-completion-event-trigger/internal/server/metrics_server.go
@@ -12,7 +12,6 @@ import (
 // Gatherer and serves it on the /metrics endpoint
 func NewMetricsServer(
 	addr string,
-	reg prometheus.Gatherer,
 ) *http.Server {
 	return &http.Server{
 		Addr: addr,
@@ -20,7 +19,7 @@ func NewMetricsServer(
 			mux := http.NewServeMux()
 			mux.Handle(
 				"/metrics",
-				promhttp.HandlerFor(reg, promhttp.HandlerOpts{}),
+				promhttp.Handler(),
 			)
 			return mux
 		}(),
@@ -29,11 +28,10 @@ func NewMetricsServer(
 
 // NewPrometheusRegistryAndServerMetrics creates new ServerMetrics using
 // go-grpc-middleware and registers it to a prometheus registry.
-func NewPrometheusRegistryAndServerMetrics() (*prometheus.Registry, *grpcprom.ServerMetrics) {
+func NewPrometheusRegistryAndServerMetrics() *grpcprom.ServerMetrics {
 	srvMetrics := grpcprom.NewServerMetrics()
 
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(srvMetrics)
+	prometheus.MustRegister(srvMetrics)
 
-	return reg, srvMetrics
+	return srvMetrics
 }


### PR DESCRIPTION
Closes #662 

In the Run Completion Event Trigger, switch from using the custom prometheus registry to the default prometheus registry - which provides cpu metrics out of the box

## Tasks

- [ ] ...
- [ ] Documentation updated
