### PR TITLE
Fix Helm chart publishing for OCI registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,14 @@ helm-publish:: helm-package ## Publish Helm chart to repositories
 	$(foreach url,$(HELM_REPOSITORIES) $(OSS_HELM_REPOSITORIES),$(call helm-upload,$(url)))
 
 define helm-upload
-@echo "Publishing Helm chart to $(1)"
-@if [[ "$(1)" == "oci://"* ]]; then \
-	helm push dist/kfp-operator-$(VERSION).tgz $(1)/kfp-operator; \
-else \
-	curl --fail --netrc-file $(NETRC_FILE) -T dist/kfp-operator-$(VERSION).tgz $(1); \
-fi
-$(NEWLINE)
+	@echo "Publishing Helm chart to $(1)"
+	@if echo "$(1)" | grep -q "^oci://"; then \
+		echo "Using Helm OCI push"; \
+		helm push dist/kfp-operator-$(VERSION).tgz $(1)/kfp-operator; \
+	else \
+		echo "Using curl upload"; \
+		curl --fail --netrc-file $(NETRC_FILE) -T dist/kfp-operator-$(VERSION).tgz "$(1)"; \
+	fi
 endef
 endif
 


### PR DESCRIPTION
The Makefile function is invalid and fails with the following for OCI registries:
```/bin/sh: 1: [[: not found```

- Make runs commands using `/bin/sh`, not bash
- `/bin/sh` does not support `[[` or `== "oci://*"`
- This solution works with `/bin/sh`