### PR TITLE
Make label sanitizing for pipeline version, schema version and sdk version consistent

### DIFF
--- a/provider-service/base/pkg/label/label.go
+++ b/provider-service/base/pkg/label/label.go
@@ -12,6 +12,8 @@ const (
 	RunConfigurationNamespace = "runconfiguration-namespace"
 	RunName                   = "run-name"
 	RunNamespace              = "run-namespace"
+	SchemaVersion             = "schema_version"
+	SdkVersion                = "sdk_version"
 )
 
 var LabelKeys = []string{

--- a/provider-service/vai/internal/provider/label_sanitizer.go
+++ b/provider-service/vai/internal/provider/label_sanitizer.go
@@ -29,9 +29,7 @@ func (dls DefaultLabelSanitizer) Sanitize(labels map[string]string) map[string]s
 
 		// Differing methods of replacing invalid chars due to historical decisions.
 		switch key {
-		case label.PipelineVersion:
-			value = vaiCompliant.ReplaceAllString(value, "-")
-		case "schema_version", "sdk_version":
+		case label.PipelineVersion, label.SchemaVersion, label.SdkVersion:
 			value = vaiCompliant.ReplaceAllString(value, "_")
 		default:
 			key = vaiCompliant.ReplaceAllString(key, "")

--- a/provider-service/vai/internal/provider/label_sanitizer_test.go
+++ b/provider-service/vai/internal/provider/label_sanitizer_test.go
@@ -39,15 +39,9 @@ var _ = Describe("DefaultLabelSanitizer", func() {
 			),
 
 			Entry(
-				"if key is pipeline-version then it replaces invalid characters with hyphen",
-				map[string]string{"pipeline-version": "0.0.1"},
-				map[string]string{"pipeline-version": "0-0-1"},
-			),
-
-			Entry(
-				"if key is schema_version or sdk_version then it replaces invalid characters with underscore",
-				map[string]string{"schema_version": "2.1.0", "sdk_version": "kfp-2.12.2"},
-				map[string]string{"schema_version": "2_1_0", "sdk_version": "kfp-2_12_2"},
+				"if key is pipeline-version, schema_version or sdk_version then it replaces invalid characters with underscore",
+				map[string]string{"pipeline-version": "0.0.1", "schema_version": "2.1.0", "sdk_version": "kfp-2.12.2"},
+				map[string]string{"pipeline-version": "0_0_1", "schema_version": "2_1_0", "sdk_version": "kfp-2_12_2"},
 			),
 		)
 


### PR DESCRIPTION
Closes #839

Retaining the separator between major, minor and patch versions for readability, but making it consistent across the different types of versions. Anything else continues to be replaced by an empty string.