### PR TITLE
allow crds to optionally have the "keep" helm resource policy annotation

### DIFF
--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: experiments.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: pipelines.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: providers.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: runconfigurations.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: runs.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: runschedules.pipelines.kubeflow.org
 spec:
   group: pipelines.kubeflow.org

--- a/helm/kfp-operator/test/values.yaml
+++ b/helm/kfp-operator/test/values.yaml
@@ -2,6 +2,7 @@ fullnameOverride: kfp-operator
 containerRegistry: ""
 crds:
   create: true
+  keep: false
 manager:
   argo:
     containerDefaults: {}

--- a/helm/kfp-operator/values.yaml
+++ b/helm/kfp-operator/values.yaml
@@ -8,6 +8,7 @@ containerRegistry: "ghcr.io/kfp-operator"
 
 crds:
   create: true
+  keep: true
 
 namespace:
   create: true

--- a/local/values.yaml
+++ b/local/values.yaml
@@ -1,5 +1,6 @@
 crds:
   create: true
+  keep: true
 namespace:
   create: false
 fullnameOverride: kfp-operator


### PR DESCRIPTION
Allow crds to optionally have the "keep" helm resource policy annotation. If enabled (is enabled by default) then if crds creation is enabled, they cannot be deleted by helm.
