### PR TITLE
Remove references to provider_config from the compilers documentation

### DIFF
--- a/compilers/README.md
+++ b/compilers/README.md
@@ -13,7 +13,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 The compile argo workflow will always execute `/compile.sh` passing in the following arguments:
 
 * `--pipeline_config` is the path to the yaml file that contains the pipeline resource definition.
-* `--provider_config` is the path to the yaml file that contains the provider configuration.
 * `--output_file` is the path to output the compiled pipeline definition to.
 
 The Python module is required to be named `compiler`. The entry point to the Python compiler module should accept (or ignore these) parameters.
@@ -23,9 +22,8 @@ Suggestion would be to match the interface defined in the TFX compiler:
 ```python
     @click.command()
     @click.option('--pipeline_config', help='Pipeline configuration in yaml format', required=True)
-    @click.option('--provider_config', help='Provider configuration in yaml format', required=True)
     @click.option('--output_file', help='Output file path', required=True)
-    def compile(pipeline_config: str, provider_config: str, output_file: str):
+    def compile(pipeline_config: str, output_file: str):
 ```
 
 The pipeline definition should be written to the output file defined in `--output_file`.


### PR DESCRIPTION
Remove references to provider_config from the compilers documentation, which should have been removed in c0fbdee1f2aebba13f7c258fa2c9ed8427f77a07
