### PR TITLE
Retry reconciliations for all resources more often

### DIFF
--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -83,7 +83,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	duration := time.Since(startTime)
-	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
+	logger.Info("Experiment reconciliation ended", "experiment", req.Name, logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -91,9 +91,10 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *ExperimentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	experiment := &pipelineshub.Experiment{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(experiment).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	})
+		For(experiment).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, experiment)
 

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -2,6 +2,8 @@ package pipelines
 
 import (
 	"context"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	config "github.com/sky-uk/kfp-operator/apis/config/hub"
@@ -89,7 +91,15 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *ExperimentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	experiment := &pipelineshub.Experiment{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(experiment)
+		For(experiment).WithOptions(controller.Options{
+		// This rate limiter is used to limit the rate of retry requests for Pipelines.
+		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
+		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
+			1*time.Minute,
+			30*time.Minute,
+			10,
+		),
+	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, experiment)
 

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -83,7 +83,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("Experiment reconciliation ended", "experiment", req.Name, logkeys.Duration, duration)
+	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -82,7 +82,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil

--- a/controllers/pipelines/experiment_controller.go
+++ b/controllers/pipelines/experiment_controller.go
@@ -2,7 +2,7 @@ package pipelines
 
 import (
 	"context"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
@@ -92,13 +92,7 @@ func (r *ExperimentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	experiment := &pipelineshub.Experiment{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(experiment).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for Pipelines.
-		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, experiment)

--- a/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
+++ b/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
@@ -6,5 +6,5 @@ import (
 )
 
 // This rate limiter is used to limit the rate of retry requests.
-// It is set to requeue after 5 minutes for the first 10 retries, and then every 30 minutes thereafter.
+// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
 var RateLimiter = workqueue.NewItemFastSlowRateLimiter(1*time.Minute, 30*time.Minute, 10)

--- a/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
+++ b/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
@@ -1,0 +1,10 @@
+package controllerconfigutil
+
+import (
+	"k8s.io/client-go/util/workqueue"
+	"time"
+)
+
+// This rate limiter is used to limit the rate of retry requests.
+// It is set to requeue after 5 minutes for the first 10 retries, and then every 30 minutes thereafter.
+var RateLimiter = workqueue.NewItemFastSlowRateLimiter(1*time.Minute, 30*time.Minute, 10)

--- a/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
+++ b/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
@@ -7,4 +7,4 @@ import (
 
 // This rate limiter is used to limit the rate of retry requests.
 // It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-var RateLimiter = workqueue.NewItemFastSlowRateLimiter(1*time.Minute, 30*time.Minute, 10)
+var RateLimiter = workqueue.NewItemFastSlowRateLimiter(5*time.Minute, 30*time.Minute, 3)

--- a/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
+++ b/controllers/pipelines/internal/controllerconfigutil/rate_limiter.go
@@ -6,5 +6,5 @@ import (
 )
 
 // This rate limiter is used to limit the rate of retry requests.
-// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
+// It is set to requeue after 5 minutes for the first 3 retries, and then every 30 minutes thereafter.
 var RateLimiter = workqueue.NewItemFastSlowRateLimiter(5*time.Minute, 30*time.Minute, 3)

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -2,7 +2,7 @@ package pipelines
 
 import (
 	"context"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
@@ -97,13 +97,7 @@ func (r *PipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pipeline := &pipelineshub.Pipeline{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(pipeline).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for Pipelines.
-		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, pipeline)

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -70,12 +70,16 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	provider, err := r.LoadProvider(ctx, pipeline.Spec.Provider)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{
+			RequeueAfter: 1 * time.Minute,
+		}, err
 	}
 
 	providerSvc, err := r.ServiceManager.Get(ctx, &provider)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{
+			RequeueAfter: 1 * time.Minute,
+		}, err
 	}
 
 	commands := r.StateHandler.StateTransition(ctx, provider, *providerSvc, pipeline)
@@ -83,7 +87,9 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, pipeline); err != nil {
 			logger.Error(err, "error executing command", logkeys.Command, commands[i])
-			return ctrl.Result{}, err
+			return ctrl.Result{
+				RequeueAfter: 1 * time.Minute,
+			}, err
 		}
 	}
 

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -87,7 +87,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -70,16 +70,12 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	provider, err := r.LoadProvider(ctx, pipeline.Spec.Provider)
 	if err != nil {
-		return ctrl.Result{
-			RequeueAfter: 1 * time.Minute,
-		}, err
+		return ctrl.Result{}, err
 	}
 
 	providerSvc, err := r.ServiceManager.Get(ctx, &provider)
 	if err != nil {
-		return ctrl.Result{
-			RequeueAfter: 1 * time.Minute,
-		}, err
+		return ctrl.Result{}, err
 	}
 
 	commands := r.StateHandler.StateTransition(ctx, provider, *providerSvc, pipeline)
@@ -87,9 +83,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	for i := range commands {
 		if err := commands[i].execute(ctx, r.EC, pipeline); err != nil {
 			logger.Error(err, "error executing command", logkeys.Command, commands[i])
-			return ctrl.Result{
-				RequeueAfter: 1 * time.Minute,
-			}, err
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -3,7 +3,9 @@ package pipelines
 import (
 	"context"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"
 
 	config "github.com/sky-uk/kfp-operator/apis/config/hub"
@@ -96,7 +98,10 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *PipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pipeline := &pipelineshub.Pipeline{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(pipeline).
+		For(pipeline, builder.WithPredicates(
+			predicate.GenerationChangedPredicate{},
+			predicate.ResourceVersionChangedPredicate{},
+		)).
 		WithOptions(controller.Options{
 			RateLimiter: controllerconfigutil.RateLimiter,
 		})

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -94,7 +94,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("Pipeline reconciliation ended", "pipeline", req.Name, logkeys.Duration, duration)
+	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -94,7 +94,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	duration := time.Since(startTime)
-	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
+	logger.Info("Pipeline reconciliation ended", "pipeline", req.Name, logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/pipeline_controller.go
+++ b/controllers/pipelines/pipeline_controller.go
@@ -96,9 +96,10 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *PipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pipeline := &pipelineshub.Pipeline{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(pipeline).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	})
+		For(pipeline).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, pipeline)
 

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -3,6 +3,7 @@ package pipelines
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -167,7 +168,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("Provider reconciliation ended", "provider", req.String(), logkeys.Duration, duration)
+	logger.Info(fmt.Sprintf("provider %s reconciliation successful", provider.Name), logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -3,7 +3,6 @@ package pipelines
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/sky-uk/kfp-operator/argo/common"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -168,7 +167,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	duration := time.Since(startTime)
-	logger.Info(fmt.Sprintf("provider %s reconciliation successful", provider.Name), logkeys.Duration, duration)
+	logger.Info("Provider reconciliation ended", "provider", req.String(), logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -61,9 +61,10 @@ func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(provider, builder.WithPredicates(
 			predicate.GenerationChangedPredicate{},
-		)).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	}).
+		)).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		}).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(
 			predicate.GenerationChangedPredicate{},
 			predicate.ResourceVersionChangedPredicate{},

--- a/controllers/pipelines/provider_controller.go
+++ b/controllers/pipelines/provider_controller.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sky-uk/kfp-operator/argo/common"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
@@ -62,13 +62,7 @@ func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(provider, builder.WithPredicates(
 			predicate.GenerationChangedPredicate{},
 		)).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for Providers.
-		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	}).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(
 			predicate.GenerationChangedPredicate{},

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -69,7 +69,7 @@ func NewRunReconciler(
 func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	startTime := time.Now()
-	logger.Info("run reconciliation started", "run", req.String())
+	logger.V(2).Info("reconciliation started")
 
 	var run = &pipelineshub.Run{}
 	if err := r.EC.Client.NonCached.Get(ctx, req.NamespacedName, run); err != nil {

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -215,9 +215,10 @@ func (r *RunReconciler) reconciliationRequestsForRunconfigurations(
 func (r *RunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	run := &pipelineshub.Run{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(run).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	})
+		For(run).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, run)
 	controllerBuilder, err := r.DependingOnPipelineReconciler.setupWithManager(

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -2,7 +2,7 @@ package pipelines
 
 import (
 	"context"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
@@ -216,13 +216,7 @@ func (r *RunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	run := &pipelineshub.Run{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(run).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for runs.
-		// It is set to requeue after 5 minutes for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, run)

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -116,7 +116,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return result, nil

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -117,7 +117,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	duration := time.Since(startTime)
-	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
+	logger.Info("Run Reconciliation ended", "run", req.String(), logkeys.Duration, duration)
 
 	return result, nil
 }

--- a/controllers/pipelines/run_controller.go
+++ b/controllers/pipelines/run_controller.go
@@ -117,7 +117,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("Run Reconciliation ended", "run", req.String(), logkeys.Duration, duration)
+	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return result, nil
 }

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -389,9 +389,10 @@ func (r *RunConfigurationReconciler) reconciliationRequestsForRunConfiguration(
 func (r *RunConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runConfiguration := &pipelineshub.RunConfiguration{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(runConfiguration).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	})
+		For(runConfiguration).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		})
 
 	controllerBuilder, err := r.DependingOnPipelineReconciler.setupWithManager(
 		mgr,

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -137,7 +137,7 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -138,7 +138,7 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("RunConfiguration reconciliation ended", "RunConfiguration", req.String(), logkeys.Duration, duration)
+	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/sky-uk/kfp-operator/common/triggers"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"slices"
@@ -390,13 +390,7 @@ func (r *RunConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runConfiguration := &pipelineshub.RunConfiguration{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(runConfiguration).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for RunConfigurations.
-		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	})
 
 	controllerBuilder, err := r.DependingOnPipelineReconciler.setupWithManager(

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -138,7 +138,7 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	duration := time.Since(startTime)
-	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
+	logger.Info("RunConfiguration reconciliation ended", "RunConfiguration", req.String(), logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -2,7 +2,7 @@ package pipelines
 
 import (
 	"context"
-	"k8s.io/client-go/util/workqueue"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/controllerconfigutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
@@ -92,13 +92,7 @@ func (r *RunScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runSchedule := &pipelineshub.RunSchedule{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(runSchedule).WithOptions(controller.Options{
-		// This rate limiter is used to limit the rate of retry requests for RunSchedules.
-		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
-		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
-			1*time.Minute,
-			30*time.Minute,
-			10,
-		),
+		RateLimiter: controllerconfigutil.RateLimiter,
 	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, runSchedule)

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -91,9 +91,10 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *RunScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runSchedule := &pipelineshub.RunSchedule{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(runSchedule).WithOptions(controller.Options{
-		RateLimiter: controllerconfigutil.RateLimiter,
-	})
+		For(runSchedule).
+		WithOptions(controller.Options{
+			RateLimiter: controllerconfigutil.RateLimiter,
+		})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, runSchedule)
 

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -82,7 +82,7 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -83,7 +83,7 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	duration := time.Since(startTime)
-	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
+	logger.Info("RunSchedule reconciliation ended", "RunSchedule", req.String(), logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -83,7 +83,7 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	duration := time.Since(startTime)
-	logger.Info("RunSchedule reconciliation ended", "RunSchedule", req.String(), logkeys.Duration, duration)
+	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/pipelines/runschedule_controller.go
+++ b/controllers/pipelines/runschedule_controller.go
@@ -2,6 +2,8 @@ package pipelines
 
 import (
 	"context"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	config "github.com/sky-uk/kfp-operator/apis/config/hub"
@@ -89,7 +91,15 @@ func (r *RunScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *RunScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	runSchedule := &pipelineshub.RunSchedule{}
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(runSchedule)
+		For(runSchedule).WithOptions(controller.Options{
+		// This rate limiter is used to limit the rate of retry requests for RunSchedules.
+		// It is set to requeue after 1 minute for the first 10 retries, and then every 30 minutes thereafter.
+		RateLimiter: workqueue.NewItemFastSlowRateLimiter(
+			1*time.Minute,
+			30*time.Minute,
+			10,
+		),
+	})
 
 	controllerBuilder = r.ResourceReconciler.setupWithManager(controllerBuilder, runSchedule)
 

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -209,9 +209,8 @@ func (st StateHandler[R]) onSucceededOrFailed(
 	logger := log.FromContext(ctx)
 	newResourceVersion := resource.ComputeVersion()
 
-	if resource.GetStatus().Version == newResourceVersion &&
-		resource.GetStatus().Conditions.GetSyncStateFromReason() != apis.Failed {
-		logger.V(2).Info("resource version has not changed and its already succeeded")
+	if resource.GetStatus().Version == newResourceVersion && resource.GetStatus().Conditions.GetSyncStateFromReason() != apis.Failed {
+		logger.V(2).Info("resource version has not changed")
 		return []Command{}
 	}
 

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -81,9 +81,8 @@ func (st *StateHandler[R]) stateTransition(
 		commands = append([]Command{AcquireResource{}}, commands...)
 	}
 
-	fmt.Printf("state transition for: %s , with state: %s and commands: %s", resource.GetNamespacedName(),
-		resource.GetStatus().Conditions.GetSyncStateFromReason(),
-		commands)
+	fmt.Printf("state transition for: %s , with state: %s", resource.GetNamespacedName(),
+		resource.GetStatus().Conditions.GetSyncStateFromReason())
 	return
 }
 

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -209,7 +209,8 @@ func (st StateHandler[R]) onSucceededOrFailed(
 	logger := log.FromContext(ctx)
 	newResourceVersion := resource.ComputeVersion()
 
-	if resource.GetStatus().Version == newResourceVersion && resource.GetStatus().Conditions.GetSyncStateFromReason() == apis.Succeeded {
+	if resource.GetStatus().Version == newResourceVersion &&
+		resource.GetStatus().Conditions.GetSyncStateFromReason() == apis.Succeeded {
 		logger.V(2).Info("resource version has not changed and its already succeeded")
 		return []Command{}
 	}

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -210,7 +210,7 @@ func (st StateHandler[R]) onSucceededOrFailed(
 	newResourceVersion := resource.ComputeVersion()
 
 	if resource.GetStatus().Version == newResourceVersion &&
-		resource.GetStatus().Conditions.GetSyncStateFromReason() == apis.Succeeded {
+		resource.GetStatus().Conditions.GetSyncStateFromReason() != apis.Failed {
 		logger.V(2).Info("resource version has not changed and its already succeeded")
 		return []Command{}
 	}

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -81,6 +81,9 @@ func (st *StateHandler[R]) stateTransition(
 		commands = append([]Command{AcquireResource{}}, commands...)
 	}
 
+	fmt.Printf("state transition for %s", resource.GetNamespacedName(),
+		" with state ", resource.GetStatus().Conditions.GetSyncStateFromReason(),
+		" and commands: ", commands)
 	return
 }
 
@@ -308,6 +311,7 @@ func (st StateHandler[R]) setStateIfProviderFinished(
 ) []Command {
 	logger := log.FromContext(ctx)
 	statusFromProviderOutput := func(workflow *argo.Workflow) *SetStatus {
+		var err error
 		var handleWorkflowErr = func(err error) *SetStatus {
 			failureMessage := "could not retrieve workflow output"
 			logger.Error(err, fmt.Sprintf("%s, failing resource", failureMessage))
@@ -365,7 +369,7 @@ func (st StateHandler[R]) setStateIfProviderFinished(
 		var failureMessage string
 
 		if failed != nil {
-			failureMessage = "operation failed"
+			failureMessage = fmt.Sprintf("operation failed, %s", err)
 		} else {
 			failureMessage = "operation progress unknown"
 		}

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -209,8 +209,8 @@ func (st StateHandler[R]) onSucceededOrFailed(
 	logger := log.FromContext(ctx)
 	newResourceVersion := resource.ComputeVersion()
 
-	if resource.GetStatus().Version == newResourceVersion {
-		logger.V(2).Info("resource version has not changed")
+	if resource.GetStatus().Version == newResourceVersion && resource.GetStatus().Conditions.GetSyncStateFromReason() == apis.Succeeded {
+		logger.V(2).Info("resource version has not changed and its already succeeded")
 		return []Command{}
 	}
 

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -81,9 +81,9 @@ func (st *StateHandler[R]) stateTransition(
 		commands = append([]Command{AcquireResource{}}, commands...)
 	}
 
-	fmt.Printf("state transition for %s", resource.GetNamespacedName(),
-		" with state ", resource.GetStatus().Conditions.GetSyncStateFromReason(),
-		" and commands: ", commands)
+	fmt.Printf("state transition for: %s , with state: %s and commands: %s", resource.GetNamespacedName(),
+		resource.GetStatus().Conditions.GetSyncStateFromReason(),
+		commands)
 	return
 }
 

--- a/controllers/pipelines/state_handler.go
+++ b/controllers/pipelines/state_handler.go
@@ -310,6 +310,7 @@ func (st StateHandler[R]) setStateIfProviderFinished(
 	transitionTime metav1.Time,
 ) []Command {
 	logger := log.FromContext(ctx)
+	var err error
 	statusFromProviderOutput := func(workflow *argo.Workflow) *SetStatus {
 		var err error
 		var handleWorkflowErr = func(err error) *SetStatus {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"time"
 
 	"github.com/sky-uk/kfp-operator/controllers/webhook"
 
@@ -80,8 +82,16 @@ func main() {
 	flag.Parse()
 
 	var err error
+	duration := 5 * time.Minute
+
 	ctrlConfig := config.KfpControllerConfig{}
-	options := ctrl.Options{Scheme: scheme, HealthProbeBindAddress: ":8081"}
+	options := ctrl.Options{
+		Scheme:                 scheme,
+		HealthProbeBindAddress: ":8081",
+		Cache: cache.Options{
+			SyncPeriod: &duration,
+		},
+	}
 
 	if configFile != "" {
 		bytes, err := os.ReadFile(configFile)

--- a/main.go
+++ b/main.go
@@ -21,8 +21,6 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"time"
 
 	"github.com/sky-uk/kfp-operator/controllers/webhook"
 
@@ -82,16 +80,8 @@ func main() {
 	flag.Parse()
 
 	var err error
-	duration := 5 * time.Minute
-
 	ctrlConfig := config.KfpControllerConfig{}
-	options := ctrl.Options{
-		Scheme:                 scheme,
-		HealthProbeBindAddress: ":8081",
-		Cache: cache.Options{
-			SyncPeriod: &duration,
-		},
-	}
+	options := ctrl.Options{Scheme: scheme, HealthProbeBindAddress: ":8081"}
 
 	if configFile != "" {
 		bytes, err := os.ReadFile(configFile)


### PR DESCRIPTION
Closes #675 

This adds a custom ratelimit for all managed resources, to not use the default ratelimit which is exponential but with large maximum delay between retries. The new rate limiter will retry a given resource every minute up to 10 times, before retrying once every 30 minutes thereafter. 

This should alleviate issues whereby resources get stuck in a failed state and need manual intervention to reconcile.
