### PR TITLE
Add provider validation to enforce namespace/name

### DIFF
--- a/apis/pipelines/hub/experiment_types.go
+++ b/apis/pipelines/hub/experiment_types.go
@@ -10,6 +10,8 @@ import (
 )
 
 type ExperimentSpec struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Provider    common.NamespacedName `json:"provider" yaml:"provider"`
 	Description string                `json:"description,omitempty"`
 }

--- a/apis/pipelines/hub/pipeline_types.go
+++ b/apis/pipelines/hub/pipeline_types.go
@@ -15,6 +15,8 @@ import (
 )
 
 type PipelineSpec struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Provider  common.NamespacedName `json:"provider" yaml:"provider"`
 	Image     string                `json:"image" yaml:"image"`
 	Env       []apis.NamedValue     `json:"env,omitempty" yaml:"env"`

--- a/apis/pipelines/hub/run_types.go
+++ b/apis/pipelines/hub/run_types.go
@@ -27,6 +27,8 @@ type ValueFrom struct {
 }
 
 type RunSpec struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Provider       common.NamespacedName `json:"provider" yaml:"provider"`
 	Pipeline       PipelineIdentifier    `json:"pipeline,omitempty"`
 	ExperimentName string                `json:"experimentName,omitempty"`

--- a/apis/pipelines/hub/runschedule_types.go
+++ b/apis/pipelines/hub/runschedule_types.go
@@ -11,6 +11,8 @@ import (
 )
 
 type RunScheduleSpec struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Provider       common.NamespacedName `json:"provider" yaml:"provider"`
 	Pipeline       PipelineIdentifier    `json:"pipeline,omitempty"`
 	ExperimentName string                `json:"experimentName,omitempty"`

--- a/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -305,6 +305,7 @@ spec:
               description:
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
             - provider

--- a/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -386,6 +386,7 @@ spec:
               image:
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
             - framework

--- a/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -642,6 +642,7 @@ spec:
                     pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                     type: string
                   provider:
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   runtimeParameters:
                     description: 'Deprecated: Needed for conversion only'

--- a/config/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -552,6 +552,7 @@ spec:
                 pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               runtimeParameters:
                 description: 'Deprecated: Needed for conversion only'

--- a/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -428,6 +428,7 @@ spec:
                 pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               runtimeParameters:
                 description: 'Deprecated: Needed for conversion only'

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -324,6 +324,7 @@ spec:
               description:
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
             - provider

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -405,6 +405,7 @@ spec:
               image:
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
             - framework

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -661,6 +661,7 @@ spec:
                     pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                     type: string
                   provider:
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   runtimeParameters:
                     description: 'Deprecated: Needed for conversion only'

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -571,6 +571,7 @@ spec:
                 pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               runtimeParameters:
                 description: 'Deprecated: Needed for conversion only'

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -447,6 +447,7 @@ spec:
                 pattern: ^[\w\-]+(?::[\w\-_.]+)?$
                 type: string
               provider:
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               runtimeParameters:
                 description: 'Deprecated: Needed for conversion only'


### PR DESCRIPTION
Closes #697 .

Error message produced on trying to apply an invalid valid:
```
The Pipeline "quickstartpp" is invalid: spec.provider: Invalid value: "/vai": spec.provider in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
```

The regex used follows the DNS-1123 subdomain rules for both namespace and name, and requires a literal `/` separator.

## Tasks

- [X] add provider field validation to all resources with provider
     - pipeline
     - run configuration
     - run
     - run schedule
     - experiment
- [X] Documentation updated - think the documentation already provided is valid. 
`spec.provider | The namespace and name of the associated Provider resource separated by a /, e.g. provider-namespace/provider-name.`
