### PR TITLE
Update jq image to manifest schema version 2

### DIFF
--- a/config/manager/workflows/common.yaml
+++ b/config/manager/workflows/common.yaml
@@ -31,7 +31,7 @@ spec:
           path: "/tmp/url-encoded.txt"
     metadata: {}
     container:
-      image: stedolan/jq:latest
+      image: apteno/alpine-jq:latest
       command: [sh, -c]
       args:
       - |

--- a/helm/kfp-operator/templates/workflows/common.yaml
+++ b/helm/kfp-operator/templates/workflows/common.yaml
@@ -33,7 +33,7 @@ spec:
     metadata:
       {{- .Values.manager.argo.metadata | toYaml | nindent 6 }}
     container:
-      image: stedolan/jq:latest
+      image: apteno/alpine-jq:latest
       command: [sh, -c]
       args:
       - |


### PR DESCRIPTION
Closes #914 

The currently used jq image is over 10 years old and is still using schema version 1 for its image manifest. This has been deprecated and for future versions of K8s will not be supported. The new image [alpine-jq](https://hub.docker.com/r/apteno/alpine-jq/tags), is a weekly build off the latest alpine image. So will remain up to date and maintained better. 