### PR TITLE
Enforce all eventbuses to run as non root user

### DIFF
--- a/helm/kfp-operator/templates/eventing/internal_eventbus.yaml
+++ b/helm/kfp-operator/templates/eventing/internal_eventbus.yaml
@@ -15,4 +15,7 @@ spec:
         resources:
           requests:
             cpu: 100m
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true
 {{- end -}}

--- a/helm/kfp-operator/templates/eventing/public_eventbus.yaml
+++ b/helm/kfp-operator/templates/eventing/public_eventbus.yaml
@@ -18,4 +18,7 @@ spec:
         resources:
           requests:
             cpu: 100m
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true
 {{- end -}}


### PR DESCRIPTION
Enforce all eventbuses to run as non root user, which aligns with the principle of least privilege.
