### PR TITLE
fix(kfp provider): pipelineRootStorage determining artifact output location

### DIFF
--- a/provider-service/kfp/internal/provider/provider.go
+++ b/provider-service/kfp/internal/provider/provider.go
@@ -53,7 +53,7 @@ func NewKfpProvider(config *config.Config) (*KfpProvider, error) {
 		return nil, err
 	}
 
-	recurringRunService, err := NewRecurringRunService(conn, labelGenerator)
+	recurringRunService, err := NewRecurringRunService(conn, labelGenerator, config.PipelineRootStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/provider-service/kfp/internal/provider/provider.go
+++ b/provider-service/kfp/internal/provider/provider.go
@@ -48,7 +48,7 @@ func NewKfpProvider(config *config.Config) (*KfpProvider, error) {
 		ProviderName: config.ProviderName,
 	}
 
-	runService, err := NewRunService(conn, labelGenerator)
+	runService, err := NewRunService(conn, labelGenerator, config.PipelineRootStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/provider-service/kfp/internal/provider/recurring_run_service.go
+++ b/provider-service/kfp/internal/provider/recurring_run_service.go
@@ -29,11 +29,16 @@ type RecurringRunService interface {
 }
 
 type DefaultRecurringRunService struct {
-	client         client.RecurringRunServiceClient
-	labelGenerator label.LabelGen
+	client              client.RecurringRunServiceClient
+	labelGenerator      label.LabelGen
+	pipelineRootStorage string
 }
 
-func NewRecurringRunService(conn *grpc.ClientConn, labelGenerator label.LabelGen) (RecurringRunService, error) {
+func NewRecurringRunService(
+	conn *grpc.ClientConn,
+	labelGenerator label.LabelGen,
+	pipelineRootStorage string,
+) (RecurringRunService, error) {
 	if conn == nil {
 		return nil, fmt.Errorf(
 			"no gRPC connection was provided to start recurring run service",
@@ -41,8 +46,9 @@ func NewRecurringRunService(conn *grpc.ClientConn, labelGenerator label.LabelGen
 	}
 
 	return &DefaultRecurringRunService{
-		client:         go_client.NewRecurringRunServiceClient(conn),
-		labelGenerator: labelGenerator,
+		client:              go_client.NewRecurringRunServiceClient(conn),
+		labelGenerator:      labelGenerator,
+		pipelineRootStorage: pipelineRootStorage,
 	}, nil
 }
 
@@ -75,6 +81,16 @@ func (rrs *DefaultRecurringRunService) CreateRecurringRun(
 		return "", err
 	}
 
+	outputDirectory := ""
+
+	if rrs.pipelineRootStorage != "" {
+		namespacedName, err := rsd.PipelineName.String()
+		if err != nil {
+			return "", err
+		}
+		outputDirectory = fmt.Sprintf("%s/%s", rrs.pipelineRootStorage, namespacedName)
+	}
+
 	recurringRun, err := rrs.client.CreateRecurringRun(ctx, &go_client.CreateRecurringRunRequest{
 		RecurringRun: &go_client.RecurringRun{
 			DisplayName: recurringRunName,
@@ -85,7 +101,8 @@ func (rrs *DefaultRecurringRunService) CreateRecurringRun(
 				},
 			},
 			RuntimeConfig: &go_client.RuntimeConfig{
-				Parameters: runtimeParams,
+				Parameters:   runtimeParams,
+				PipelineRoot: outputDirectory,
 			},
 			MaxConcurrency: 1,
 			Trigger: &go_client.Trigger{

--- a/provider-service/kfp/internal/provider/recurring_run_service_test.go
+++ b/provider-service/kfp/internal/provider/recurring_run_service_test.go
@@ -29,10 +29,11 @@ var _ = Describe("DefaultRecurringRunService", func() {
 	)
 
 	const (
-		recurringRunId    = "recurring-run-id"
-		pipelineId        = "pipeline-id"
-		pipelineVersionId = "pipeline-version-id"
-		experimentVersion = "experiment-version"
+		recurringRunId      = "recurring-run-id"
+		pipelineId          = "pipeline-id"
+		pipelineVersionId   = "pipeline-version-id"
+		experimentVersion   = "experiment-version"
+		pipelineRootStorage = "pipelineRootStorage"
 	)
 
 	BeforeEach(func() {
@@ -41,6 +42,7 @@ var _ = Describe("DefaultRecurringRunService", func() {
 		recurringRunService = DefaultRecurringRunService{
 			&mockClient,
 			&mockLabelGen,
+			pipelineRootStorage,
 		}
 		rsd = testutil.RandomRunScheduleDefinition()
 	})
@@ -80,6 +82,12 @@ var _ = Describe("DefaultRecurringRunService", func() {
 						},
 						RuntimeConfig: &go_client.RuntimeConfig{
 							Parameters: expectedRuntimeParams,
+							PipelineRoot: fmt.Sprintf(
+								"%s/%s/%s",
+								pipelineRootStorage,
+								rsd.PipelineName.Namespace,
+								rsd.PipelineName.Name,
+							),
 						},
 						MaxConcurrency: 1,
 						Trigger: &go_client.Trigger{
@@ -103,6 +111,36 @@ var _ = Describe("DefaultRecurringRunService", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(expectedId))
+		})
+
+		When("PipelineRootStorage is empty string", func() {
+			It("should submit a recurring run request with PipelineRoot as empty string", func() {
+				expectedId := "expected-recurring-run-id"
+				mockLabelGen.On("GenerateLabels", mock.Anything).Return(map[string]string{}, nil)
+				mockClient.On(
+					"CreateRecurringRun",
+					mock.MatchedBy(func(req *go_client.CreateRecurringRunRequest) bool {
+						return req.RecurringRun.RuntimeConfig.PipelineRoot == ""
+					}),
+				).Return(&go_client.RecurringRun{RecurringRunId: expectedId}, nil)
+
+				recurringRunService = DefaultRecurringRunService{
+					client:              &mockClient,
+					labelGenerator:      &mockLabelGen,
+					pipelineRootStorage: "",
+				}
+
+				res, err := recurringRunService.CreateRecurringRun(
+					ctx,
+					rsd,
+					pipelineId,
+					pipelineVersionId,
+					experimentVersion,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(expectedId))
+			})
 		})
 
 		When("run schedule definition doesn't have a name", func() {

--- a/provider-service/kfp/internal/provider/run_service.go
+++ b/provider-service/kfp/internal/provider/run_service.go
@@ -72,14 +72,13 @@ func (rs DefaultRunService) CreateRun(
 		return "", err
 	}
 
-	namespacedName, err := rd.PipelineName.String()
-	if err != nil {
-		return "", err
-	}
-
 	outputDirectory := ""
 
 	if rs.pipelineRootStorage != "" {
+		namespacedName, err := rd.PipelineName.String()
+		if err != nil {
+			return "", err
+		}
 		outputDirectory = fmt.Sprintf("%s/%s", rs.pipelineRootStorage, namespacedName)
 	}
 

--- a/provider-service/kfp/internal/provider/run_service.go
+++ b/provider-service/kfp/internal/provider/run_service.go
@@ -26,13 +26,15 @@ type RunService interface {
 }
 
 type DefaultRunService struct {
-	client         client.RunServiceClient
-	labelGenerator label.LabelGen
+	client              client.RunServiceClient
+	labelGenerator      label.LabelGen
+	pipelineRootStorage string
 }
 
 func NewRunService(
 	conn *grpc.ClientConn,
 	labelGenerator label.LabelGen,
+	pipelineRootStorage string,
 ) (RunService, error) {
 	if conn == nil {
 		return nil, fmt.Errorf(
@@ -41,8 +43,9 @@ func NewRunService(
 	}
 
 	return &DefaultRunService{
-		client:         go_client.NewRunServiceClient(conn),
-		labelGenerator: labelGenerator,
+		client:              go_client.NewRunServiceClient(conn),
+		labelGenerator:      labelGenerator,
+		pipelineRootStorage: pipelineRootStorage,
 	}, nil
 }
 
@@ -69,6 +72,13 @@ func (rs DefaultRunService) CreateRun(
 		return "", err
 	}
 
+	namespacedName, err := rd.PipelineName.String()
+	if err != nil {
+		return "", err
+	}
+
+	outputDirectory := fmt.Sprintf("%s/%s", rs.pipelineRootStorage, namespacedName)
+
 	run, err := rs.client.CreateRun(ctx, &go_client.CreateRunRequest{
 		Run: &go_client.Run{
 			ExperimentId: experimentId,
@@ -80,7 +90,8 @@ func (rs DefaultRunService) CreateRun(
 				},
 			},
 			RuntimeConfig: &go_client.RuntimeConfig{
-				Parameters: runParameters,
+				Parameters:   runParameters,
+				PipelineRoot: outputDirectory,
 			},
 		},
 	})

--- a/provider-service/kfp/internal/provider/run_service.go
+++ b/provider-service/kfp/internal/provider/run_service.go
@@ -77,7 +77,11 @@ func (rs DefaultRunService) CreateRun(
 		return "", err
 	}
 
-	outputDirectory := fmt.Sprintf("%s/%s", rs.pipelineRootStorage, namespacedName)
+	outputDirectory := ""
+
+	if rs.pipelineRootStorage != "" {
+		outputDirectory = fmt.Sprintf("%s/%s", rs.pipelineRootStorage, namespacedName)
+	}
 
 	run, err := rs.client.CreateRun(ctx, &go_client.CreateRunRequest{
 		Run: &go_client.Run{

--- a/provider-service/kfp/internal/provider/run_service_test.go
+++ b/provider-service/kfp/internal/provider/run_service_test.go
@@ -13,7 +13,6 @@ import (
 	latest "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/testutil"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/mocks"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -106,12 +105,10 @@ var _ = Describe("RunService", func() {
 			It("should submit a run request with PipelineRoot as empty string", func() {
 				expectedId := "expected-id"
 				mockLabelGen.On("GenerateLabels", mock.Anything).Return(map[string]string{}, nil)
-				emptyPipelineRootReq := proto.Clone(expectedReq).(*go_client.CreateRunRequest)
-				emptyPipelineRootReq.Run.RuntimeConfig.PipelineRoot = ""
-				mockClient.On("CreateRun", emptyPipelineRootReq).Return(
-					&go_client.Run{RunId: expectedId},
-					nil,
-				)
+				mockClient.On("CreateRun", mock.MatchedBy(func(req *go_client.CreateRunRequest) bool {
+					return req.Run.RuntimeConfig.PipelineRoot == ""
+				})).Return(&go_client.Run{RunId: expectedId}, nil)
+
 				runService = DefaultRunService{
 					client:              &mockClient,
 					labelGenerator:      &mockLabelGen,

--- a/provider-service/kfp/internal/provider/run_service_test.go
+++ b/provider-service/kfp/internal/provider/run_service_test.go
@@ -63,7 +63,8 @@ var _ = Describe("RunService", func() {
 				},
 			},
 			RuntimeConfig: &go_client.RuntimeConfig{
-				Parameters: expectedRuntimeParams,
+				Parameters:   expectedRuntimeParams,
+				PipelineRoot: "pipelineRootStorage/pipelineNamespace/pipelineName",
 			},
 		},
 	}
@@ -73,8 +74,9 @@ var _ = Describe("RunService", func() {
 			mockClient = mocks.MockRunServiceClient{}
 			mockLabelGen = mocks.MockLabelGen{}
 			runService = DefaultRunService{
-				client:         &mockClient,
-				labelGenerator: &mockLabelGen,
+				client:              &mockClient,
+				labelGenerator:      &mockLabelGen,
+				pipelineRootStorage: "pipelineRootStorage",
 			}
 		},
 	)

--- a/provider-service/kfp/internal/provider/run_service_test.go
+++ b/provider-service/kfp/internal/provider/run_service_test.go
@@ -13,6 +13,7 @@ import (
 	latest "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/testutil"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/mocks"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -101,6 +102,34 @@ var _ = Describe("RunService", func() {
 			Expect(runId).To(Equal(expectedId))
 		})
 
+		When("PipelineRootStorage is empty string", func() {
+			It("should submit a run request with PipelineRoot as empty string", func() {
+				expectedId := "expected-id"
+				mockLabelGen.On("GenerateLabels", mock.Anything).Return(map[string]string{}, nil)
+				emptyPipelineRootReq := proto.Clone(expectedReq).(*go_client.CreateRunRequest)
+				emptyPipelineRootReq.Run.RuntimeConfig.PipelineRoot = ""
+				mockClient.On("CreateRun", emptyPipelineRootReq).Return(
+					&go_client.Run{RunId: expectedId},
+					nil,
+				)
+				runService = DefaultRunService{
+					client:              &mockClient,
+					labelGenerator:      &mockLabelGen,
+					pipelineRootStorage: "",
+				}
+				runId, err := runService.CreateRun(
+					ctx,
+					rd,
+					pipelineId,
+					pipelineVersionId,
+					experimentVersion,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runId).To(Equal(expectedId))
+			})
+		})
+
 		When("Name is invalid", func() {
 			It("should return an error", func() {
 				rdCopy := rd
@@ -120,7 +149,7 @@ var _ = Describe("RunService", func() {
 			})
 		})
 
-		When("RunService Errors", func() {
+		When("RunServiceClient Errors", func() {
 			It("should return an error", func() {
 				expectedErr := errors.New("error")
 				mockLabelGen.On("GenerateLabels", mock.Anything).Return(map[string]string{}, nil)


### PR DESCRIPTION
Currently the pipelineRootStorage in kfp provider does nothing. This PR fixes this such that it determines where the output artifacts are created, similar to the vai provider.

Closes https://github.com/sky-uk/kfp-operator/issues/1242
