### PR TITLE
Add schemaVersion and sdkVersion labels to Schema2Handler

### DIFF
--- a/provider-service/vai/internal/provider/pipeline_schema_handler.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler.go
@@ -88,6 +88,21 @@ func (sv2 Schema2Handler) extract(raw map[string]any) (*PipelineValues, error) {
 		return nil, err
 	}
 
+	schemaVersion, ok := pipelineSpec["schemaVersion"].(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"expected string for 'schemaVersion', got %T",
+			raw["schemaVersion"],
+		)
+	}
+	sdkVersion, ok := pipelineSpec["sdkVersion"].(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"expected string for 'sdkVersion', got %T",
+			raw["sdkVersion"],
+		)
+	}
+
 	labels, ok := raw["labels"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -95,6 +110,9 @@ func (sv2 Schema2Handler) extract(raw map[string]any) (*PipelineValues, error) {
 			raw["labels"],
 		)
 	}
+	labels["schema_version"] = sanitizeString(schemaVersion)
+	labels["sdk_version"] = sanitizeString(sdkVersion)
+
 	convertedLabels := make(map[string]string)
 	for k, v := range labels {
 		if strVal, ok := v.(string); ok {

--- a/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
@@ -176,7 +176,9 @@ var _ = Describe("Schema2Handler", func() {
 		raw = map[string]any{
 			"displayName": "test-display-name",
 			"pipelineSpec": map[string]any{
-				"key": "value",
+				"key":           "value",
+				"schemaVersion": "2.0.0",
+				"sdkVersion":    "tfx-1.15.1",
 			},
 			"labels": map[string]any{
 				"label-key-from-raw": "label-value-from-raw",
@@ -188,13 +190,15 @@ var _ = Describe("Schema2Handler", func() {
 	})
 
 	Context("Extract", Ordered, func() {
-		It("should extract pipeline values from the raw map", func() {
+		It("should extract pipeline values from the raw map and sanitize schemaVersion and sdkVersion", func() {
 			pipelineValues, err := schema2Handler.extract(raw)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pipelineValues.name).To(Equal(raw["displayName"]))
 			pipelineSpec, err := structpb.NewStruct(
 				map[string]any{
-					"key": "value",
+					"key":           "value",
+					"schemaVersion": "2.0.0",
+					"sdkVersion":    "tfx-1.15.1",
 				},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -202,6 +206,8 @@ var _ = Describe("Schema2Handler", func() {
 			Expect(pipelineValues.labels).To(Equal(
 				map[string]string{
 					"label-key-from-raw": "label-value-from-raw",
+					"schema_version":     "2_0_0",
+					"sdk_version":        "tfx-1_15_1",
 				},
 			))
 		})


### PR DESCRIPTION
Closes #825

Add schemaVersion and sdkVersion labels to Schema2Handler (VAI Provider) so that Vertex AI can display these labels just like it does for Schema2_1Handler.