### PR TITLE
Remove pipelineRootStorage access in compilers

### DIFF
--- a/compilers/kfp-sdk/acceptance/test_compiler.py
+++ b/compilers/kfp-sdk/acceptance/test_compiler.py
@@ -53,4 +53,3 @@ def test_compiler__compile(tmp_path):
             pipeline = yaml.safe_load(f.read())
 
         assert pipeline["schemaVersion"] == "2.1.0"
-        assert pipeline["defaultPipelineRoot"] == "gs://bucket/test"

--- a/compilers/kfp-sdk/compiler/compiler.py
+++ b/compilers/kfp-sdk/compiler/compiler.py
@@ -18,24 +18,17 @@ from typing import Callable
 @click.option("--output_file", help="Output file path", required=True)
 def compile(pipeline_config: str, provider_config: str, output_file: str):
     """Compiles KFP SDK pipeline into a Kubeflow Pipelines pipeline definition"""
-    with open(pipeline_config, "r") as pipeline_stream, open(
-        provider_config, "r"
-    ) as provider_stream:
+    with open(pipeline_config, "r") as pipeline_stream:
         pipeline_config_contents = yaml.safe_load(pipeline_stream)
-        provider_config_contents = yaml.safe_load(provider_stream)
         pipeline_name = get_pipeline_name(pipeline_config_contents)
         sanitised_pipeline_name = sanitise_namespaced_pipeline_name(pipeline_name)
-        pipeline_root = get_pipeline_root(provider_config_contents, pipeline_name)
         pipeline_environment = pipeline_config_contents.get("env", [])
         click.secho(
-            f"Compiling {sanitised_pipeline_name} pipeline with root {pipeline_root}: {pipeline_config_contents}",
+            f"Compiling {sanitised_pipeline_name} pipeline: {pipeline_config_contents}",
             fg="green",
         )
 
         pipeline_fn = load_fn(pipeline_config_contents, pipeline_environment)
-
-        # Override user provided pipeline root with the one from provider configuration.
-        pipeline_fn.pipeline_spec.default_pipeline_root = pipeline_root
 
         compiler.Compiler().compile(
             pipeline_fn, pipeline_name=sanitised_pipeline_name, package_path=output_file
@@ -48,13 +41,6 @@ def get_pipeline_name(pipeline_config_contents: dict) -> str:
         return pipeline_config_contents["name"]
     else:
         raise KeyError("Missing required pipeline name in pipeline configuration.")
-
-
-def get_pipeline_root(provider_config_contents: dict, pipeline_name: str) -> str:
-    if "pipelineRootStorage" in provider_config_contents:
-        return provider_config_contents["pipelineRootStorage"] + "/" + pipeline_name
-    else:
-        raise KeyError("Missing required pipeline root in provider configuration.")
 
 
 def load_fn(pipeline_config_contents: dict, environment: list) -> Callable:

--- a/compilers/kfp-sdk/tests/test_compiler.py
+++ b/compilers/kfp-sdk/tests/test_compiler.py
@@ -71,11 +71,3 @@ def test_sanitise_namespaced_pipeline_name():
     for input, output in tests:
         sanitised = compiler.sanitise_namespaced_pipeline_name(input)
         assert sanitised == output, f"Expected {output}, got {sanitised}"
-
-
-def test_compiler_get_pipeline_root():
-    provider_config_contents = {"pipelineRootStorage": "storage"}
-    assert (
-        compiler.get_pipeline_root(provider_config_contents, "pipeline")
-        == "storage/pipeline"
-    )

--- a/compilers/tfx/tests/test_compiler.py
+++ b/compilers/tfx/tests/test_compiler.py
@@ -15,16 +15,6 @@ def test_name_values_to_cli_args():
     ]
 
 
-def test_pipeline_paths_for_config():
-    pipeline_config = {'name': 'pipeline'}
-    provider_config = {'pipelineRootStorage': "pipeline_root"}
-
-    pipeline_root, temp_directory = compiler.pipeline_paths_for_config(pipeline_config, provider_config)
-
-    assert pipeline_root == "pipeline_root/pipeline"
-    assert temp_directory == "pipeline_root/pipeline/tmp"
-
-
 def test_sanitise_namespaced_pipeline_name():
     assert compiler.sanitise_namespaced_pipeline_name("pipeline-name") == "pipeline-name"
     assert compiler.sanitise_namespaced_pipeline_name("/pipeline-name") == "-pipeline-name"


### PR DESCRIPTION
Closes https://github.com/sky-uk/kfp-operator/issues/721

Pipeline root storage is being set at submission time to the provider service, so no longer needs to be accessed and passed to `pipeline.Pipeline()` or to `Compiler().compile()`.

This also removes the extra beamArg of `--temp_location` in the TFX compiler which was being hardcoded by the compiler to be: `<pipelineRootStorage>/<pipeline>/tmp`. Users are now expected to set this beamArg themselves, either in the a Pipeline's `.spec.framework.parameters.beamArgs` or apply a default in a Provider's `.spec.frameworks[].patches` like so:
```
apiVersion: pipelines.kubeflow.org/v1beta1
kind: Provider
metadata:
  name: my-provider
spec:
  frameworks:
    - name: tfx
      image: kfp-operator-tfx-compiler:latest
      patches:
        - payload: '[{"op":"add","path":"/framework/parameters/beamArgs/1","value":{"name":"temp_location","value":"<pipelineRootStorage>/provider/tmp"}}]'
          type: json
```
Note that if setting it as a default, the `temp_location` will no longer by split up by the pipeline name.

## Tasks

- [x] Documentation updated - this was not documented before so nothing to do
- [x] QA (tested on both KFPSDK and TFX pipelines)
