### PR TITLE
No longer ignore minor golang library updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,4 @@ updates:
     ignore:
     - dependency-name: "*"
       update-types:
-      - "version-update:semver-minor"
       - "version-update:semver-major"


### PR DESCRIPTION
Closes #705

No longer ignore minor golang library updates because now we are only 1 minor version behind the latest golang version.