### PR TITLE
chore(dependabot): only target kfpsdk-quickstart dir for python dependencies and do not target dirs that no longer have gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,7 @@ updates:
   - package-ecosystem: "gomod"
     directories:
     - "/"
-    - "/common"
     - "/docs-gen"
-    - "/argo/common"
-    - "/argo/providers"
-    - "/provider-service/base"
-    - "/provider-service/kfp"
-    - "/provider-service/vai"
-    - "/provider-service/stub"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,19 @@ updates:
     rebase-strategy: "disabled"
     allow:
     - dependency-type: "direct"
+
+  - package-ecosystem: "poetry"
+    directory: "/docs-gen/includes/master/kfpsdk-quickstart"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    allow:
+    - dependency-type: "direct"
+
+  - package-ecosystem: "poetry"
+    directory: "/docs-gen/includes/0.7.0/kfpsdk-quickstart"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    allow:
+    - dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,15 +16,8 @@ updates:
     - dependency-type: "direct"
 
   - package-ecosystem: "pip"
-    directory: "/docs-gen/includes/master/kfpsdk-quickstart"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-    allow:
-    - dependency-type: "direct"
-
-  - package-ecosystem: "pip"
-    directory: "/docs-gen/includes/0.7.0/kfpsdk-quickstart"
+    directories:
+    - "/docs-gen/includes/*/kfpsdk-quickstart"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     allow:
     - dependency-type: "direct"
 
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/docs-gen/includes/master/kfpsdk-quickstart"
     schedule:
       interval: "weekly"
@@ -23,7 +23,7 @@ updates:
     allow:
     - dependency-type: "direct"
 
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/docs-gen/includes/0.7.0/kfpsdk-quickstart"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Update dependabot config to:
- only target the `kfpsdk-quickstart` python dependencies
- no longer target directories where there used to be separate go modules that were removed in d7f686d30177d32ceecb81bb61e81ee42c340d35
