### PR TITLE
Remove dependency on golang.org/x/exp

### DIFF
--- a/apis/conditions.go
+++ b/apis/conditions.go
@@ -1,9 +1,11 @@
 package apis
 
 import (
-	"github.com/samber/lo"
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 	"strings"
+
+	"github.com/samber/lo"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,7 +48,7 @@ func (conditions Conditions) SetReasonForSyncState(state SynchronizationState) C
 	condition := conditionsAsMap[ConditionTypes.SynchronizationSucceeded]
 	condition.Reason = string(state)
 	conditionsAsMap[ConditionTypes.SynchronizationSucceeded] = condition
-	return maps.Values(conditionsAsMap)
+	return slices.Collect(maps.Values(conditionsAsMap))
 }
 
 // SetObservedGeneration updates all conditions that match a given type
@@ -75,7 +77,7 @@ func (conditions Conditions) MergeIntoConditions(condition metav1.Condition) Con
 		conditionsAsMap[condition.Type] = condition
 	}
 
-	return maps.Values(conditionsAsMap)
+	return slices.Collect(maps.Values(conditionsAsMap))
 }
 
 type SynchronizationState string

--- a/controllers/pipelines/provider_service_manager.go
+++ b/controllers/pipelines/provider_service_manager.go
@@ -3,13 +3,13 @@ package pipelines
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/samber/lo"
 	config "github.com/sky-uk/kfp-operator/apis/config/hub"
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/controllers"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/sync v0.17.0
 	google.golang.org/api v0.247.0
 	google.golang.org/grpc v1.76.0

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
 golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
-golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
Remove dependency on golang.org/x/exp - the old dependencies are now part of the stdlib.
