### PR TITLE
refactor(kfp-provider): move KfpApi/MetadataStore interfaces to consumer

### DIFF
--- a/provider-service/kfp/internal/client/kfp_api.go
+++ b/provider-service/kfp/internal/client/kfp_api.go
@@ -14,10 +14,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 )
 
-type KfpApi interface {
-	GetResourceReferences(ctx context.Context, runId string) (resource.References, error)
-}
-
 type GrpcKfpApi struct {
 	RunServiceClient
 }
@@ -73,7 +69,7 @@ func (gka *GrpcKfpApi) GetResourceReferences(ctx context.Context, runId string) 
 	return resourceReferences, nil
 }
 
-func CreateKfpApi(ctx context.Context, config config.Config) (KfpApi, error) {
+func CreateKfpApi(ctx context.Context, config config.Config) (*GrpcKfpApi, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	kfpApi, err := ConnectToKfpApi(config.Parameters.GrpcKfpApiAddress)
 	if err != nil {

--- a/provider-service/kfp/internal/client/metadata_store.go
+++ b/provider-service/kfp/internal/client/metadata_store.go
@@ -23,15 +23,14 @@ const (
 	DisplayName                = "display_name"
 )
 
-type MetadataStore interface {
-	GetArtifactsForRun(ctx context.Context, runId string) ([]common.PipelineComponent, error)
-}
-
 type GrpcMetadataStore struct {
 	MetadataStoreServiceClient MetadataStoreServiceClient
 }
 
-func (gms *GrpcMetadataStore) GetArtifactsForRun(ctx context.Context, runId string) ([]common.PipelineComponent, error) {
+func (gms *GrpcMetadataStore) GetArtifactsForRun(
+	ctx context.Context,
+	runId string,
+) ([]common.PipelineComponent, error) {
 	// Resolve run context
 	typeName := PipelineRunTypeName
 	ctxResp, err := gms.MetadataStoreServiceClient.GetContextByTypeAndName(ctx,
@@ -142,7 +141,7 @@ func propertiesToPrimitiveMap(in map[string]*ml_metadata.Value) map[string]any {
 	return out
 }
 
-func CreateMetadataStore(ctx context.Context, config config.Config) (MetadataStore, error) {
+func CreateMetadataStore(ctx context.Context, config config.Config) (*GrpcMetadataStore, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	metadataStore, err := ConnectToMetadataStore(config.Parameters.GrpcMetadataStoreAddress)
 	if err != nil {

--- a/provider-service/kfp/internal/runcompletion/event_flow.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow.go
@@ -8,15 +8,29 @@ import (
 	"github.com/sky-uk/kfp-operator/pkg/common"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg"
 	. "github.com/sky-uk/kfp-operator/provider-service/base/pkg/streams"
-	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/client"
+	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/client/resource"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+type kfpApi interface {
+	GetResourceReferences(
+		ctx context.Context,
+		runId string,
+	) (resource.References, error)
+}
+
+type metadataStore interface {
+	GetArtifactsForRun(
+		ctx context.Context,
+		runId string,
+	) ([]common.PipelineComponent, error)
+}
+
 type EventFlow struct {
 	ProviderConfig config.Config
-	MetadataStore  client.MetadataStore
-	KfpApi         client.KfpApi
+	metadataStore  metadataStore
+	kfpApi         kfpApi
 	Logger         logr.Logger
 	in             chan StreamMessage[*unstructured.Unstructured]
 	out            chan StreamMessage[*common.RunCompletionEventData]
@@ -68,13 +82,18 @@ func (ef *EventFlow) Error(inlet Inlet[error]) {
 	}
 }
 
-func NewEventFlow(ctx context.Context, config config.Config, kfpApi client.KfpApi, metadataStore client.MetadataStore) (*EventFlow, error) {
+func NewEventFlow(
+	ctx context.Context,
+	config config.Config,
+	kfpApiClient kfpApi,
+	metadataStore metadataStore,
+) (*EventFlow, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	flow := &EventFlow{
 		ProviderConfig: config,
-		MetadataStore:  metadataStore,
-		KfpApi:         kfpApi,
+		metadataStore:  metadataStore,
+		kfpApi:         kfpApiClient,
 		Logger:         logger,
 		in:             make(chan StreamMessage[*unstructured.Unstructured]),
 		out:            make(chan StreamMessage[*common.RunCompletionEventData]),
@@ -122,13 +141,13 @@ func (ef *EventFlow) eventForWorkflow(ctx context.Context, workflow *unstructure
 	}
 
 	runId := workflow.GetLabels()[pipelineRunIdLabel]
-	resourceReferences, err := ef.KfpApi.GetResourceReferences(ctx, runId)
+	resourceReferences, err := ef.kfpApi.GetResourceReferences(ctx, runId)
 	if err != nil {
 		ef.Logger.Error(err, "failed to retrieve resource references")
 		return nil, err
 	}
 
-	pipelineComponents, err := ef.MetadataStore.GetArtifactsForRun(ctx, runId)
+	pipelineComponents, err := ef.metadataStore.GetArtifactsForRun(ctx, runId)
 	if err != nil {
 		ef.Logger.Error(err, "failed to retrieve pipeline components")
 		return nil, err

--- a/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
@@ -78,8 +78,8 @@ var _ = Context("Eventing Flow", func() {
 
 			eventingServer := EventFlow{
 				Logger:        logr.Discard(),
-				MetadataStore: &mockMetadataStore,
-				KfpApi:        &mockKfpApi,
+				metadataStore: &mockMetadataStore,
+				kfpApi:        &mockKfpApi,
 			}
 
 			event, err := eventingServer.eventForWorkflow(context.Background(), workflow)
@@ -100,8 +100,8 @@ var _ = Context("Eventing Flow", func() {
 
 			eventingServer := EventFlow{
 				Logger:        logr.Discard(),
-				MetadataStore: &mockMetadataStore,
-				KfpApi:        &mockKfpApi,
+				metadataStore: &mockMetadataStore,
+				kfpApi:        &mockKfpApi,
 			}
 
 			mockKfpApi.On("GetResourceReferences", runId).Return(resource.RandomReferences(), nil)
@@ -126,8 +126,8 @@ var _ = Context("Eventing Flow", func() {
 
 			eventingServer := EventFlow{
 				Logger:        logr.Discard(),
-				MetadataStore: &mockMetadataStore,
-				KfpApi:        &mockKfpApi,
+				metadataStore: &mockMetadataStore,
+				kfpApi:        &mockKfpApi,
 			}
 
 			expectedError := errors.New("an error occurred")
@@ -172,8 +172,8 @@ var _ = Context("Eventing Flow", func() {
 
 		eventingServer := EventFlow{
 			Logger:        logr.Discard(),
-			MetadataStore: &mockMetadataStore,
-			KfpApi:        &mockKfpApi,
+			metadataStore: &mockMetadataStore,
+			kfpApi:        &mockKfpApi,
 			ProviderConfig: config.Config{
 				ProviderName: common.NamespacedName{Namespace: "default", Name: "kfp"},
 			},


### PR DESCRIPTION
As a result, runcompletion no longer imports the client package, and adding methods to the gRPC clients can no longer leak into the consumer.
