### PR TITLE
refactor(vai-provider): Move JobEnricher, PipelineSchemaHandler, LabelSanitizer interfaces to consumer

### DIFF
--- a/provider-service/vai/internal/provider/job_enricher.go
+++ b/provider-service/vai/internal/provider/job_enricher.go
@@ -7,13 +7,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-type JobEnricher interface {
-	Enrich(
-		job *aiplatformpb.PipelineJob,
-		raw map[string]any,
-	) (*aiplatformpb.PipelineJob, error)
-}
-
 type DefaultJobEnricher struct {
 	pipelineSchemaHandler PipelineSchemaHandler
 	labelSanitizer        LabelSanitizer

--- a/provider-service/vai/internal/provider/job_enricher.go
+++ b/provider-service/vai/internal/provider/job_enricher.go
@@ -7,9 +7,17 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type pipelineSchemaHandler interface {
+	extract(raw map[string]any) (*PipelineValues, error)
+}
+
+type labelSanitizer interface {
+	Sanitize(labels map[string]string) map[string]string
+}
+
 type DefaultJobEnricher struct {
-	pipelineSchemaHandler PipelineSchemaHandler
-	labelSanitizer        LabelSanitizer
+	pipelineSchemaHandler pipelineSchemaHandler
+	labelSanitizer        labelSanitizer
 }
 
 func NewDefaultJobEnricher() DefaultJobEnricher {

--- a/provider-service/vai/internal/provider/label_sanitizer.go
+++ b/provider-service/vai/internal/provider/label_sanitizer.go
@@ -7,10 +7,6 @@ import (
 	"github.com/sky-uk/kfp-operator/provider-service/base/pkg/label"
 )
 
-type LabelSanitizer interface {
-	Sanitize(labels map[string]string) map[string]string
-}
-
 type DefaultLabelSanitizer struct{}
 
 // Vertex AI PipelineJob label keys and values can be no longer than 63 chars,

--- a/provider-service/vai/internal/provider/pipeline_schema_handler.go
+++ b/provider-service/vai/internal/provider/pipeline_schema_handler.go
@@ -19,10 +19,6 @@ type PipelineValues struct {
 	schemaVersion *semver.Version
 }
 
-type PipelineSchemaHandler interface {
-	extract(raw map[string]any) (*PipelineValues, error)
-}
-
 // DefaultPipelineSchemaHandler handles both the bare KFP pipeline spec and the
 // TFX PipelineJob wrapper, for either schemaVersion 2.0 or 2.1.
 type DefaultPipelineSchemaHandler struct{}

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -47,13 +47,20 @@ type scheduleClient interface {
 	) (*aiplatformpb.Schedule, error)
 }
 
+type jobEnricher interface {
+	Enrich(
+		job *aiplatformpb.PipelineJob,
+		raw map[string]any,
+	) (*aiplatformpb.PipelineJob, error)
+}
+
 type VAIProvider struct {
 	config         *config.VAIProviderConfig
 	fileHandler    FileHandler
 	pipelineClient pipelineJobCreator
 	scheduleClient scheduleClient
 	jobBuilder     JobBuilder
-	jobEnricher    JobEnricher
+	jobEnricher    jobEnricher
 }
 
 func NewVAIProvider(


### PR DESCRIPTION
Make the aforementioned provider interfaces consumer-driven, which follows golang best practices.