### PR TITLE
chore:  Update golang version to 1.26.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 python 3.10.12
 protoc 32.1
 hugo extended_0.160.1
-golang 1.26.2
+golang 1.26.4
 nodejs 24.9.0
 minikube 1.31.2
 uv 0.9.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sky-uk/kfp-operator
 
-go 1.26.2
+go 1.26.4
 
 require (
 	cloud.google.com/go/aiplatform v1.125.0


### PR DESCRIPTION
Updates golang to version 1.26.4

Changlelog available:
https://github.com/golang/go/issues?q=milestone%3AGo1.26.4+label%3ACherryPickApproved