### PR TITLE
add KFP SDK support to top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Kubeflow Pipelines Operator provides a declarative API for managing and running machine learning pipelines on Kubeflow with [Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-We currently only support TFX pipelines.
+We currently support pipelines written with [TFX](https://www.tensorflow.org/tfx) and [KFP SDK](https://kubeflow-pipelines.readthedocs.io/).
 
 ## Documentation:
 


### PR DESCRIPTION
Noticed that the root level README was out of date, as it didn't include support for KDP SDK