### PR TITLE
Use builtin logr.FromContextOrDiscard instead of log.LoggerFromContext

### DIFF
--- a/internal/log/logging.go
+++ b/internal/log/logging.go
@@ -1,21 +1,11 @@
 package log
 
 import (
-	"context"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
-func LoggerFromContext(ctx context.Context) logr.Logger {
-	logger, err := logr.FromContext(ctx)
-	if err != nil {
-		return logr.Discard()
-	}
-
-	return logger
-}
 
 func NewLogger(logLevel zapcore.Level) (logr.Logger, error) {
 	config := zap.NewProductionConfig()

--- a/provider-service/base/pkg/server/provider_server.go
+++ b/provider-service/base/pkg/server/provider_server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-logr/logr"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/config"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
@@ -30,7 +29,7 @@ func livenessHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func createHandler(ctx context.Context, hr resource.HttpHandledResource) http.HandlerFunc {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestCtx := logr.NewContext(r.Context(), logger)
@@ -65,7 +64,7 @@ func createHandler(ctx context.Context, hr resource.HttpHandledResource) http.Ha
 }
 
 func updateHandler(ctx context.Context, hr resource.HttpHandledResource) http.HandlerFunc {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestCtx := logr.NewContext(r.Context(), logger)
@@ -106,7 +105,7 @@ func updateHandler(ctx context.Context, hr resource.HttpHandledResource) http.Ha
 }
 
 func deleteHandler(ctx context.Context, hr resource.HttpHandledResource) http.HandlerFunc {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestCtx := logr.NewContext(r.Context(), logger)

--- a/provider-service/base/pkg/server/resource/experiment.go
+++ b/provider-service/base/pkg/server/resource/experiment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 )
 
@@ -17,7 +17,7 @@ func (*Experiment) Type() string {
 }
 
 func (e *Experiment) Create(ctx context.Context, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	ed := base.ExperimentDefinition{}
 	if err := json.Unmarshal(body, &ed); err != nil {
 		logger.Error(err, "Failed to unmarshal ExperimentDefinition while creating Experiment")
@@ -37,7 +37,7 @@ func (e *Experiment) Create(ctx context.Context, body []byte) (base.Output, erro
 }
 
 func (e *Experiment) Update(ctx context.Context, id string, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	ed := base.ExperimentDefinition{}
 	if err := json.Unmarshal(body, &ed); err != nil {
 		logger.Error(err, "Failed to unmarshal ExperimentDefinition while updating Experiment")
@@ -57,7 +57,7 @@ func (e *Experiment) Update(ctx context.Context, id string, body []byte) (base.O
 }
 
 func (e *Experiment) Delete(ctx context.Context, id string) error {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if err := e.Provider.DeleteExperiment(ctx, id); err != nil {
 		logger.Error(err, "DeleteExperiment failed", "id", id)
 		return err

--- a/provider-service/base/pkg/server/resource/pipeline.go
+++ b/provider-service/base/pkg/server/resource/pipeline.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 )
 
@@ -17,7 +17,7 @@ func (*Pipeline) Type() string {
 }
 
 func (p *Pipeline) Create(ctx context.Context, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	pdw := PipelineDefinitionWrapper{}
 	if err := json.Unmarshal(body, &pdw); err != nil {
 		logger.Error(err, "Failed to unmarshal PipelineDefinitionWrapper while creating Pipeline")
@@ -37,7 +37,7 @@ func (p *Pipeline) Create(ctx context.Context, body []byte) (base.Output, error)
 }
 
 func (p *Pipeline) Update(ctx context.Context, id string, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	pdw := PipelineDefinitionWrapper{}
 	if err := json.Unmarshal(body, &pdw); err != nil {
 		logger.Error(err, "Failed to unmarshal PipelineDefinitionWrapper while updating Pipeline")
@@ -57,7 +57,7 @@ func (p *Pipeline) Update(ctx context.Context, id string, body []byte) (base.Out
 }
 
 func (p *Pipeline) Delete(ctx context.Context, id string) error {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if err := p.Provider.DeletePipeline(ctx, id); err != nil {
 		logger.Error(err, "DeletePipeline failed", "id", id)
 		return err

--- a/provider-service/base/pkg/server/resource/run.go
+++ b/provider-service/base/pkg/server/resource/run.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 )
 
@@ -17,7 +17,7 @@ func (*Run) Type() string {
 }
 
 func (r *Run) Create(ctx context.Context, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	rd := base.RunDefinition{}
 
 	if err := json.Unmarshal(body, &rd); err != nil {
@@ -42,7 +42,7 @@ func (r *Run) Update(_ context.Context, _ string, _ []byte) (base.Output, error)
 }
 
 func (r *Run) Delete(ctx context.Context, id string) error {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if err := r.Provider.DeleteRun(ctx, id); err != nil {
 		logger.Error(err, "DeleteRun failed", "id", id)
 		return err

--- a/provider-service/base/pkg/server/resource/runschedule.go
+++ b/provider-service/base/pkg/server/resource/runschedule.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 )
 
@@ -17,7 +17,7 @@ func (*RunSchedule) Type() string {
 }
 
 func (rs *RunSchedule) Create(ctx context.Context, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	rsd := base.RunScheduleDefinition{}
 	if err := json.Unmarshal(body, &rsd); err != nil {
 		logger.Error(err, "Failed to unmarshal RunScheduleDefinition while creating RunSchedule")
@@ -37,7 +37,7 @@ func (rs *RunSchedule) Create(ctx context.Context, body []byte) (base.Output, er
 }
 
 func (rs *RunSchedule) Update(ctx context.Context, id string, body []byte) (base.Output, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	rsd := base.RunScheduleDefinition{}
 	if err := json.Unmarshal(body, &rsd); err != nil {
 		logger.Error(err, "Failed to unmarshal RunScheduleDefinition while updating RunSchedule")
@@ -57,7 +57,7 @@ func (rs *RunSchedule) Update(ctx context.Context, id string, body []byte) (base
 }
 
 func (rs *RunSchedule) Delete(ctx context.Context, id string) error {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if err := rs.Provider.DeleteRunSchedule(ctx, id); err != nil {
 		logger.Error(err, "DeleteRunSchedule failed", "id", id)
 		return err

--- a/provider-service/base/pkg/server/server.go
+++ b/provider-service/base/pkg/server/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/internal/metrics"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/config"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
@@ -15,7 +15,7 @@ import (
 )
 
 func Start(ctx context.Context, cfg config.Config, provider resource.Provider) error {
-	log := log.LoggerFromContext(ctx)
+	log := logr.FromContextOrDiscard(ctx)
 
 	meterProvider, err := metrics.InitMeterProvider(fmt.Sprintf("provider-service-%s", cfg.ProviderName))
 	if err != nil {

--- a/provider-service/base/pkg/streams/sinks/error_sink.go
+++ b/provider-service/base/pkg/streams/sinks/error_sink.go
@@ -2,7 +2,8 @@ package sinks
 
 import (
 	"context"
-	"github.com/sky-uk/kfp-operator/internal/log"
+
+	"github.com/go-logr/logr"
 )
 
 type ErrorSink struct {
@@ -22,7 +23,7 @@ func (es ErrorSink) In() chan<- error {
 }
 
 func (es ErrorSink) Log(ctx context.Context) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	for err := range es.in {
 		logger.Error(err, "failed to handle event")
 	}

--- a/provider-service/base/pkg/streams/sources/pub_sub_source.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source.go
@@ -7,7 +7,6 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/go-logr/logr"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg"
 )
 
@@ -33,7 +32,7 @@ func (ps *PubSubSource) ErrorOut() <-chan error {
 }
 
 func NewPubSubSource(ctx context.Context, project string, subscription string) (*PubSubSource, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	pubSubClient, err := pubsub.NewClient(ctx, project)
 	if err != nil {

--- a/provider-service/base/pkg/streams/sources/workflow_source.go
+++ b/provider-service/base/pkg/streams/sources/workflow_source.go
@@ -3,7 +3,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"strconv"
 	"strings"
 
@@ -45,7 +44,7 @@ func (ws *WorkflowSource) Out() <-chan StreamMessage[*unstructured.Unstructured]
 }
 
 func NewWorkflowSource(ctx context.Context, namespace string, k8sClient K8sClient) (*WorkflowSource, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	workflowSource := &WorkflowSource{
 		K8sClient: k8sClient,

--- a/provider-service/kfp/internal/client/kfp_api.go
+++ b/provider-service/kfp/internal/client/kfp_api.go
@@ -2,13 +2,14 @@ package client
 
 import (
 	"context"
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"time"
+
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/label"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/client/resource"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"time"
 
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 )
@@ -73,7 +74,7 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 }
 
 func CreateKfpApi(ctx context.Context, config config.Config) (KfpApi, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	kfpApi, err := ConnectToKfpApi(config.Parameters.GrpcKfpApiAddress)
 	if err != nil {
 		logger.Error(err, "failed to connect to Kubeflow API", "address", config.Parameters.GrpcKfpApiAddress)

--- a/provider-service/kfp/internal/client/metadata_store.go
+++ b/provider-service/kfp/internal/client/metadata_store.go
@@ -3,8 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/client/ml_metadata"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/config"
 	"google.golang.org/grpc"
@@ -197,7 +198,7 @@ func propertiesToPrimitiveMap(in map[string]*ml_metadata.Value) map[string]inter
 }
 
 func CreateMetadataStore(ctx context.Context, config config.Config) (MetadataStore, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	metadataStore, err := ConnectToMetadataStore(config.Parameters.GrpcMetadataStoreAddress)
 	if err != nil {
 		logger.Error(err, "failed to connect to metadata store", "address", config.Parameters.GrpcMetadataStoreAddress)

--- a/provider-service/kfp/internal/runcompletion/event_flow.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	argo "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"github.com/sky-uk/kfp-operator/pkg/common"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg/streams"
@@ -70,7 +69,7 @@ func (ef *EventFlow) Error(inlet Inlet[error]) {
 }
 
 func NewEventFlow(ctx context.Context, config config.Config, kfpApi client.KfpApi, metadataStore client.MetadataStore) (*EventFlow, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	flow := &EventFlow{
 		ProviderConfig: config,

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/label"
 
 	aiplatform "cloud.google.com/go/aiplatform/apiv1"
 	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"github.com/sky-uk/kfp-operator/pkg/common"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
@@ -123,7 +124,7 @@ func (vaip *VAIProvider) DeletePipeline(ctx context.Context, id string) error {
 }
 
 func (vaip *VAIProvider) CreateRun(ctx context.Context, rd base.RunDefinition) (string, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	pipelinePath, err := util.PipelineStorageObject(
 		rd.PipelineName,
@@ -178,7 +179,7 @@ func (vaip *VAIProvider) CreateRunSchedule(
 	ctx context.Context,
 	rsd base.RunScheduleDefinition,
 ) (string, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	pipelinePath, err := util.PipelineStorageObject(
 		rsd.PipelineName,
@@ -238,7 +239,7 @@ func (vaip *VAIProvider) UpdateRunSchedule(
 	rsd base.RunScheduleDefinition,
 	_ string,
 ) (string, error) {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	pipelinePath, err := util.PipelineStorageObject(
 		rsd.PipelineName,

--- a/triggers/run-completion-event-trigger/internal/publisher/publisher_handler.go
+++ b/triggers/run-completion-event-trigger/internal/publisher/publisher_handler.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go"
-	"github.com/sky-uk/kfp-operator/internal/log"
 	"github.com/sky-uk/kfp-operator/pkg/common"
 )
 
@@ -44,7 +44,7 @@ type DataWrapper struct {
 }
 
 func NewNatsPublisher(ctx context.Context, nc *nats.Conn, subject string) *NatsPublisher {
-	logger := log.LoggerFromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 
 	logger.Info("New nats publisher:", "Subject", subject, "Server", nc.ConnectedUrl())
 	return &NatsPublisher{

--- a/triggers/run-completion-event-trigger/internal/server/health_server.go
+++ b/triggers/run-completion-event-trigger/internal/server/health_server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -17,7 +17,7 @@ func (hs *HealthServer) Check(
 	ctx context.Context,
 	req *healthpb.HealthCheckRequest,
 ) (*healthpb.HealthCheckResponse, error) {
-	log := log.LoggerFromContext(ctx)
+	log := logr.FromContextOrDiscard(ctx)
 
 	switch req.GetService() {
 	case "liveness":

--- a/triggers/run-completion-event-trigger/internal/server/server.go
+++ b/triggers/run-completion-event-trigger/internal/server/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/sky-uk/kfp-operator/internal/log"
+	"github.com/go-logr/logr"
 	configLoader "github.com/sky-uk/kfp-operator/triggers/run-completion-event-trigger/cmd/config"
 	"github.com/sky-uk/kfp-operator/triggers/run-completion-event-trigger/internal/converters"
 	"github.com/sky-uk/kfp-operator/triggers/run-completion-event-trigger/internal/publisher"
@@ -24,7 +24,7 @@ func (s *Server) ProcessEventFeed(
 	ctx context.Context,
 	runCompletion *pb.RunCompletionEvent,
 ) (*emptypb.Empty, error) {
-	logger := log.LoggerFromContext(ctx).WithValues("runId", runCompletion.RunId)
+	logger := logr.FromContextOrDiscard(ctx).WithValues("runId", runCompletion.RunId)
 
 	commonRunCompletionEvent, err := converters.ProtoRunCompletionToCommon(runCompletion)
 	if err != nil {


### PR DESCRIPTION
Use builtin logr.FromContextOrDiscard instead of log.LoggerFromContext because they are functionally identical, so prefer the builtin function instead.