### PR TITLE
Simplify provider namespace name config loading

### DIFF
--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -43,10 +43,6 @@ spec:
               cpu: 250m
               memory: 128Mi
           env:
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: OPERATORWEBHOOK
             value: http://kfp-operator-runcompletion-webhook-service.kfp-operator-system:80/events
           - name: SERVER_PORT

--- a/controllers/pipelines/provider_deployment_manager.go
+++ b/controllers/pipelines/provider_deployment_manager.go
@@ -12,6 +12,7 @@ import (
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/controllers"
 	"github.com/sky-uk/kfp-operator/internal/config"
+	"github.com/sky-uk/kfp-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -143,9 +144,14 @@ func populateServiceContainer(serviceContainerName string, podTemplate corev1.Po
 		return nil, fmt.Errorf("unable to populate service container: container with name %s not found on deployment", serviceContainerName)
 	}
 
+	namespacedName, err := common.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}.String()
+	if err != nil {
+		return nil, err
+	}
+
 	envVars := []corev1.EnvVar{{
 		Name:  ProviderNameEnvVar,
-		Value: provider.Name,
+		Value: namespacedName,
 	}, {
 		Name:  PipelineRootStorageEnvVar,
 		Value: provider.Spec.PipelineRootStorage,

--- a/controllers/pipelines/provider_deployment_manager_test.go
+++ b/controllers/pipelines/provider_deployment_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sky-uk/kfp-operator/controllers"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/testutil"
 	"github.com/sky-uk/kfp-operator/internal/config"
+	"github.com/sky-uk/kfp-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -189,6 +190,9 @@ var _ = Context("Provider Deployment Manager", func() {
 
 			providerSuffixedName := fmt.Sprintf("provider-%s", provider.Name)
 
+			providerNamespacedName, err := common.NamespacedName{Namespace: provider.Namespace, Name: provider.Name}.String()
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(Equal([]corev1.EnvVar{
 				{
 					Name:  "PARAMETERS_KEY1",
@@ -204,7 +208,7 @@ var _ = Context("Provider Deployment Manager", func() {
 				},
 				{
 					Name:  ProviderNameEnvVar,
-					Value: provider.Name,
+					Value: providerNamespacedName,
 				},
 			}))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(provider.Spec.ServiceImage))

--- a/helm/kfp-operator/templates/configmap.yaml
+++ b/helm/kfp-operator/templates/configmap.yaml
@@ -43,10 +43,6 @@ data:
               resources:
                 {{- $.Values.provider.resources | toYaml | nindent 16 }}
               env:
-              - name: POD_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
               - name: OPERATORWEBHOOK
                 value: http://{{ include "kfp-operator.fullname" . }}-runcompletion-webhook-service.{{ .Values.namespace.name }}:80/events
               - name: SERVER_PORT

--- a/provider-service/base/pkg/config/config.go
+++ b/provider-service/base/pkg/config/config.go
@@ -6,20 +6,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/sky-uk/kfp-operator/pkg/common"
 	"github.com/spf13/viper"
 )
 
 type Config struct {
-	ProviderName        string        `mapstructure:"providerName"`
-	PipelineRootStorage string        `mapstructure:"pipelineRootStorage"`
-	OperatorWebhook     string        `mapstructure:"operatorWebhook"`
-	Pod                 Pod           `mapstructure:"pod"`
-	Server              Server        `mapstructure:"server"`
-	Metrics             MetricsConfig `mapstructure:"metrics"`
-}
-
-type Pod struct {
-	Namespace string `mapstructure:"namespace"`
+	ProviderName        common.NamespacedName `mapstructure:"providerName"`
+	PipelineRootStorage string                `mapstructure:"pipelineRootStorage"`
+	OperatorWebhook     string                `mapstructure:"operatorWebhook"`
+	Server              Server                `mapstructure:"server"`
+	Metrics             MetricsConfig         `mapstructure:"metrics"`
 }
 
 type Server struct {
@@ -47,7 +44,7 @@ func LoadConfig[T any](initConfig T) (*T, error) {
 	}
 
 	var config T
-	if err := viper.Unmarshal(&config); err != nil {
+	if err := viper.Unmarshal(&config, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc())); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config %w", err)
 	}
 

--- a/provider-service/base/pkg/config/config_unit_test.go
+++ b/provider-service/base/pkg/config/config_unit_test.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,18 +27,6 @@ var _ = Context("load", func() {
 			config, err := LoadConfig(defaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config).To(Equal(&defaultConfig))
-		})
-	})
-
-	When("given a pod namespace environment variable", func() {
-		It("correctly overrides config value", func() {
-			err := os.Setenv("POD_NAMESPACE", "kfp-operator-system")
-			Expect(err).NotTo(HaveOccurred())
-			expected := defaultConfig
-			expected.Pod.Namespace = "kfp-operator-system"
-			config, err := LoadConfig(defaultConfig)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(config).To(Equal(&expected))
 		})
 	})
 })

--- a/provider-service/kfp/cmd/main.go
+++ b/provider-service/kfp/cmd/main.go
@@ -55,22 +55,21 @@ func main() {
 
 	kfpProviderConfig, err := baseConfig.LoadConfig(
 		kfpConfig.Config{
-			Name:                serviceConfig.ProviderName,
-			Namespace:           serviceConfig.Pod.Namespace,
+			ProviderName:        serviceConfig.ProviderName,
 			PipelineRootStorage: serviceConfig.PipelineRootStorage,
 		},
 	)
 	if err != nil {
-		logger.Error(err, "failed to load provider config", "provider", serviceConfig.ProviderName, "namespace", serviceConfig.Pod.Namespace)
+		logger.Error(err, "failed to load provider config", "provider", serviceConfig.ProviderName)
 		panic(err)
 	}
-	logger.Info(fmt.Sprintf("loaded provider config: %+v", kfpProviderConfig), "provider", serviceConfig.ProviderName, "namespace", serviceConfig.Pod.Namespace)
+	logger.Info(fmt.Sprintf("loaded provider config: %+v", kfpProviderConfig), "provider", serviceConfig.ProviderName)
 
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(
 		func() error {
-			provider, err := kfp.NewKfpProvider(kfpProviderConfig, serviceConfig.Pod.Namespace)
+			provider, err := kfp.NewKfpProvider(kfpProviderConfig)
 			if err != nil {
 				return fmt.Errorf("failed to create provider: %w", err)
 			}

--- a/provider-service/kfp/internal/config/config.go
+++ b/provider-service/kfp/internal/config/config.go
@@ -1,15 +1,16 @@
 package config
 
+import "github.com/sky-uk/kfp-operator/pkg/common"
+
 type Config struct {
-	Name                string     `yaml:"name"`
-	Namespace           string     `yaml:"namespace"`
-	PipelineRootStorage string     `yaml:"pipelineRootStorage"`
-	Parameters          Parameters `yaml:"parameters"`
+	ProviderName        common.NamespacedName `mapstructure:"providerName" yaml:"providerName"`
+	PipelineRootStorage string                `mapstructure:"pipelineRootStorage" yaml:"pipelineRootStorage"`
+	Parameters          Parameters            `mapstructure:"parameters" yaml:"parameters"`
 }
 
 type Parameters struct {
-	KfpNamespace             string `yaml:"kfpNamespace,omitempty"`
-	RestKfpApiUrl            string `yaml:"restKfpApiUrl,omitempty"`
-	GrpcMetadataStoreAddress string `yaml:"grpcMetadataStoreAddress,omitempty"`
-	GrpcKfpApiAddress        string `yaml:"grpcKfpApiAddress,omitempty"`
+	KfpNamespace             string `mapstructure:"kfpNamespace" yaml:"kfpNamespace,omitempty"`
+	RestKfpApiUrl            string `mapstructure:"restKfpApiUrl" yaml:"restKfpApiUrl,omitempty"`
+	GrpcMetadataStoreAddress string `mapstructure:"grpcMetadataStoreAddress" yaml:"grpcMetadataStoreAddress,omitempty"`
+	GrpcKfpApiAddress        string `mapstructure:"grpcKfpApiAddress" yaml:"grpcKfpApiAddress,omitempty"`
 }

--- a/provider-service/kfp/internal/provider/provider.go
+++ b/provider-service/kfp/internal/provider/provider.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/sky-uk/kfp-operator/pkg/common"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/label"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
@@ -24,7 +23,7 @@ type KfpProvider struct {
 	labelService          LabelService
 }
 
-func NewKfpProvider(config *config.Config, namespace string) (*KfpProvider, error) {
+func NewKfpProvider(config *config.Config) (*KfpProvider, error) {
 	pipelineUploadService, err := NewPipelineUploadService(
 		config.Parameters.RestKfpApiUrl,
 	)
@@ -46,10 +45,7 @@ func NewKfpProvider(config *config.Config, namespace string) (*KfpProvider, erro
 	}
 
 	labelGenerator := label.DefaultLabelGen{
-		ProviderName: common.NamespacedName{
-			Name:      config.Name,
-			Namespace: namespace,
-		},
+		ProviderName: config.ProviderName,
 	}
 
 	runService, err := NewRunService(conn, labelGenerator)

--- a/provider-service/kfp/internal/runcompletion/event_decoupled_test.go
+++ b/provider-service/kfp/internal/runcompletion/event_decoupled_test.go
@@ -85,8 +85,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	config := &config.Config{
-		Name:      provider.Name,
-		Namespace: provider.Namespace,
+		ProviderName: provider,
 	}
 
 	eventSource, err = sources.NewWorkflowSource(context.Background(), defaultNamespace, pkg.K8sClient{Client: k8sClient})

--- a/provider-service/kfp/internal/runcompletion/event_flow.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow.go
@@ -140,11 +140,6 @@ func (ef *EventFlow) eventForWorkflow(ctx context.Context, workflow *unstructure
 		return nil, err
 	}
 
-	provider := common.NamespacedName{
-		Name:      ef.ProviderConfig.Name,
-		Namespace: ef.ProviderConfig.Namespace,
-	}
-
 	return &common.RunCompletionEventData{
 		Status:                status,
 		PipelineName:          resourceReferences.PipelineName,
@@ -153,7 +148,7 @@ func (ef *EventFlow) eventForWorkflow(ctx context.Context, workflow *unstructure
 		RunId:                 runId,
 		ServingModelArtifacts: modelArtifacts,
 		PipelineComponents:    pipelineComponents,
-		Provider:              provider,
+		Provider:              ef.ProviderConfig.ProviderName,
 		RunStartTime:          resourceReferences.CreatedAt,
 		RunEndTime:            resourceReferences.FinishedAt,
 	}, nil

--- a/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
@@ -148,7 +148,7 @@ var _ = Context("Eventing Flow", func() {
 			MetadataStore: &mockMetadataStore,
 			KfpApi:        &mockKfpApi,
 			ProviderConfig: config.Config{
-				Name: "kfp",
+				ProviderName: common.NamespacedName{Namespace: "default", Name: "kfp"},
 			},
 		}
 
@@ -159,8 +159,8 @@ var _ = Context("Eventing Flow", func() {
 		Expect(event.ServingModelArtifacts).To(Equal(artifacts))
 		Expect(*event.RunConfigurationName).To(Equal(resourceReferences.RunConfigurationName))
 		Expect(*event.RunName).To(Equal(resourceReferences.RunName))
-		Expect(event.Provider.Name).To(Equal(eventingServer.ProviderConfig.Name))
-		Expect(event.Provider.Namespace).To(Equal(eventingServer.ProviderConfig.Namespace))
+		Expect(event.Provider.Name).To(Equal(eventingServer.ProviderConfig.ProviderName.Name))
+		Expect(event.Provider.Namespace).To(Equal(eventingServer.ProviderConfig.ProviderName.Namespace))
 		Expect(err).NotTo(HaveOccurred())
 	},
 		Entry("workflow succeeded", argo.WorkflowSucceeded),

--- a/provider-service/vai/cmd/main.go
+++ b/provider-service/vai/cmd/main.go
@@ -54,17 +54,14 @@ func main() {
 	logger.Info(fmt.Sprintf("loaded base config: %+v", serviceConfig))
 
 	vaiProviderConfig, err := baseConfig.LoadConfig(vaiConfig.VAIProviderConfig{
-		ProviderName: common.NamespacedName{
-			Name:      serviceConfig.ProviderName,
-			Namespace: serviceConfig.Pod.Namespace,
-		},
+		ProviderName:        serviceConfig.ProviderName,
 		PipelineRootStorage: serviceConfig.PipelineRootStorage,
 	})
 	if err != nil {
-		logger.Error(err, "failed to load provider config", "provider", serviceConfig.ProviderName, "namespace", serviceConfig.Pod.Namespace)
+		logger.Error(err, "failed to load provider config", "provider", serviceConfig.ProviderName)
 		panic(err)
 	}
-	logger.Info(fmt.Sprintf("loaded provider config: %+v", vaiProviderConfig), "provider", serviceConfig.ProviderName, "namespace", serviceConfig.Pod.Namespace)
+	logger.Info(fmt.Sprintf("loaded provider config: %+v", vaiProviderConfig), "provider", serviceConfig.ProviderName)
 
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/provider-service/vai/internal/config/config.go
+++ b/provider-service/vai/internal/config/config.go
@@ -7,19 +7,19 @@ import (
 )
 
 type VAIProviderConfig struct {
-	ProviderName        common.NamespacedName `yaml:"providerName"`
-	PipelineRootStorage string                `yaml:"pipelineRootStorage"`
-	Parameters          Parameters            `yaml:"parameters"`
+	ProviderName        common.NamespacedName `mapstructure:"providerName" yaml:"providerName"`
+	PipelineRootStorage string                `mapstructure:"pipelineRootStorage" yaml:"pipelineRootStorage"`
+	Parameters          Parameters            `mapstructure:"parameters" yaml:"parameters"`
 }
 
 type Parameters struct {
-	VaiProject                            string `yaml:"vaiProject"`
-	VaiLocation                           string `yaml:"vaiLocation"`
-	VaiJobServiceAccount                  string `yaml:"vaiJobServiceAccount"`
-	GcsEndpoint                           string `yaml:"gcsEndpoint"`
-	PipelineBucket                        string `yaml:"pipelineBucket"`
-	EventsourcePipelineEventsSubscription string `yaml:"eventsourcePipelineEventsSubscription"`
-	MaxConcurrentRunCount                 int64  `yaml:"maxConcurrentRunCount"`
+	VaiProject                            string `mapstructure:"vaiProject" yaml:"vaiProject"`
+	VaiLocation                           string `mapstructure:"vaiLocation" yaml:"vaiLocation"`
+	VaiJobServiceAccount                  string `mapstructure:"vaiJobServiceAccount" yaml:"vaiJobServiceAccount"`
+	GcsEndpoint                           string `mapstructure:"gcsEndpoint" yaml:"gcsEndpoint"`
+	PipelineBucket                        string `mapstructure:"pipelineBucket" yaml:"pipelineBucket"`
+	EventsourcePipelineEventsSubscription string `mapstructure:"eventsourcePipelineEventsSubscription" yaml:"eventsourcePipelineEventsSubscription"`
+	MaxConcurrentRunCount                 int64  `mapstructure:"maxConcurrentRunCount" yaml:"maxConcurrentRunCount"`
 }
 
 func (vaipc VAIProviderConfig) VaiEndpoint() string {


### PR DESCRIPTION
links to #1027 

Refactors the existing provider namespace config loading to be simpler and not rely on k8s environment mappings.
