### PR TITLE
feature: expose runconfiguration dependency graph as metrics

### DIFF
--- a/controllers/pipelines/internal/metrics/triggered_runs_metrics.go
+++ b/controllers/pipelines/internal/metrics/triggered_runs_metrics.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	runtimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	labelStartedBy                  = "started_by"
+	labelStartedByResource          = "started_by_resource"
+	labelStartedByResourceNamespace = "started_by_resource_namespace"
+	labelRunConfiguration           = "run_configuration"
+	labelNamespace                  = "namespace"
+	labelPipeline                   = "pipeline"
+)
+
+type RunTriggeredLabels struct {
+	StartedBy                  string
+	StartedByResource          string
+	StartedByResourceNamespace string
+	RunConfiguration           string
+	Namespace                  string
+	Pipeline                   string
+}
+
+func (rtl RunTriggeredLabels) ToPrometheusLabels() prometheus.Labels {
+	return prometheus.Labels{
+		labelStartedBy:                  rtl.StartedBy,
+		labelStartedByResource:          rtl.StartedByResource,
+		labelStartedByResourceNamespace: rtl.StartedByResourceNamespace,
+		labelRunConfiguration:           rtl.RunConfiguration,
+		labelNamespace:                  rtl.Namespace,
+		labelPipeline:                   rtl.Pipeline,
+	}
+}
+
+var RunsTriggeredTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "kfp_operator_onchange_runs_total",
+		Help: "Total number of runs triggered by RunConfiguration onChange events.",
+	},
+	[]string{labelStartedBy, labelStartedByResource, labelStartedByResourceNamespace, labelRunConfiguration, labelNamespace, labelPipeline},
+)
+
+func init() {
+	runtimeMetrics.Registry.MustRegister(RunsTriggeredTotal)
+}

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -29,34 +29,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	runConfigurationNodeLabel   = "run_configuration_node"
-	runConfigurationEdgeLabel   = "run_configuration_edge"
-	runConfigurationIdLabel     = "id"
-	runConfigurationTitleLabel  = "title"
-	runConfigurationSourceLabel = "source"
-	runConfigurationTargetLabel = "target"
-)
-
-var runConfigNode = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: runConfigurationNodeLabel,
-		Help: "Node: RunConfiguration node in the dependency graph",
+var runsTriggeredTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "kfp_operator_runs_triggered_total",
+		Help: "Total number of runs triggered by RunConfigurations",
 	},
-	[]string{runConfigurationIdLabel, runConfigurationTitleLabel},
-)
-
-var runConfigEdge = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: runConfigurationEdgeLabel,
-		Help: "Edge: dependency between RunConfigurations (source executes before target)",
-	},
-	[]string{runConfigurationIdLabel, runConfigurationSourceLabel, runConfigurationTargetLabel},
+	[]string{"started_by", "started_by_resource", "started_by_resource_namespace", "run_configuration", "namespace", "pipeline"},
 )
 
 func init() {
-	runtimeMetrics.Registry.MustRegister(runConfigNode)
-	runtimeMetrics.Registry.MustRegister(runConfigEdge)
+	runtimeMetrics.Registry.MustRegister(runsTriggeredTotal)
 }
 
 // RunConfigurationReconciler reconciles a RunConfiguration object
@@ -107,7 +89,6 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.V(3).Info("found run configuration", "resource", runConfiguration)
 
 	if runConfiguration.DeletionTimestamp != nil {
-		r.clearDependencyMetrics(runConfiguration)
 		return ctrl.Result{}, nil
 	}
 
@@ -177,35 +158,10 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	r.updateDependencyMetrics(runConfiguration)
-
 	duration := time.Now().Sub(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
-}
-
-func (r *RunConfigurationReconciler) clearDependencyMetrics(rc *pipelineshub.RunConfiguration) {
-	rcName := rc.Name
-	runConfigEdge.DeletePartialMatch(prometheus.Labels{"target": rcName})
-	runConfigEdge.DeletePartialMatch(prometheus.Labels{"source": rcName})
-	runConfigNode.DeletePartialMatch(prometheus.Labels{"id": rcName})
-}
-
-func (r *RunConfigurationReconciler) updateDependencyMetrics(rc *pipelineshub.RunConfiguration) {
-	rcName := rc.Name
-	runConfigEdge.DeletePartialMatch(prometheus.Labels{"target": rcName})
-
-	// Ensure this RunConfiguration is registered as a node
-	runConfigNode.WithLabelValues(rcName, rcName).Set(1)
-
-	for _, dep := range rc.GetReferencedRCs() {
-		sourceName := dep.Name
-		edgeId := sourceName + " -> " + rcName
-		runConfigEdge.WithLabelValues(edgeId, sourceName, rcName).Set(1)
-		// Ensure the source is also registered as a node
-		runConfigNode.WithLabelValues(sourceName, sourceName).Set(1)
-	}
 }
 
 func (r *RunConfigurationReconciler) triggerUntriggeredRuns(
@@ -236,7 +192,29 @@ func (r *RunConfigurationReconciler) triggerUntriggeredRuns(
 		desiredRun.Labels = lo.Assign(desiredRun.Labels, indicator.AsK8sLabels())
 	}
 
-	return r.EC.Client.Create(ctx, desiredRun)
+	if err := r.EC.Client.Create(ctx, desiredRun); err != nil {
+		return err
+	}
+
+	startedBy := ""
+	startedByResource := ""
+	startedByResourceNamespace := ""
+	if indicator != nil {
+		startedBy = indicator.Type
+		startedByResource = indicator.Source
+		startedByResourceNamespace = indicator.SourceNamespace
+	}
+
+	runsTriggeredTotal.WithLabelValues(
+		startedBy,
+		startedByResource,
+		startedByResourceNamespace,
+		runConfiguration.Name,
+		runConfiguration.Namespace,
+		runConfiguration.Spec.Run.Pipeline.Name,
+	).Inc()
+
+	return nil
 }
 
 func (r *RunConfigurationReconciler) updateRcTriggers(

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -7,10 +7,10 @@ import (
 	"slices"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"github.com/sky-uk/kfp-operator/apis"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/logkeys"
+	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/metrics"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/workflowfactory"
 	"github.com/sky-uk/kfp-operator/internal/config"
 	"github.com/sky-uk/kfp-operator/pkg/common"
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	runtimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
@@ -28,18 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var runsTriggeredTotal = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "kfp_operator_runs_triggered_total",
-		Help: "Total number of runs triggered by RunConfigurations",
-	},
-	[]string{"started_by", "started_by_resource", "started_by_resource_namespace", "run_configuration", "namespace", "pipeline"},
-)
-
-func init() {
-	runtimeMetrics.Registry.MustRegister(runsTriggeredTotal)
-}
 
 // RunConfigurationReconciler reconciles a RunConfiguration object
 type RunConfigurationReconciler struct {
@@ -180,7 +167,7 @@ func (r *RunConfigurationReconciler) triggerUntriggeredRuns(
 	}
 
 	if runExists := slices.ContainsFunc(runs, func(run pipelineshub.Run) bool {
-		return string(run.ComputeHash()) == string(desiredRun.ComputeHash())
+		return string(run.CanomputeHash()) == string(desiredRun.ComputeHash())
 	}); runExists {
 		return nil
 	}
@@ -196,23 +183,18 @@ func (r *RunConfigurationReconciler) triggerUntriggeredRuns(
 		return err
 	}
 
-	startedBy := ""
-	startedByResource := ""
-	startedByResourceNamespace := ""
+	labels := metrics.RunTriggeredLabels{
+		RunConfiguration: runConfiguration.Name,
+		Namespace:        runConfiguration.Namespace,
+		Pipeline:         runConfiguration.Spec.Run.Pipeline.Name,
+	}
 	if indicator != nil {
-		startedBy = indicator.Type
-		startedByResource = indicator.Source
-		startedByResourceNamespace = indicator.SourceNamespace
+		labels.StartedBy = indicator.Type
+		labels.StartedByResource = indicator.Source
+		labels.StartedByResourceNamespace = indicator.SourceNamespace
 	}
 
-	runsTriggeredTotal.WithLabelValues(
-		startedBy,
-		startedByResource,
-		startedByResourceNamespace,
-		runConfiguration.Name,
-		runConfiguration.Namespace,
-		runConfiguration.Spec.Run.Pipeline.Name,
-	).Inc()
+	metrics.RunsTriggeredTotal.With(labels.ToPrometheusLabels()).Inc()
 
 	return nil
 }

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -167,7 +167,7 @@ func (r *RunConfigurationReconciler) triggerUntriggeredRuns(
 	}
 
 	if runExists := slices.ContainsFunc(runs, func(run pipelineshub.Run) bool {
-		return string(run.CanomputeHash()) == string(desiredRun.ComputeHash())
+		return string(run.ComputeHash()) == string(desiredRun.ComputeHash())
 	}); runExists {
 		return nil
 	}

--- a/controllers/pipelines/runconfiguration_controller.go
+++ b/controllers/pipelines/runconfiguration_controller.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"github.com/sky-uk/kfp-operator/apis"
 	"github.com/sky-uk/kfp-operator/controllers/pipelines/internal/logkeys"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	runtimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
@@ -26,6 +28,36 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const (
+	runConfigurationNodeLabel   = "run_configuration_node"
+	runConfigurationEdgeLabel   = "run_configuration_edge"
+	runConfigurationIdLabel     = "id"
+	runConfigurationTitleLabel  = "title"
+	runConfigurationSourceLabel = "source"
+	runConfigurationTargetLabel = "target"
+)
+
+var runConfigNode = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: runConfigurationNodeLabel,
+		Help: "Node: RunConfiguration node in the dependency graph",
+	},
+	[]string{runConfigurationIdLabel, runConfigurationTitleLabel},
+)
+
+var runConfigEdge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: runConfigurationEdgeLabel,
+		Help: "Edge: dependency between RunConfigurations (source executes before target)",
+	},
+	[]string{runConfigurationIdLabel, runConfigurationSourceLabel, runConfigurationTargetLabel},
+)
+
+func init() {
+	runtimeMetrics.Registry.MustRegister(runConfigNode)
+	runtimeMetrics.Registry.MustRegister(runConfigEdge)
+}
 
 // RunConfigurationReconciler reconciles a RunConfiguration object
 type RunConfigurationReconciler struct {
@@ -66,7 +98,7 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	startTime := time.Now()
 	logger.V(2).Info("reconciliation started")
 
-	var runConfiguration = &pipelineshub.RunConfiguration{}
+	runConfiguration := &pipelineshub.RunConfiguration{}
 	if err := r.EC.Client.NonCached.Get(ctx, req.NamespacedName, runConfiguration); err != nil {
 		logger.Error(err, "unable to fetch run configuration")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -75,6 +107,7 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.V(3).Info("found run configuration", "resource", runConfiguration)
 
 	if runConfiguration.DeletionTimestamp != nil {
+		r.clearDependencyMetrics(runConfiguration)
 		return ctrl.Result{}, nil
 	}
 
@@ -144,10 +177,35 @@ func (r *RunConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	r.updateDependencyMetrics(runConfiguration)
+
 	duration := time.Now().Sub(startTime)
 	logger.V(2).Info("reconciliation ended", logkeys.Duration, duration)
 
 	return ctrl.Result{}, nil
+}
+
+func (r *RunConfigurationReconciler) clearDependencyMetrics(rc *pipelineshub.RunConfiguration) {
+	rcName := rc.Name
+	runConfigEdge.DeletePartialMatch(prometheus.Labels{"target": rcName})
+	runConfigEdge.DeletePartialMatch(prometheus.Labels{"source": rcName})
+	runConfigNode.DeletePartialMatch(prometheus.Labels{"id": rcName})
+}
+
+func (r *RunConfigurationReconciler) updateDependencyMetrics(rc *pipelineshub.RunConfiguration) {
+	rcName := rc.Name
+	runConfigEdge.DeletePartialMatch(prometheus.Labels{"target": rcName})
+
+	// Ensure this RunConfiguration is registered as a node
+	runConfigNode.WithLabelValues(rcName, rcName).Set(1)
+
+	for _, dep := range rc.GetReferencedRCs() {
+		sourceName := dep.Name
+		edgeId := sourceName + " -> " + rcName
+		runConfigEdge.WithLabelValues(edgeId, sourceName, rcName).Set(1)
+		// Ensure the source is also registered as a node
+		runConfigNode.WithLabelValues(sourceName, sourceName).Set(1)
+	}
 }
 
 func (r *RunConfigurationReconciler) triggerUntriggeredRuns(


### PR DESCRIPTION
Closes #1123

Adds a simple metric setup that exposes the dependency graph of run configurations. This will allow for visualisation tools to render this graph.
