### PR TITLE
fix(dependabot): retarget the `compilers/kfp-sdk` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
 
   - package-ecosystem: "pip"
     directories:
+    - "/compilers/kfp-sdk"
     - "/docs-gen/includes/*/kfpsdk-quickstart"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Was incorrectly missed in b3a49d10