### PR TITLE
chore(deps): exclude archived doc versions from dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,8 @@ updates:
 
   - package-ecosystem: "uv"
     directories:
-    - "/compilers/kfp-sdk"
-    - "/docs-gen/includes/master/kfpsdk-quickstart"
+    - "/compilers/**"
+    - "/docs-gen/includes/master/**"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "uv"
     directories:
     - "/compilers/kfp-sdk"
-    - "/docs-gen/includes/*/kfpsdk-quickstart"
+    - "/docs-gen/includes/master/kfpsdk-quickstart"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"
@@ -28,3 +28,16 @@ updates:
     - dependency-type: "direct"
     commit-message:
       prefix: "chore(deps)"
+    exclude-paths:
+    - "docs-gen/includes/versions/**"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "chore(deps)"
+    exclude-paths:
+    - "docs-gen/includes/versions/**"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
- Archived doc versions still contain pyproject.toml and poetry.lock from before the uv migration. These trigger unwanted security PRs for dependencies that are not relevant to master code.
- Watch for tfx related library upgrades (master-only)

Closes #1149
