### PR TITLE
feat: automate local minikube setup with end-to-end eventing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,23 @@
 # Development
 
+<!-- TOC -->
+* [Development](#development)
+  * [Set up the development environment](#set-up-the-development-environment)
+  * [Run unit tests](#run-unit-tests)
+  * [Building and Publishing](#building-and-publishing)
+    * [Building and publishing container images](#building-and-publishing-container-images)
+    * [Building and publishing the Helm chart](#building-and-publishing-the-helm-chart)
+  * [Running locally](#running-locally)
+    * [Getting started](#getting-started)
+    * [Rebuild after code changes](#rebuild-after-code-changes)
+    * [Tear down](#tear-down)
+    * [How the stubs work](#how-the-stubs-work)
+  * [Run Argo integration tests](#run-argo-integration-tests)
+  * [Coding Guidelines](#coding-guidelines)
+    * [Logging](#logging)
+  * [CRD Versioning](#crd-versioning)
+<!-- TOC -->
+
 We use [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) to scaffold the kubernetes controllers.
 The [Kubebuilder Book](https://book.kubebuilder.io/) is a good introduction to the topic and we recommend reading it before proceeding.
 
@@ -98,13 +116,56 @@ Provide an optional [.netrc file](https://www.gnu.org/software/inetutils/manual/
 
 ## Running locally
 
-Running `make minikube-up` will spin up a local K8s cluster with the operator deployed.
+The local development environment uses a **stub provider** so you can test the full operator reconciliation loop without any real training infrastructure (no Vertex AI, no Kubeflow Pipelines, etc.).
 
-You can optionally perform additional provider setup and teardown steps by including a `provider-setup.sh` and `provider-teardown.sh` script.
+### Getting started
 
-CRDs will be installed into a local [minikube](https://github.com/kubernetes/minikube) cluster.
+```sh
+# Spin everything up (minikube, argo, cert-manager, minio, operator, eventing, stub provider)
+make minikube-up
 
-Please refer to the [quickstart tutorial](../quickstart) for instructions on creating a sample pipeline resource.
+# Apply resources
+kubectl apply -f local/pipeline.yaml
+kubectl apply -f local/runconfiguration.yaml
+
+# Watch them reconcile
+kubectl get pipelines -w
+kubectl get runconfigurations -w
+kubectl get runschedules -w
+kubectl get runs -w
+```
+
+After a minute or so, `stub-pipeline` should reach `Succeeded` and `stub-runconfiguration` should be actively creating RunSchedules and a Run.
+The Run should reach `Succeeded` and then be deleted. Shortly after the Run is created, the stub provider fires a fake run completion event.
+You can verify the full eventing flow by checking the Sensor logs — it should log `Successfully processed trigger 'log'` once the event has passed through the webhook, trigger service, NATS, and EventSource.
+
+### Rebuild after code changes
+
+```sh
+make minikube-upgrade
+```
+
+This rebuilds the operator, stub provider, and stub compiler images, pushes them to the in-cluster registry, and does a `helm upgrade`.
+
+### Tear down
+
+```sh
+make minikube-down
+```
+
+### How the stubs work
+
+- The stub provider (`provider-service/stub`) implements the full provider gRPC interface but doesn't talk to any external service.
+  Every operation (create/update/delete for pipelines, runs, run schedules, and experiments) returns a hardcoded success response immediately.
+  This means the operator's reconciliation loop runs end-to-end — creating Argo Workflows, waiting for them to complete, updating status — without needing real infrastructure.
+  - When a run is created, the stub provider also fires a fake run completion event to the operator's webhook after a 5-second delay (simulating pipeline execution time).
+    This exercises the full eventing flow: the event is received by the webhook, forwarded via gRPC to the run completion event trigger, published to NATS, picked up by the Argo Events EventSource, and delivered to the Sensor.
+
+- The stub compiler (`compilers/stub`) is equally minimal. Its `compile.sh` writes a static `{"foo": "bar"}` JSON file as the compiled pipeline output, and its `inject.sh` simply copies the compile script into the workflow step.
+  This is enough for the operator to treat the pipeline as successfully compiled.
+
+- The stub Provider CR (`local/stub-provider.yaml`) registers both `stub` and `tfx` as supported frameworks, both pointing at the stub compiler image.
+  This lets you test with either framework name in your Pipeline resources.
 
 ## Run Argo integration tests
 

--- a/local/argo-artifact-config.yaml
+++ b/local/argo-artifact-config.yaml
@@ -1,0 +1,15 @@
+nodeEvents:
+  enabled: true
+workflowEvents:
+  enabled: true
+artifactRepository:
+  s3:
+    bucket: argo-artifacts
+    endpoint: minio.argo:9000
+    insecure: true
+    accessKeySecret:
+      name: argo-artifacts-minio
+      key: accesskey
+    secretKeySecret:
+      name: argo-artifacts-minio
+      key: secretkey

--- a/local/eventsource.yaml
+++ b/local/eventsource.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  namespace: kfp-operator-system
+spec:
+  nats:
+    native: {}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: run-completion
+  namespace: kfp-operator-system
+spec:
+  eventBusName: default
+  nats:
+    run-completion:
+      jsonBody: true
+      subject: events
+      url: nats://eventbus-kfp-operator-events-stan-svc.kfp-operator-system.svc:4222

--- a/local/eventsource.yaml
+++ b/local/eventsource.yaml
@@ -13,7 +13,6 @@ metadata:
   name: run-completion
   namespace: kfp-operator-system
 spec:
-  eventBusName: default
   nats:
     run-completion:
       jsonBody: true

--- a/local/minio.yaml
+++ b/local/minio.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-artifacts-minio
+  namespace: argo
+type: Opaque
+stringData:
+  accesskey: minioadmin
+  secretkey: minioadmin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: argo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        image: minio/minio:latest
+        command: ["minio", "server", "/data"]
+        env:
+        - name: MINIO_ROOT_USER
+          value: minioadmin
+        - name: MINIO_ROOT_PASSWORD
+          value: minioadmin
+        ports:
+        - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: argo
+spec:
+  selector:
+    app: minio
+  ports:
+  - port: 9000
+    targetPort: 9000
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-artifacts-minio
+  namespace: kfp-operator-system
+type: Opaque
+stringData:
+  accesskey: minioadmin
+  secretkey: minioadmin

--- a/local/pipeline.yaml
+++ b/local/pipeline.yaml
@@ -1,0 +1,11 @@
+apiVersion: pipelines.kubeflow.org/v1beta1
+kind: Pipeline
+metadata:
+  name: stub-pipeline
+  namespace: default
+spec:
+  provider: kfp-operator-system/stub
+  image: alpine:latest
+  framework:
+    name: stub
+    parameters: {}

--- a/local/provider.yaml
+++ b/local/provider.yaml
@@ -1,0 +1,17 @@
+apiVersion: pipelines.kubeflow.org/v1beta1
+kind: Provider
+metadata:
+  name: stub
+  namespace: kfp-operator-system
+spec:
+  serviceImage: localhost:5000/kfp-operator/kfp-operator-stub-provider-service:VERSION
+  serviceAccount: default
+  pipelineRootStorage: /tmp/pipeline-root
+  frameworks:
+  - name: stub
+    image: localhost:5000/kfp-operator/kfp-operator-stub-compiler:VERSION
+  - name: tfx
+    image: localhost:5000/kfp-operator/kfp-operator-stub-compiler:VERSION
+  allowedNamespaces:
+  - default
+  - kfp-operator-system

--- a/local/runconfiguration.yaml
+++ b/local/runconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: pipelines.kubeflow.org/v1beta1
+kind: RunConfiguration
+metadata:
+  name: stub-runconfiguration
+  namespace: default
+spec:
+  run:
+    provider: kfp-operator-system/stub
+    pipeline: stub-pipeline
+    experimentName: Default
+  triggers:
+    onChange:
+    - pipeline
+    schedules:
+    - cronExpression: "0 * * * *"
+      startTime: "2025-01-01T00:00:00Z"
+      endTime: "2025-12-31T23:59:59Z"

--- a/local/runconfiguration.yaml
+++ b/local/runconfiguration.yaml
@@ -14,4 +14,4 @@ spec:
     schedules:
     - cronExpression: "0 * * * *"
       startTime: "2025-01-01T00:00:00Z"
-      endTime: "2025-12-31T23:59:59Z"
+      endTime: "2030-12-31T23:59:59Z"

--- a/local/runconfiguration.yaml
+++ b/local/runconfiguration.yaml
@@ -11,6 +11,7 @@ spec:
   triggers:
     onChange:
     - pipeline
+    - runSpec
     schedules:
     - cronExpression: "0 * * * *"
       startTime: "2025-01-01T00:00:00Z"

--- a/local/sensor.yaml
+++ b/local/sensor.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: stub-run-completion
+  namespace: kfp-operator-system
+spec:
+  eventBusName: default
+  dependencies:
+    - name: run-completion
+      eventSourceName: run-completion
+      eventName: run-completion
+  triggers:
+    - template:
+        name: log
+        log: {}

--- a/local/sensor.yaml
+++ b/local/sensor.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   eventBusName: default
   dependencies:
-    - name: run-completion
-      eventSourceName: run-completion
-      eventName: run-completion
+  - name: run-completion
+    eventSourceName: run-completion
+    eventName: run-completion
   triggers:
-    - template:
-        name: log
-        log: {}
+  - template:
+      name: log
+      log: {}

--- a/local/sensor.yaml
+++ b/local/sensor.yaml
@@ -4,7 +4,6 @@ metadata:
   name: stub-run-completion
   namespace: kfp-operator-system
 spec:
-  eventBusName: default
   dependencies:
   - name: run-completion
     eventSourceName: run-completion

--- a/local/values.yaml
+++ b/local/values.yaml
@@ -16,7 +16,7 @@ manager:
       name: kfp-operator-argo
       create: true
   configuration:
-    defaultProvider: vai
+    defaultProvider: stub
     defaultExperiment: Default
     runCompletionTTL: 30s
   monitoring:
@@ -45,20 +45,9 @@ statusFeedback:
   enabled: true
 
 providers:
-- vai
+- stub
 
 provider:
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/gcloud/key-file.json
-  volumes:
-  - name: gcp-credentials
-    secret:
-      secretName: gcp-credentials
-  volumeMounts:
-  - name: gcp-credentials
-    mountPath: /etc/gcloud
-    readOnly: true
   replicas: 1
   resources:
     limits:

--- a/local/values.yaml
+++ b/local/values.yaml
@@ -44,9 +44,6 @@ runcompletionEventTrigger:
 statusFeedback:
   enabled: true
 
-providers:
-- stub
-
 provider:
   replicas: 1
   resources:

--- a/minikube.mk
+++ b/minikube.mk
@@ -2,20 +2,22 @@ MINIKUBE_PROFILE := local-kfp-operator
 MINIKUBE_REGISTRY := localhost:5000/kfp-operator
 MINIKUBE_VERSION := $(shell git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*' | sed 's/^v//')
 MINIKUBE_REGISTRY_PORT = $(shell docker inspect $(MINIKUBE_PROFILE) --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
+MINIKUBE_GOARCH := $(shell go env GOARCH)
 
 ##@ Local development with stub provider (no real training infrastructure needed)
 
 minikube-start: ## Start minikube cluster with registry
 	minikube start -p $(MINIKUBE_PROFILE) --driver=docker --registry-mirror="https://mirror.gcr.io"
 	minikube addons enable registry -p $(MINIKUBE_PROFILE) --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4" ## The default gcr.io/k8s-minikube/kube-registry-proxy:0.0.5 isn't available anymore, the real fix is to update to the latest version of minikube
+	minikube ssh -p $(MINIKUBE_PROFILE) "sudo sysctl fs.inotify.max_user_watches=524288 && sudo sysctl fs.inotify.max_user_instances=512"
 
-minikube-install-dependencies: ## Install Argo Workflows, Argo Events, and cert-manager
+minikube-install-dependencies: helm-cmd ## Install Argo Workflows, Argo Events, and cert-manager
 	$(HELM) repo add argo https://argoproj.github.io/argo-helm
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
-	$(HELM) install argo-workflows argo/argo-workflows -n argo --create-namespace
-	$(HELM) install argo-events argo/argo-events -n argo-events --create-namespace
-	$(HELM) install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
+	$(HELM) upgrade --install argo-workflows argo/argo-workflows -n argo --create-namespace
+	$(HELM) upgrade --install argo-events argo/argo-events -n argo-events --create-namespace
+	$(HELM) upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 	kubectl create namespace kfp-operator-system --dry-run=client -o yaml | kubectl apply -f -
 	@echo "Waiting for cert-manager webhook to be ready..."
 	kubectl rollout status deployment/cert-manager-webhook -n cert-manager
@@ -25,6 +27,7 @@ minikube-install-minio: ## Deploy MinIO for Argo artifact storage
 	kubectl apply -f ./local/minio.yaml
 	kubectl rollout status deployment/minio -n argo
 	@echo "Creating argo-artifacts bucket..."
+	kubectl delete pod minio-setup -n argo --ignore-not-found
 	kubectl run minio-setup --image=minio/mc:latest --restart=Never -n argo --command -- \
 		sh -c 'mc alias set local http://minio:9000 minioadmin minioadmin && mc mb local/argo-artifacts --ignore-existing'
 	kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup -n argo
@@ -37,16 +40,16 @@ minikube-install-minio: ## Deploy MinIO for Argo artifact storage
 	@echo "MinIO artifact storage configured successfully."
 
 minikube-helm-install: helm-package-operator ./local/values.yaml ## Helm install the operator
-	$(HELM) install -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=$(MINIKUBE_REGISTRY)
+	$(HELM) upgrade --install -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=$(MINIKUBE_REGISTRY)
 
 minikube-helm-upgrade: helm-package-operator ./local/values.yaml ## Helm upgrade the operator
 	$(HELM) upgrade -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=$(MINIKUBE_REGISTRY)
 
 minikube-install-operator: export CONTAINER_REPOSITORIES=localhost:$(MINIKUBE_REGISTRY_PORT)/kfp-operator
 minikube-install-operator: ## Build and push operator + stub images, then helm install
-	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION)
-	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION)
-	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
+	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
+	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
 	$(MAKE) minikube-helm-install VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
 
 minikube-apply-provider: ## Apply the stub Provider CR into the cluster
@@ -70,9 +73,9 @@ minikube-up: ## Spin up the full local stack from scratch
 
 minikube-upgrade: export CONTAINER_REPOSITORIES=localhost:$(MINIKUBE_REGISTRY_PORT)/kfp-operator
 minikube-upgrade: ## Rebuild and upgrade operator + stub provider in-place
-	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION)
-	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION)
-	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
+	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
+	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
 	$(MAKE) minikube-helm-upgrade VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
 	$(MAKE) minikube-apply-provider
 

--- a/minikube.mk
+++ b/minikube.mk
@@ -4,11 +4,11 @@ MINIKUBE_VERSION := $(shell git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*
 MINIKUBE_REGISTRY_PORT = $(shell docker inspect $(MINIKUBE_PROFILE) --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
 MINIKUBE_GOARCH := $(shell go env GOARCH)
 
-##@ Local development with stub provider (no real training infrastructure needed)
+##@ Local development with stub provider
 
 minikube-start: ## Start minikube cluster with registry
 	minikube start -p $(MINIKUBE_PROFILE) --driver=docker --registry-mirror="https://mirror.gcr.io"
-	minikube addons enable registry -p $(MINIKUBE_PROFILE) --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4" ## The default gcr.io/k8s-minikube/kube-registry-proxy:0.0.5 isn't available anymore, the real fix is to update to the latest version of minikube
+	minikube addons enable registry -p $(MINIKUBE_PROFILE) --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4" # The default gcr.io/k8s-minikube/kube-registry-proxy:0.0.5 isn't available anymore, the real fix is to update to the latest version of minikube
 	minikube ssh -p $(MINIKUBE_PROFILE) "sudo sysctl fs.inotify.max_user_watches=524288 && sudo sysctl fs.inotify.max_user_instances=512"
 
 minikube-install-dependencies: helm-cmd ## Install Argo Workflows, Argo Events, and cert-manager

--- a/minikube.mk
+++ b/minikube.mk
@@ -76,7 +76,7 @@ minikube-upgrade: ## Rebuild and upgrade operator + stub provider in-place
 	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
 	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
 	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION) GOARCH=$(MINIKUBE_GOARCH)
-	$(MAKE) minikube-helm-upgrade VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
+	$(MAKE) minikube-helm-upgrade VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=$(CONTAINER_REPOSITORIES)
 	$(MAKE) minikube-apply-provider
 
 minikube-down: ## Tear down the minikube cluster

--- a/minikube.mk
+++ b/minikube.mk
@@ -1,78 +1,80 @@
-minikube-install-dependencies:
+MINIKUBE_PROFILE := local-kfp-operator
+MINIKUBE_REGISTRY := localhost:5000/kfp-operator
+MINIKUBE_VERSION := $(shell git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*' | sed 's/^v//')
+MINIKUBE_REGISTRY_PORT = $(shell docker inspect $(MINIKUBE_PROFILE) --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
+
+##@ Local development with stub provider (no real training infrastructure needed)
+
+minikube-start: ## Start minikube cluster with registry
+	minikube start -p $(MINIKUBE_PROFILE) --driver=docker --registry-mirror="https://mirror.gcr.io"
+	minikube addons enable registry -p $(MINIKUBE_PROFILE) --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4" ## The default gcr.io/k8s-minikube/kube-registry-proxy:0.0.5 isn't available anymore, the real fix is to update to the latest version of minikube
+
+minikube-install-dependencies: ## Install Argo Workflows, Argo Events, and cert-manager
 	$(HELM) repo add argo https://argoproj.github.io/argo-helm
+	$(HELM) repo add jetstack https://charts.jetstack.io
+	$(HELM) repo update
 	$(HELM) install argo-workflows argo/argo-workflows -n argo --create-namespace
 	$(HELM) install argo-events argo/argo-events -n argo-events --create-namespace
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.crds.yaml
-	openssl req -new -newkey rsa:2048 -days 365 -keyout ./local/kfp-operator-webhook.key -out ./local/kfp-operator-webhook.csr \
-	  -subj "/C=US/ST=California/L=San Francisco/O=My Organization/OU=My Unit/CN=kfp-operator-webhook-service.kfp-operator-system.svc" \
-	  -extensions san -config <(echo "[req]"; echo "distinguished_name=req_distinguished_name"; echo "x509_extensions = san"; \
-	  echo "[req_distinguished_name]"; echo "C=US"; echo "ST=California"; echo "L=San Francisco"; echo "O=My Organization"; \
-	  echo "OU=My Unit"; echo "CN=kfp-operator-webhook-service.kfp-operator-system.svc"; \
-	  echo "[san]"; echo "subjectAltName=DNS:kfp-operator-webhook-service.kfp-operator-system.svc,DNS:kfp-operator-webhook-service") -nodes
-	openssl x509 -req -in ./local/kfp-operator-webhook.csr -signkey ./local/kfp-operator-webhook.key -out ./local/kfp-operator-webhook.crt \
-	  -extensions v3_req -extfile <(echo "[v3_req]"; echo "subjectAltName=DNS:kfp-operator-webhook-service.kfp-operator-system.svc,DNS:kfp-operator-webhook-service")
-	kubectl create namespace kfp-operator-system
-	kubectl create namespace vai
-	kubectl create namespace kfp
-	kubectl create secret tls webhook-server-cert --cert=./local/kfp-operator-webhook.crt --key=./local/kfp-operator-webhook.key --namespace kfp-operator-system
-	sleep 20
+	$(HELM) install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
+	kubectl create namespace kfp-operator-system --dry-run=client -o yaml | kubectl apply -f -
+	@echo "Waiting for cert-manager webhook to be ready..."
+	kubectl rollout status deployment/cert-manager-webhook -n cert-manager
 
-minikube-helm-install-operator: helm-package-operator ./local/values.yaml
+minikube-install-minio: ## Deploy MinIO for Argo artifact storage
+	@echo "Deploying MinIO for Argo artifact storage..."
+	kubectl apply -f ./local/minio.yaml
+	kubectl rollout status deployment/minio -n argo
+	@echo "Creating argo-artifacts bucket..."
+	kubectl run minio-setup --image=minio/mc:latest --restart=Never -n argo --command -- \
+		sh -c 'mc alias set local http://minio:9000 minioadmin minioadmin && mc mb local/argo-artifacts --ignore-existing'
+	kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup -n argo
+	kubectl delete pod minio-setup -n argo --ignore-not-found
+	@echo "Configuring Argo workflow controller to use MinIO..."
+	kubectl create configmap argo-workflows-workflow-controller-configmap -n argo \
+		--from-file=config=./local/argo-artifact-config.yaml --dry-run=client -o yaml | kubectl apply -f -
+	kubectl rollout restart deployment/argo-workflows-workflow-controller -n argo
+	kubectl rollout status deployment/argo-workflows-workflow-controller -n argo
+	@echo "MinIO artifact storage configured successfully."
 
-	$(HELM) install -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=localhost:5000/kfp-operator
+minikube-helm-install: helm-package-operator ./local/values.yaml ## Helm install the operator
+	$(HELM) install -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=$(MINIKUBE_REGISTRY)
 
-minikube-helm-upgrade-operator: helm-package-operator ./local/values.yaml
-	$(HELM) upgrade -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=localhost:5000/kfp-operator
+minikube-helm-upgrade: helm-package-operator ./local/values.yaml ## Helm upgrade the operator
+	$(HELM) upgrade -f ./local/values.yaml kfp-operator dist/kfp-operator-$(VERSION).tgz --set containerRegistry=$(MINIKUBE_REGISTRY)
 
-minikube-install-operator: export VERSION=$(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*') | sed 's/^v//')
-minikube-install-operator: export REGISTRY_PORT=$(shell docker inspect local-kfp-operator --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
-minikube-install-operator: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PORT}/kfp-operator
-minikube-install-operator:
-	$(MAKE) docker-push docker-push-triggers docker-push-providers
-	$(MAKE) minikube-helm-install-operator VERSION=${VERSION} CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
+minikube-install-operator: export CONTAINER_REPOSITORIES=localhost:$(MINIKUBE_REGISTRY_PORT)/kfp-operator
+minikube-install-operator: ## Build and push operator + stub images, then helm install
+	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) minikube-helm-install VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
 
-minikube-install-provider: export VERSION=$(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*') | sed 's/^v//')
-minikube-install-provider: export REGISTRY_PORT=$(shell docker inspect local-kfp-operator --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
-minikube-install-provider: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PORT}/kfp-operator
-minikube-install-provider:
-	$(MAKE) -C provider-service docker-push
-	$(MAKE) minikube-provider-setup
+minikube-apply-provider: ## Apply the stub Provider CR into the cluster
+	@sed "s|:VERSION|:$(MINIKUBE_VERSION)|g" ./local/provider.yaml | kubectl apply -f -
 
-minikube-provider-setup:
-	@if [ -f ./provider-setup.sh ]; then \
-		echo "Running provider setup script"; \
-		bash ./provider-setup.sh; \
-	else \
-		echo "Provider setup script not found"; \
-	fi
+minikube-install-eventing: ## Deploy EventSource and Sensor for run completion events
+	@echo "Deploying Argo Events EventSource and Sensor..."
+	kubectl apply -f ./local/eventsource.yaml
+	kubectl apply -f ./local/sensor.yaml
+	@echo "Waiting for EventBus to be ready..."
+	kubectl wait --for=condition=Deployed eventbus/default -n kfp-operator-system
+	@echo "Eventing resources deployed."
 
-minikube-provider-teardown:
-	@if [ -f ./provider-teardown.sh ]; then \
-		echo "Running provider teardown script"; \
-		bash ./provider-teardown.sh; \
-	else \
-		echo "Provider teardown script not found"; \
-	fi
-
-minikube-upgrade-operator: export VERSION=$(shell (git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*') | sed 's/^v//')
-minikube-upgrade-operator: export REGISTRY_PORT=$(shell docker inspect local-kfp-operator --format '{{ (index .NetworkSettings.Ports "5000/tcp" 0).HostPort }}')
-minikube-upgrade-operator: export CONTAINER_REPOSITORIES=localhost:${REGISTRY_PORT}/kfp-operator
-minikube-upgrade-operator:
-	$(MAKE) docker-push docker-push-triggers
-	$(MAKE) minikube-helm-upgrade-operator VERSION=${VERSION} CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
-
-minikube-upgrade-provider: minikube-provider-teardown minikube-install-provider
-
-minikube-start:
-	minikube start -p local-kfp-operator --driver=docker --registry-mirror="https://mirror.gcr.io"
-	minikube addons enable registry -p local-kfp-operator
-
-minikube-up:
+minikube-up: ## Spin up the full local stack from scratch
 	$(MAKE) minikube-start
 	$(MAKE) minikube-install-dependencies
 	$(MAKE) minikube-install-operator
-	$(MAKE) minikube-install-provider
+	$(MAKE) minikube-install-minio
+	$(MAKE) minikube-install-eventing
+	$(MAKE) minikube-apply-provider
 
-minikube-down:
-	$(MAKE) minikube-provider-teardown
-	minikube delete -p local-kfp-operator
+minikube-upgrade: export CONTAINER_REPOSITORIES=localhost:$(MINIKUBE_REGISTRY_PORT)/kfp-operator
+minikube-upgrade: ## Rebuild and upgrade operator + stub provider in-place
+	$(MAKE) docker-push docker-push-triggers VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) -C provider-service/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) -C compilers/stub docker-push VERSION=$(MINIKUBE_VERSION)
+	$(MAKE) minikube-helm-upgrade VERSION=$(MINIKUBE_VERSION) CONTAINER_REPOSITORIES=${CONTAINER_REPOSITORIES}
+	$(MAKE) minikube-apply-provider
+
+minikube-down: ## Tear down the minikube cluster
+	minikube delete -p $(MINIKUBE_PROFILE)

--- a/provider-service/stub/cmd/main.go
+++ b/provider-service/stub/cmd/main.go
@@ -18,7 +18,6 @@ func main() {
 	}
 
 	ctx := logr.NewContext(context.Background(), logger)
-	stubProvider := provider.New(logger)
 	cfg, err := baseConfig.LoadConfig(
 		baseConfig.Config{
 			Server: baseConfig.Server{
@@ -33,6 +32,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	stubProvider := provider.New(logger, cfg.OperatorWebhook, cfg.ProviderName)
 
 	if err = server.Start(ctx, *cfg, stubProvider); err != nil {
 		panic(err)

--- a/provider-service/stub/internal/provider/provider.go
+++ b/provider-service/stub/internal/provider/provider.go
@@ -1,21 +1,33 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/sky-uk/kfp-operator/pkg/common"
 	. "github.com/sky-uk/kfp-operator/pkg/common/testutil/provider"
 	"github.com/sky-uk/kfp-operator/pkg/providers/base"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/server/resource"
 )
 
 type StubProvider struct {
-	logger logr.Logger
+	logger          logr.Logger
+	operatorWebhook string
+	providerName    common.NamespacedName
 }
 
-func New(logger logr.Logger) resource.Provider {
-	return &StubProvider{logger}
+func New(logger logr.Logger, operatorWebhook string, providerName common.NamespacedName) resource.Provider {
+	return &StubProvider{
+		logger:          logger,
+		operatorWebhook: operatorWebhook,
+		providerName:    providerName,
+	}
 }
 
 func (p *StubProvider) CreatePipeline(
@@ -55,8 +67,52 @@ func (p *StubProvider) CreateRun(
 ) (string, error) {
 	if strings.EqualFold(rd.Name.Name, CreateRunFail) {
 		return "", &CreateRunError{}
+	}
+
+	if p.operatorWebhook != "" {
+		go p.fireRunCompletionEvent(rd)
+	}
+
+	return CreateRunSucceeded, nil
+}
+
+func (p *StubProvider) fireRunCompletionEvent(rd base.RunDefinition) {
+	startTime := time.Now().UTC()
+	time.Sleep(5 * time.Second)
+	now := time.Now().UTC()
+	runId := fmt.Sprintf("stub-run-%d", now.Unix())
+
+	event := common.RunCompletionEventData{
+		Status:               common.RunCompletionStatuses.Succeeded,
+		PipelineName:         rd.PipelineName,
+		RunConfigurationName: rd.RunConfigurationName.NonEmptyPtr(),
+		RunName:              rd.Name.NonEmptyPtr(),
+		RunId:                runId,
+		RunStartTime:         &startTime,
+		RunEndTime:           &now,
+		PipelineComponents:   []common.PipelineComponent{},
+		Provider:             p.providerName,
+	}
+
+	body, err := json.Marshal(event)
+	if err != nil {
+		p.logger.Error(err, "failed to marshal run completion event")
+		return
+	}
+
+	p.logger.Info("firing run completion event", "webhook", p.operatorWebhook, "runId", runId, "runName", rd.Name)
+
+	resp, err := http.Post(p.operatorWebhook, "application/json", bytes.NewReader(body))
+	if err != nil {
+		p.logger.Error(err, "failed to send run completion event")
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		p.logger.Info("run completion event sent successfully", "runId", runId)
 	} else {
-		return CreateRunSucceeded, nil
+		p.logger.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "run completion event failed", "runId", runId)
 	}
 }
 


### PR DESCRIPTION
Overhauls the local minikube setup so `make minikube-up` brings up a fully working environment that exercises the complete operator lifecycle end-to-end, including eventing.

### Key changes

-  `minikube.mk` - Restructured into smaller composable targets (minikube-start, minikube-install-dependencies, minikube-install-operator, etc.). Replaced sleeps with proper readiness checks.
- Stub provider - Now fires a fake run completion event 5 seconds after a Run is created, exercising the full eventing flow: Webhook → gRPC Trigger → NATS → EventSource → Sensor.
- New local resources - Added stub Pipeline, RunConfiguration, Provider CR, EventSource, Sensor, MinIO deployment, and Argo artifact config.
- `DEVELOPMENT.md` - Updated with setup instructions and explanation of the stub eventing flow.