### PR TITLE
fix(vai-provider): handle 2.0.0 and 2.1.0 pipeline schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/aiplatform v1.125.0
 	cloud.google.com/go/pubsub/v2 v2.6.0
 	cloud.google.com/go/storage v1.62.2
-	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/argoproj/argo-workflows/v3 v3.7.13
 	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch/v5 v5.9.11
@@ -65,6 +64,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/aiplatform v1.125.0
 	cloud.google.com/go/pubsub/v2 v2.6.0
 	cloud.google.com/go/storage v1.62.2
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/argoproj/argo-workflows/v3 v3.7.13
 	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch/v5 v5.9.11
@@ -64,7 +65,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect

--- a/provider-service/vai/internal/provider/job_builder.go
+++ b/provider-service/vai/internal/provider/job_builder.go
@@ -91,8 +91,6 @@ func (jb DefaultJobBuilder) MkRunSchedulePipelineJob(
 		}
 	}
 
-	// Populated on the deprecated Parameters field; the enricher promotes
-	// to ParameterValues when schemaVersion >= 2.1.0.
 	templateUri, err := util.PipelineUri(
 		rsd.PipelineName,
 		rsd.PipelineVersion,
@@ -159,6 +157,8 @@ func (jb DefaultJobBuilder) newPipelineJob(labels map[string]string, params map[
 	pipelineJob := &aiplatformpb.PipelineJob{
 		Labels: labels,
 		RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
+			// Populated on the deprecated Parameters field; the enricher promotes
+			// to ParameterValues when schemaVersion >= 2.1.0.
 			Parameters:         params,
 			GcsOutputDirectory: fmt.Sprintf("%s/%s", jb.pipelineRootStorage, resourceName),
 		},

--- a/provider-service/vai/internal/provider/job_builder.go
+++ b/provider-service/vai/internal/provider/job_builder.go
@@ -91,9 +91,8 @@ func (jb DefaultJobBuilder) MkRunSchedulePipelineJob(
 		}
 	}
 
-	// Note: unable to migrate from `Parameters` to `ParameterValues` at this
-	// point as `PipelineJob.pipeline_spec.schema_version` used by TFX
-	// is 2.0.0 see deprecated comment.
+	// Populated on the deprecated Parameters field; the enricher promotes
+	// to ParameterValues when schemaVersion >= 2.1.0.
 	templateUri, err := util.PipelineUri(
 		rsd.PipelineName,
 		rsd.PipelineVersion,

--- a/provider-service/vai/internal/provider/job_builder_test.go
+++ b/provider-service/vai/internal/provider/job_builder_test.go
@@ -27,6 +27,7 @@ var _ = Describe("JobBuilder", func() {
 		When("templateUri is valid", func() {
 			It("should make a run pipeline job", func() {
 				rd := testutil.RandomRunDefinition()
+				rd.Parameters = map[string]string{"foo": "bar", "baz": "qux"}
 				job, err := jb.MkRunPipelineJob(rd, "")
 				expectedTemplateUri := fmt.Sprintf(
 					"gs://%s/%s/%s/%s",
@@ -38,8 +39,9 @@ var _ = Describe("JobBuilder", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(job.Labels).To(Equal(map[string]string{"rd-key": "rd-value"}))
+				Expect(job.RuntimeConfig.Parameters).To(HaveLen(len(rd.Parameters)))
 				for k, v := range job.RuntimeConfig.Parameters {
-					Expect(v.GetStringValue).To(Equal(rd.Parameters[k]))
+					Expect(v.GetStringValue()).To(Equal(rd.Parameters[k]))
 				}
 				Expect(job.ServiceAccount).To(Equal(jb.serviceAccount))
 				Expect(job.TemplateUri).To(Equal(expectedTemplateUri))
@@ -88,6 +90,7 @@ var _ = Describe("JobBuilder", func() {
 		When("templateUri is valid", func() {
 			It("should make a run schedule pipeline job", func() {
 				rsd := testutil.RandomRunScheduleDefinition()
+				rsd.Parameters = map[string]string{"foo": "bar", "baz": "qux"}
 				job, err := jb.MkRunSchedulePipelineJob(rsd, "")
 				expectedTemplateUri := fmt.Sprintf(
 					"gs://%s/%s/%s/%s",
@@ -99,8 +102,9 @@ var _ = Describe("JobBuilder", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(job.Labels).To(Equal(map[string]string{"rsd-key": "rsd-value"}))
+				Expect(job.RuntimeConfig.Parameters).To(HaveLen(len(rsd.Parameters)))
 				for k, v := range job.RuntimeConfig.Parameters {
-					Expect(v.GetStringValue).To(Equal(rsd.Parameters[k]))
+					Expect(v.GetStringValue()).To(Equal(rsd.Parameters[k]))
 				}
 				Expect(job.ServiceAccount).To(Equal(jb.serviceAccount))
 				Expect(job.TemplateUri).To(Equal(expectedTemplateUri))

--- a/provider-service/vai/internal/provider/job_enricher.go
+++ b/provider-service/vai/internal/provider/job_enricher.go
@@ -20,11 +20,8 @@ type DefaultJobEnricher struct {
 
 func NewDefaultJobEnricher() DefaultJobEnricher {
 	return DefaultJobEnricher{
-		pipelineSchemaHandler: DefaultPipelineSchemaHandler{
-			schema2Handler:   Schema2Handler{},
-			schema2_1Handler: Schema2_1Handler{},
-		},
-		labelSanitizer: DefaultLabelSanitizer{},
+		pipelineSchemaHandler: DefaultPipelineSchemaHandler{},
+		labelSanitizer:        DefaultLabelSanitizer{},
 	}
 }
 

--- a/provider-service/vai/internal/provider/job_enricher.go
+++ b/provider-service/vai/internal/provider/job_enricher.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 
 	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type JobEnricher interface {
@@ -42,5 +43,36 @@ func (dje DefaultJobEnricher) Enrich(
 
 	job.Labels = dje.labelSanitizer.Sanitize(job.Labels)
 	job.PipelineSpec = pv.pipelineSpec
+
+	// Vertex binds RuntimeConfig per schemaVersion: Parameters for <= 2.0.0,
+	// ParameterValues for >= 2.1.0. Submitting the wrong field returns
+	// INTERNAL_ERROR.
+	if pv.schemaVersion != nil && !pv.schemaVersion.LessThan(SchemaVersion2_1) {
+		promoteParametersToValues(job)
+	}
 	return job, nil
+}
+
+// promoteParametersToValues copies RuntimeConfig.Parameters into
+// RuntimeConfig.ParameterValues and clears Parameters.
+func promoteParametersToValues(job *aiplatformpb.PipelineJob) {
+	if job.RuntimeConfig == nil || len(job.RuntimeConfig.Parameters) == 0 {
+		return
+	}
+	if job.RuntimeConfig.ParameterValues == nil {
+		job.RuntimeConfig.ParameterValues = make(map[string]*structpb.Value, len(job.RuntimeConfig.Parameters))
+	}
+	for name, value := range job.RuntimeConfig.Parameters {
+		switch v := value.GetValue().(type) {
+		case *aiplatformpb.Value_StringValue:
+			job.RuntimeConfig.ParameterValues[name] = structpb.NewStringValue(v.StringValue)
+		case *aiplatformpb.Value_IntValue:
+			job.RuntimeConfig.ParameterValues[name] = structpb.NewNumberValue(float64(v.IntValue))
+		case *aiplatformpb.Value_DoubleValue:
+			job.RuntimeConfig.ParameterValues[name] = structpb.NewNumberValue(v.DoubleValue)
+		default:
+			job.RuntimeConfig.ParameterValues[name] = structpb.NewNullValue()
+		}
+	}
+	job.RuntimeConfig.Parameters = nil
 }

--- a/provider-service/vai/internal/provider/job_enricher_test.go
+++ b/provider-service/vai/internal/provider/job_enricher_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
+	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/provider-service/vai/internal/mocks"
@@ -41,7 +42,8 @@ var _ = Describe("DefaultJobEnricher", func() {
 				"sdk_version":      "kfp-2.12.2",
 				"Other&%":          "someVAl!ue",
 			},
-			pipelineSpec: &structpb.Struct{},
+			pipelineSpec:  &structpb.Struct{},
+			schemaVersion: semver.MustParse("2.1.0"),
 		}
 
 		BeforeEach(func() {
@@ -94,6 +96,46 @@ var _ = Describe("DefaultJobEnricher", func() {
 			job := aiplatformpb.PipelineJob{}
 			_, err := defaultJobEnricher.Enrich(&job, input)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("keeps RuntimeConfig.Parameters for a 2.0.0 schema spec", func() {
+			pv := pipelineValues
+			pv.schemaVersion = semver.MustParse("2.0.0")
+			pv.labels = map[string]string{"schema_version": "2.0.0"}
+			pipelineSchemaHandler.On("extract", input).Return(&pv, nil)
+			labelSanitizer.On("Sanitize", pv.labels).Return(pv.labels)
+
+			job := aiplatformpb.PipelineJob{
+				RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
+					Parameters: map[string]*aiplatformpb.Value{
+						"foo": {Value: &aiplatformpb.Value_StringValue{StringValue: "bar"}},
+					},
+				},
+			}
+			_, err := defaultJobEnricher.Enrich(&job, input)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(job.RuntimeConfig.Parameters).To(HaveKey("foo"))
+			Expect(job.RuntimeConfig.ParameterValues).To(BeEmpty())
+		})
+
+		It("promotes RuntimeConfig.Parameters to ParameterValues for a 2.1.0 schema spec", func() {
+			pipelineSchemaHandler.On("extract", input).Return(&pipelineValues, nil)
+			labelSanitizer.On("Sanitize", pipelineValues.labels).Return(pipelineValues.labels)
+
+			job := aiplatformpb.PipelineJob{
+				RuntimeConfig: &aiplatformpb.PipelineJob_RuntimeConfig{
+					Parameters: map[string]*aiplatformpb.Value{
+						"str": {Value: &aiplatformpb.Value_StringValue{StringValue: "bar"}},
+						"num": {Value: &aiplatformpb.Value_IntValue{IntValue: 7}},
+					},
+				},
+			}
+			_, err := defaultJobEnricher.Enrich(&job, input)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(job.RuntimeConfig.Parameters).To(BeEmpty())
+			Expect(job.RuntimeConfig.ParameterValues).To(HaveKey("str"))
+			Expect(job.RuntimeConfig.ParameterValues["str"].GetStringValue()).To(Equal("bar"))
+			Expect(job.RuntimeConfig.ParameterValues["num"].GetNumberValue()).To(Equal(float64(7)))
 		})
 	})
 })

--- a/provider-service/vai/internal/provider/pipeline_schema_handler.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler.go
@@ -3,14 +3,20 @@ package provider
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// SchemaVersion2_1 is the schemaVersion at which Vertex AI's PipelineJob
+// requires RuntimeConfig.ParameterValues instead of the deprecated Parameters.
+var SchemaVersion2_1 = semver.MustParse("2.1.0")
+
 type PipelineValues struct {
-	name         string
-	labels       map[string]string
-	pipelineSpec *structpb.Struct
+	name          string
+	labels        map[string]string
+	pipelineSpec  *structpb.Struct
+	schemaVersion *semver.Version
 }
 
 type PipelineSchemaHandler interface {
@@ -49,6 +55,10 @@ func (DefaultPipelineSchemaHandler) extract(raw map[string]any) (*PipelineValues
 			spec["schemaVersion"],
 		)
 	}
+	parsedSchemaVersion, err := semver.NewVersion(schemaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid 'schemaVersion' %q: %w", schemaVersion, err)
+	}
 	sdkVersion, ok := spec["sdkVersion"].(string)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -72,9 +82,10 @@ func (DefaultPipelineSchemaHandler) extract(raw map[string]any) (*PipelineValues
 	}
 
 	return &PipelineValues{
-		name:         name,
-		labels:       labels,
-		pipelineSpec: pipelineSpecStruct,
+		name:          name,
+		labels:        labels,
+		pipelineSpec:  pipelineSpecStruct,
+		schemaVersion: parsedSchemaVersion,
 	}, nil
 }
 

--- a/provider-service/vai/internal/provider/pipeline_schema_handler.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler.go
@@ -1,15 +1,10 @@
 package provider
 
 import (
-	"errors"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"google.golang.org/protobuf/types/known/structpb"
-)
 
-var (
-	SchemaVersionNotFound = errors.New("expected 'schemaVersion' or 'pipelineSpec' in the pipeline values")
-	SemVerV2              = semver.MustParse("2.0")
+	"github.com/samber/lo"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type PipelineValues struct {
@@ -22,153 +17,75 @@ type PipelineSchemaHandler interface {
 	extract(raw map[string]any) (*PipelineValues, error)
 }
 
-type DefaultPipelineSchemaHandler struct {
-	schema2Handler   PipelineSchemaHandler
-	schema2_1Handler PipelineSchemaHandler
-}
+// DefaultPipelineSchemaHandler handles both the bare KFP pipeline spec and the
+// TFX PipelineJob wrapper, for either schemaVersion 2.0 or 2.1.
+type DefaultPipelineSchemaHandler struct{}
 
-type Schema2Handler struct{}
-type Schema2_1Handler struct{}
+func (DefaultPipelineSchemaHandler) extract(raw map[string]any) (*PipelineValues, error) {
+	spec, name, wrapperLabels := unwrap(raw)
 
-func extractSchemaVersion(raw map[string]any) (*semver.Version, error) {
-	// 2.1 location of schemaVersion
-	schemaVersion, ok := raw["schemaVersion"].(string)
-	if !ok {
-		// 2.0 location of schemaVersion
-		pipelineSpec, ok := raw["pipelineSpec"].(map[string]any)
+	// An empty name means the spec is not wrapped, so take the name from pipelineInfo.
+	if name == "" {
+		pipelineInfo, ok := spec["pipelineInfo"].(map[string]any)
 		if !ok {
-			return nil, SchemaVersionNotFound
+			return nil, fmt.Errorf(
+				"expected map for 'pipelineInfo', got %T",
+				spec["pipelineInfo"],
+			)
 		}
-		schemaVersion, ok = pipelineSpec["schemaVersion"].(string)
+		name, ok = pipelineInfo["name"].(string)
 		if !ok {
-			return nil, SchemaVersionNotFound
+			return nil, fmt.Errorf(
+				"expected string for 'pipelineInfo.name', got %T",
+				pipelineInfo["name"],
+			)
 		}
 	}
-	version, err := semver.NewVersion(schemaVersion)
-	if err != nil {
-		return nil, err
-	}
-	return version, nil
-}
 
-func (dps DefaultPipelineSchemaHandler) extract(raw map[string]any) (*PipelineValues, error) {
-	version, err := extractSchemaVersion(raw)
-
-	if err != nil {
-		return nil, err
-	}
-	if version.GreaterThan(SemVerV2) {
-		return dps.schema2_1Handler.extract(raw)
-	} else {
-		return dps.schema2Handler.extract(raw)
-	}
-}
-
-func (sv2 Schema2Handler) extract(raw map[string]any) (*PipelineValues, error) {
-	displayName, ok := raw["displayName"].(string)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected string for 'displayName', got %T",
-			raw["displayName"],
-		)
-	}
-
-	pipelineSpec, ok := raw["pipelineSpec"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected map for 'pipelineSpec', got %T",
-			raw["pipelineSpec"],
-		)
-	}
-
-	pipelineSpecStruct, err := structpb.NewStruct(pipelineSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	schemaVersion, ok := pipelineSpec["schemaVersion"].(string)
+	schemaVersion, ok := spec["schemaVersion"].(string)
 	if !ok {
 		return nil, fmt.Errorf(
 			"expected string for 'schemaVersion', got %T",
-			raw["schemaVersion"],
+			spec["schemaVersion"],
 		)
 	}
-	sdkVersion, ok := pipelineSpec["sdkVersion"].(string)
+	sdkVersion, ok := spec["sdkVersion"].(string)
 	if !ok {
 		return nil, fmt.Errorf(
 			"expected string for 'sdkVersion', got %T",
-			raw["sdkVersion"],
+			spec["sdkVersion"],
 		)
 	}
 
-	labels, ok := raw["labels"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected map for 'labels', got %T",
-			raw["labels"],
-		)
-	}
-	labels["schema_version"] = schemaVersion
-	labels["sdk_version"] = sdkVersion
-
-	convertedLabels := make(map[string]string)
-	for k, v := range labels {
-		if strVal, ok := v.(string); ok {
-			convertedLabels[k] = strVal
-		} else {
-			convertedLabels[k] = fmt.Sprintf("%v", v)
+	labels := lo.MapValues(wrapperLabels, func(value any, _ string) string {
+		if stringValue, ok := value.(string); ok {
+			return stringValue
 		}
-	}
-
-	return &PipelineValues{
-		name:         displayName,
-		labels:       convertedLabels,
-		pipelineSpec: pipelineSpecStruct,
-	}, nil
-}
-
-func (sv21 Schema2_1Handler) extract(raw map[string]any) (*PipelineValues, error) {
-	pipelineInfo, ok := raw["pipelineInfo"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected map for 'pipelineInfo', got %T",
-			raw["pipelineInfo"],
-		)
-	}
-	displayName, ok := pipelineInfo["name"].(string)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected string for 'pipelineInfo.name', got %T",
-			pipelineInfo["name"],
-		)
-	}
-
-	schemaVersion, ok := raw["schemaVersion"].(string)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected string for 'schemaVersion', got %T",
-			raw["schemaVersion"],
-		)
-	}
-	sdkVersion, ok := raw["sdkVersion"].(string)
-	if !ok {
-		return nil, fmt.Errorf(
-			"expected string for 'sdkVersion', got %T",
-			raw["sdkVersion"],
-		)
-	}
-	labels := make(map[string]string)
+		return fmt.Sprintf("%v", value)
+	})
 	labels["schema_version"] = schemaVersion
 	labels["sdk_version"] = sdkVersion
 
-	pipelineSpecStruct, err := structpb.NewStruct(raw)
+	pipelineSpecStruct, err := structpb.NewStruct(spec)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PipelineValues{
-		name:         displayName,
+		name:         name,
 		labels:       labels,
 		pipelineSpec: pipelineSpecStruct,
 	}, nil
+}
+
+// unwrap returns the inner spec plus the wrapper's displayName and labels when
+// raw is a TFX PipelineJob wrapper, otherwise raw itself with no wrapper values.
+func unwrap(raw map[string]any) (spec map[string]any, displayName string, labels map[string]any) {
+	pipelineSpec, isWrapped := raw["pipelineSpec"].(map[string]any)
+	if !isWrapped {
+		return raw, "", nil
+	}
+	displayName, _ = raw["displayName"].(string)
+	labels, _ = raw["labels"].(map[string]any)
+	return pipelineSpec, displayName, labels
 }

--- a/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("DefaultPipelineSchemaHandler", func() {
 	var handler = DefaultPipelineSchemaHandler{}
 
-	Context("wrapped IR (Vertex PipelineJob envelope)", func() {
+	Context("wrapped pipeline spec (Vertex PipelineJob wrapper)", func() {
 		var raw map[string]any
 
 		BeforeEach(func() {
@@ -42,9 +42,9 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 				"schema_version":     "2.0.0",
 				"sdk_version":        "tfx-1.15.1",
 			}))
-			specMap := pipelineValues.pipelineSpec.AsMap()
-			Expect(specMap["key"]).To(Equal("value"))
-			Expect(specMap).ToNot(HaveKey("pipelineSpec"))
+			pipelineSpecMap := pipelineValues.pipelineSpec.AsMap()
+			Expect(pipelineSpecMap["key"]).To(Equal("value"))
+			Expect(pipelineSpecMap).ToNot(HaveKey("pipelineSpec"))
 		})
 
 		It("uses the wrapper displayName for a wrapped 2.1 spec (regression)", func() {
@@ -76,7 +76,7 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 		})
 	})
 
-	Context("bare IR (kfp-sdk output)", func() {
+	Context("bare pipeline spec (kfp-sdk output)", func() {
 		var raw map[string]any
 
 		BeforeEach(func() {
@@ -106,10 +106,10 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 				"sdk_version":    "kfp-2.0.1",
 				"schema_version": "2.1.0",
 			}))
-			specMap := pipelineValues.pipelineSpec.AsMap()
-			Expect(specMap["components"].(map[string]any)["component1"]).To(Equal("some-component"))
-			Expect(specMap["deploymentSpec"].(map[string]any)["executors"]).To(Equal("some-executor"))
-			Expect(specMap["root"].(map[string]any)["dag"]).To(Equal("some-dag"))
+			pipelineSpecMap := pipelineValues.pipelineSpec.AsMap()
+			Expect(pipelineSpecMap["components"].(map[string]any)["component1"]).To(Equal("some-component"))
+			Expect(pipelineSpecMap["deploymentSpec"].(map[string]any)["executors"]).To(Equal("some-executor"))
+			Expect(pipelineSpecMap["root"].(map[string]any)["dag"]).To(Equal("some-dag"))
 		})
 
 		When("pipelineInfo is not set", func() {

--- a/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
@@ -3,149 +3,129 @@
 package provider
 
 import (
-	"errors"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var _ = Describe("Schema2_1Handler", func() {
-	var (
-		raw2_1                       map[string]any
-		raw2                         map[string]any
-		mockPipelineSchemaHandler2   MockPipelineSchemaHandler
-		mockPipelineSchemaHandler2_1 MockPipelineSchemaHandler
-		defaultHandler               DefaultPipelineSchemaHandler
-		expectedReturn               PipelineValues
-	)
+var _ = Describe("DefaultPipelineSchemaHandler", func() {
+	var handler = DefaultPipelineSchemaHandler{}
 
-	BeforeEach(func() {
-		mockPipelineSchemaHandler2 = MockPipelineSchemaHandler{}
-		mockPipelineSchemaHandler2_1 = MockPipelineSchemaHandler{}
-		defaultHandler = DefaultPipelineSchemaHandler{
-			schema2Handler:   &mockPipelineSchemaHandler2,
-			schema2_1Handler: &mockPipelineSchemaHandler2_1,
-		}
+	Context("wrapped IR (Vertex PipelineJob envelope)", func() {
+		var raw map[string]any
 
-		raw2 = map[string]any{
-			"pipelineSpec": map[string]any{
-				"schemaVersion": "2.0",
-			},
-		}
-		raw2_1 = map[string]any{
-			"schemaVersion": "2.1",
-		}
-
-		expectedReturn = PipelineValues{}
-	})
-
-	Context("Extract", Ordered, func() {
-		It("should use 2.0 handler", func() {
-			mockPipelineSchemaHandler2.On("extract", raw2).Return(&expectedReturn, nil)
-			pipelineValues, err := defaultHandler.extract(raw2)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipelineValues).To(Equal(&expectedReturn))
-			Expect(mockPipelineSchemaHandler2_1.Calls).To(BeEmpty())
-		})
-
-		It("should use 2.1 handler", func() {
-			mockPipelineSchemaHandler2_1.On("extract", raw2_1).Return(&expectedReturn, nil)
-			pipelineValues, err := defaultHandler.extract(raw2_1)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipelineValues).To(Equal(&expectedReturn))
-			Expect(mockPipelineSchemaHandler2.Calls).To(BeEmpty())
-		})
-
-		It("should return error when schemaVersion is not found", func() {
-			_, err := defaultHandler.extract(map[string]any{})
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should return error when schemaVersion in schema 2.1 position and is not a string", func() {
-			raw2_1["schemaVersion"] = 123
-			_, err := defaultHandler.extract(raw2_1)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should return error when schemaVersion in schema 2.0 position and is not a string", func() {
-			raw2["pipelineSpec"].(map[string]any)["schemaVersion"] = 123
-			_, err := defaultHandler.extract(raw2)
-			Expect(err).To(HaveOccurred())
-		})
-
-		someError := errors.New("an error")
-		It("should use return error from 2.0 handler", func() {
-			mockPipelineSchemaHandler2.On("extract", raw2).Return(nil, someError)
-			_, err := defaultHandler.extract(raw2)
-			Expect(err).To(HaveOccurred())
-			Expect(mockPipelineSchemaHandler2_1.Calls).To(BeEmpty())
-		})
-
-		It("should use return error from 2.1 handler", func() {
-			mockPipelineSchemaHandler2_1.On("extract", raw2_1).Return(&expectedReturn, someError)
-			_, err := defaultHandler.extract(raw2_1)
-			Expect(err).To(HaveOccurred())
-			Expect(mockPipelineSchemaHandler2.Calls).To(BeEmpty())
-		})
-	})
-})
-
-var _ = Describe("Schema2_1Handler", func() {
-	var raw map[string]any
-	var schema21Handler = Schema2_1Handler{}
-
-	BeforeEach(func() {
-		raw = map[string]any{
-			"pipelineInfo": map[string]any{
-				"name": "test-display-name",
-			},
-			"sdkVersion":    "KFP-1.2.3",
-			"schemaVersion": "Version-1.2.3",
-			"components": map[string]any{
-				"component1": "some-component",
-			},
-			"deploymentSpec": map[string]any{
-				"executors": "some-executor",
-			},
-			"root": map[string]any{
-				"dag": "some-dag",
-			},
-		}
-	})
-
-	Context("Extract", Ordered, func() {
-		It("should return the pipeline values from the raw map", func() {
-			pipelineValues, err := schema21Handler.extract(raw)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipelineValues.name).To(Equal(raw["pipelineInfo"].(map[string]any)["name"].(string)))
-			Expect(pipelineValues.labels).To(Equal(
-				map[string]string{
-					"sdk_version":    "KFP-1.2.3",
-					"schema_version": "Version-1.2.3",
+		BeforeEach(func() {
+			raw = map[string]any{
+				"displayName": "test-display-name",
+				"pipelineSpec": map[string]any{
+					"key":           "value",
+					"schemaVersion": "2.0.0",
+					"sdkVersion":    "tfx-1.15.1",
+					"pipelineInfo": map[string]any{
+						"name": "inner-pipeline-name",
+					},
 				},
-			))
-			deploySpec := pipelineValues.pipelineSpec.AsMap()["deploymentSpec"].(map[string]any)
-			components := pipelineValues.pipelineSpec.AsMap()["components"].(map[string]any)
-			root := pipelineValues.pipelineSpec.AsMap()["root"].(map[string]any)
-			Expect(components["component1"]).To(Equal("some-component"))
-			Expect(deploySpec["executors"]).To(Equal("some-executor"))
-			Expect(root["dag"]).To(Equal("some-dag"))
+				"labels": map[string]any{
+					"label-key-from-raw": "label-value-from-raw",
+				},
+				"runtimeConfig": map[string]any{
+					"gcsOutputDirectory": "gs://test-bucket",
+				},
+			}
 		})
 
-		When("pipelineInfo is not a set", func() {
-			It("should return error", func() {
-				raw["pipelineInfo"] = nil
+		It("uses the wrapper displayName and the inner spec for a 2.0 spec", func() {
+			pipelineValues, err := handler.extract(raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipelineValues.name).To(Equal("test-display-name"))
+			Expect(pipelineValues.labels).To(Equal(map[string]string{
+				"label-key-from-raw": "label-value-from-raw",
+				"schema_version":     "2.0.0",
+				"sdk_version":        "tfx-1.15.1",
+			}))
+			specMap := pipelineValues.pipelineSpec.AsMap()
+			Expect(specMap["key"]).To(Equal("value"))
+			Expect(specMap).ToNot(HaveKey("pipelineSpec"))
+		})
 
-				_, err := schema21Handler.extract(raw)
+		It("uses the wrapper displayName for a wrapped 2.1 spec (regression)", func() {
+			raw["pipelineSpec"].(map[string]any)["schemaVersion"] = "2.1.0"
+			raw["pipelineSpec"].(map[string]any)["sdkVersion"] = "kfp-2.0.1"
+			pipelineValues, err := handler.extract(raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipelineValues.name).To(Equal("test-display-name"))
+			Expect(pipelineValues.labels["schema_version"]).To(Equal("2.1.0"))
+			Expect(pipelineValues.labels["sdk_version"]).To(Equal("kfp-2.0.1"))
+		})
+
+		When("schemaVersion in the inner spec is not a string", func() {
+			It("should return error", func() {
+				raw["pipelineSpec"].(map[string]any)["schemaVersion"] = 123
+
+				_, err := handler.extract(raw)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
-		When("displayName is not a string", func() {
+		When("sdkVersion in the inner spec is not a string", func() {
+			It("should return error", func() {
+				raw["pipelineSpec"].(map[string]any)["sdkVersion"] = 123
+
+				_, err := handler.extract(raw)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("bare IR (kfp-sdk output)", func() {
+		var raw map[string]any
+
+		BeforeEach(func() {
+			raw = map[string]any{
+				"pipelineInfo": map[string]any{
+					"name": "test-pipeline-name",
+				},
+				"sdkVersion":    "kfp-2.0.1",
+				"schemaVersion": "2.1.0",
+				"components": map[string]any{
+					"component1": "some-component",
+				},
+				"deploymentSpec": map[string]any{
+					"executors": "some-executor",
+				},
+				"root": map[string]any{
+					"dag": "some-dag",
+				},
+			}
+		})
+
+		It("uses pipelineInfo.name and the bare spec", func() {
+			pipelineValues, err := handler.extract(raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipelineValues.name).To(Equal("test-pipeline-name"))
+			Expect(pipelineValues.labels).To(Equal(map[string]string{
+				"sdk_version":    "kfp-2.0.1",
+				"schema_version": "2.1.0",
+			}))
+			specMap := pipelineValues.pipelineSpec.AsMap()
+			Expect(specMap["components"].(map[string]any)["component1"]).To(Equal("some-component"))
+			Expect(specMap["deploymentSpec"].(map[string]any)["executors"]).To(Equal("some-executor"))
+			Expect(specMap["root"].(map[string]any)["dag"]).To(Equal("some-dag"))
+		})
+
+		When("pipelineInfo is not set", func() {
+			It("should return error", func() {
+				raw["pipelineInfo"] = nil
+
+				_, err := handler.extract(raw)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("pipelineInfo.name is not a string", func() {
 			It("should return error", func() {
 				raw["pipelineInfo"].(map[string]any)["name"] = 123
 
-				_, err := schema21Handler.extract(raw)
+				_, err := handler.extract(raw)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -154,7 +134,7 @@ var _ = Describe("Schema2_1Handler", func() {
 			It("should return error", func() {
 				raw["schemaVersion"] = 123
 
-				_, err := schema21Handler.extract(raw)
+				_, err := handler.extract(raw)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -163,98 +143,7 @@ var _ = Describe("Schema2_1Handler", func() {
 			It("should return error", func() {
 				raw["sdkVersion"] = 123
 
-				_, err := schema21Handler.extract(raw)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-})
-
-var _ = Describe("Schema2Handler", func() {
-	var raw map[string]any
-	var schema2Handler = Schema2Handler{}
-
-	BeforeEach(func() {
-		raw = map[string]any{
-			"displayName": "test-display-name",
-			"pipelineSpec": map[string]any{
-				"key":           "value",
-				"schemaVersion": "2.0.0",
-				"sdkVersion":    "tfx-1.15.1",
-			},
-			"labels": map[string]any{
-				"label-key-from-raw": "label-value-from-raw",
-			},
-			"runtimeConfig": map[string]any{
-				"gcsOutputDirectory": "gs://test-bucket",
-			},
-		}
-	})
-
-	Context("Extract", Ordered, func() {
-		It("should extract pipeline values from the raw map and sanitize schemaVersion and sdkVersion", func() {
-			pipelineValues, err := schema2Handler.extract(raw)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipelineValues.name).To(Equal(raw["displayName"]))
-			pipelineSpec, err := structpb.NewStruct(
-				map[string]any{
-					"key":           "value",
-					"schemaVersion": "2.0.0",
-					"sdkVersion":    "tfx-1.15.1",
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipelineValues.pipelineSpec).To(Equal(pipelineSpec))
-			Expect(pipelineValues.labels).To(Equal(
-				map[string]string{
-					"label-key-from-raw": "label-value-from-raw",
-					"schema_version":     "2.0.0",
-					"sdk_version":        "tfx-1.15.1",
-				},
-			))
-		})
-
-		When("displayName is not a string", func() {
-			It("should return error", func() {
-				raw["displayName"] = 123
-
-				_, err := schema2Handler.extract(raw)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		When("pipelineSpec is not a map", func() {
-			It("should return error", func() {
-				raw["pipelineSpec"] = 123
-
-				_, err := schema2Handler.extract(raw)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		When("labels is not a map", func() {
-			It("should return error", func() {
-				raw["labels"] = 123
-
-				_, err := schema2Handler.extract(raw)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		When("schemaVersion is not a string", func() {
-			It("should return error", func() {
-				raw["pipelineSpec"].(map[string]any)["schemaVersion"] = 123
-
-				_, err := schema2Handler.extract(raw)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		When("sdkVersion is not a string", func() {
-			It("should return error", func() {
-				raw["pipelineSpec"].(map[string]any)["sdkVersion"] = 123
-
-				_, err := schema2Handler.extract(raw)
+				_, err := handler.extract(raw)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler_test.go
@@ -42,6 +42,8 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 				"schema_version":     "2.0.0",
 				"sdk_version":        "tfx-1.15.1",
 			}))
+			Expect(pipelineValues.schemaVersion).ToNot(BeNil())
+			Expect(pipelineValues.schemaVersion.String()).To(Equal("2.0.0"))
 			pipelineSpecMap := pipelineValues.pipelineSpec.AsMap()
 			Expect(pipelineSpecMap["key"]).To(Equal("value"))
 			Expect(pipelineSpecMap).ToNot(HaveKey("pipelineSpec"))
@@ -55,6 +57,17 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 			Expect(pipelineValues.name).To(Equal("test-display-name"))
 			Expect(pipelineValues.labels["schema_version"]).To(Equal("2.1.0"))
 			Expect(pipelineValues.labels["sdk_version"]).To(Equal("kfp-2.0.1"))
+			Expect(pipelineValues.schemaVersion).ToNot(BeNil())
+			Expect(pipelineValues.schemaVersion.String()).To(Equal("2.1.0"))
+		})
+
+		When("schemaVersion is not a valid semver", func() {
+			It("should return error", func() {
+				raw["pipelineSpec"].(map[string]any)["schemaVersion"] = "not-a-version"
+
+				_, err := handler.extract(raw)
+				Expect(err).To(HaveOccurred())
+			})
 		})
 
 		When("schemaVersion in the inner spec is not a string", func() {
@@ -106,6 +119,8 @@ var _ = Describe("DefaultPipelineSchemaHandler", func() {
 				"sdk_version":    "kfp-2.0.1",
 				"schema_version": "2.1.0",
 			}))
+			Expect(pipelineValues.schemaVersion).ToNot(BeNil())
+			Expect(pipelineValues.schemaVersion.String()).To(Equal("2.1.0"))
 			pipelineSpecMap := pipelineValues.pipelineSpec.AsMap()
 			Expect(pipelineSpecMap["components"].(map[string]any)["component1"]).To(Equal("some-component"))
 			Expect(pipelineSpecMap["deploymentSpec"].(map[string]any)["executors"]).To(Equal("some-executor"))


### PR DESCRIPTION
links to #651 

  Vertex AI's `PipelineJob.RuntimeConfig` binds parameters via different fields depending on `pipelineSpec.schemaVersion`:

  - `<= 2.0.0` — uses `RuntimeConfig.Parameters` (deprecated).
  - `>= 2.1.0` — uses `RuntimeConfig.ParameterValues`.

  The VAI provider only populated the deprecated `Parameters` field. When TFX (or any compiler) emitted a 2.1.0 IR, Vertex failed the job with `INTERNAL_ERROR` because the runtime config and the submitted `pipelineSpec` disagreed.
 
 ## Changes

  - Parse `pipelineSpec.schemaVersion` into a `*semver.Version` on `PipelineValues`; reject invalid versions up-front.
  - In `DefaultJobEnricher.Enrich`, when the resolved schema version is `>= 2.1.0`, promote `RuntimeConfig.Parameters` onto `RuntimeConfig.ParameterValues` and clear `Parameters`. String, int
  and double variants are covered.
  - `MkRunPipelineJob` / `MkRunSchedulePipelineJob` keep building the deprecated `Parameters` field; the enricher (which is the only place that knows the IR version) does the swap. This keeps
  the builder schema-agnostic.