### PR TITLE
Improve run-configuration status feedback when updating

### DIFF
--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -447,7 +447,6 @@ func aggregateState(dependencies []pipelineshub.RunSchedule) (aggState apis.Sync
 		if state == apis.Failed {
 			aggState = apis.Failed
 			message = dependency.Status.Conditions.SynchronizationSucceeded().Message
-			return
 		} else if state != apis.Succeeded {
 			aggState = apis.Updating
 			message = "Waiting for all dependant runschedules to be in a state of Succeeded"

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -450,7 +450,7 @@ func aggregateState(dependencies []pipelineshub.RunSchedule) (aggState apis.Sync
 			return
 		} else if state != apis.Succeeded {
 			aggState = apis.Updating
-			message = "Waiting for all dependant runschedules to be succeeded"
+			message = "Waiting for all dependant runschedules to be in a state of Succeeded"
 			return
 		}
 	}

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -447,9 +447,10 @@ func aggregateState(dependencies []pipelineshub.RunSchedule) (aggState apis.Sync
 		if state == apis.Failed {
 			aggState = apis.Failed
 			message = dependency.Status.Conditions.SynchronizationSucceeded().Message
+			return
 		} else if state != apis.Succeeded {
 			aggState = apis.Updating
-			message = ""
+			message = "Waiting for all dependant runschedules to be succeeded"
 			return
 		}
 	}

--- a/controllers/pipelines/runconfiguration_controller_test.go
+++ b/controllers/pipelines/runconfiguration_controller_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 var _ = Context("aggregateState", func() {
+	const updatingMessage = "Waiting for all dependant runschedules to be succeeded"
 	DescribeTable("calculates based on sub states", func(subStates []apis.SynchronizationState, expectedState apis.SynchronizationState, expectedMessage string) {
 		runSchedules := make([]pipelineshub.RunSchedule, len(subStates))
 		for i, state := range subStates {
@@ -36,10 +37,10 @@ var _ = Context("aggregateState", func() {
 	},
 		Entry(nil, []apis.SynchronizationState{}, apis.Succeeded, ""),
 		Entry(nil, []apis.SynchronizationState{apis.Failed, apis.Succeeded}, apis.Failed, "Failed"),
-		Entry(nil, []apis.SynchronizationState{apis.Updating, apis.Failed}, apis.Updating, ""),
-		Entry(nil, []apis.SynchronizationState{apis.Deleting, apis.Failed}, apis.Updating, ""),
-		Entry(nil, []apis.SynchronizationState{apis.Deleted, apis.Failed}, apis.Updating, ""),
-		Entry(nil, []apis.SynchronizationState{"", apis.Failed}, apis.Updating, ""),
+		Entry(nil, []apis.SynchronizationState{apis.Updating, apis.Failed}, apis.Updating, updatingMessage),
+		Entry(nil, []apis.SynchronizationState{apis.Deleting, apis.Failed}, apis.Updating, updatingMessage),
+		Entry(nil, []apis.SynchronizationState{apis.Deleted, apis.Failed}, apis.Updating, updatingMessage),
+		Entry(nil, []apis.SynchronizationState{"", apis.Failed}, apis.Updating, updatingMessage),
 		Entry(nil, []apis.SynchronizationState{apis.Succeeded}, apis.Succeeded, ""),
 	)
 })

--- a/controllers/pipelines/runconfiguration_controller_test.go
+++ b/controllers/pipelines/runconfiguration_controller_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var _ = Context("aggregateState", func() {
-	const updatingMessage = "Waiting for all dependant runschedules to be succeeded"
+	const updatingMessage = "Waiting for all dependant runschedules to be in a state of Succeeded"
 	DescribeTable("calculates based on sub states", func(subStates []apis.SynchronizationState, expectedState apis.SynchronizationState, expectedMessage string) {
 		runSchedules := make([]pipelineshub.RunSchedule, len(subStates))
 		for i, state := range subStates {


### PR DESCRIPTION
Closes #667.

A small and simple improvement, that gives the users some indication what a runconfiguration is waiting for when updating.
It simply populates the currently empty `message` field with a helpful message providing context on what it is doing.

## Tasks

- [ ] ...
- [ ] Documentation updated
