### PR TITLE
readd the cert-manager annotations removed in `29389503`

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,6 +21,16 @@ patchesStrategicMerge:
 - patches/webhook_in_providers.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+- patches/cainjection_in_pipelines.yaml
+- patches/cainjection_in_runs.yaml
+- patches/cainjection_in_runconfigurations.yaml
+- patches/cainjection_in_runschedules.yaml
+- patches/cainjection_in_experiments.yaml
+- patches/cainjection_in_providers.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/cainjection_in_experiments.yaml
+++ b/config/crd/patches/cainjection_in_experiments.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: experiments.pipelines.kubeflow.org
+

--- a/config/crd/patches/cainjection_in_pipelines.yaml
+++ b/config/crd/patches/cainjection_in_pipelines.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: pipelines.pipelines.kubeflow.org
+

--- a/config/crd/patches/cainjection_in_providers.yaml
+++ b/config/crd/patches/cainjection_in_providers.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: providers.pipelines.kubeflow.org
+

--- a/config/crd/patches/cainjection_in_runconfigurations.yaml
+++ b/config/crd/patches/cainjection_in_runconfigurations.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: runconfigurations.pipelines.kubeflow.org
+

--- a/config/crd/patches/cainjection_in_runs.yaml
+++ b/config/crd/patches/cainjection_in_runs.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: runs.pipelines.kubeflow.org
+

--- a/config/crd/patches/cainjection_in_runschedules.yaml
+++ b/config/crd/patches/cainjection_in_runschedules.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: runschedules.pipelines.kubeflow.org
+

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_experiments.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_pipelines.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_providers.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runconfigurations.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runs.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep

--- a/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
+++ b/helm/kfp-operator/templates/crd/bases/pipelines.kubeflow.org_runschedules.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if and .Values.manager.multiversion.enabled (eq .Values.manager.webhookCertificates.provider "cert-manager") }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "kfp-operator.fullname" . }}-serving-cert
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.crds.keep }}
     helm.sh/resource-policy: keep


### PR DESCRIPTION
re-add the cert-manager annotations removed in `29389503` because it turns out the annotation is responsible for injecting the caBundle field into the crds, and it's separate from the controller deployment's requirement for having the actual cert.
