### PR TITLE
Rename Framework.Type Framework.Name to match equivalent PipelineFramework in the argo package

### DIFF
--- a/provider-service/base/pkg/server/resource/provider.go
+++ b/provider-service/base/pkg/server/resource/provider.go
@@ -21,7 +21,7 @@ type PipelineDefinition struct {
 }
 
 type PipelineFramework struct {
-	Type       string                           `json:"type" yaml:"type"`
+	Name       string                           `json:"name" yaml:"name"`
 	Parameters map[string]*apiextensionsv1.JSON `json:"parameters" yaml:"parameters"`
 }
 

--- a/provider-service/base/pkg/testutil/testutil.go
+++ b/provider-service/base/pkg/testutil/testutil.go
@@ -45,7 +45,7 @@ func RandomPipelineDefinition() resource.PipelineDefinition {
 		Version:   common.RandomString(),
 		Image:     common.RandomString(),
 		Env:       make([]apis.NamedValue, 0),
-		Framework: resource.PipelineFramework{Type: common.RandomString()},
+		Framework: resource.PipelineFramework{Name: common.RandomString()},
 	}
 }
 


### PR DESCRIPTION
Closes #790
Rename PipelineDefinitionWrapper.PipelineDefinition.Framework.Type to PipelineDefinitionWrapper.PipelineDefinition.Framework.Name for uniformity.
