### PR TITLE
refactor(vai-provider): move JobBuilder and FileHandler interfaces to consumer

### DIFF
--- a/provider-service/vai/internal/provider/file_handler.go
+++ b/provider-service/vai/internal/provider/file_handler.go
@@ -13,12 +13,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-type FileHandler interface {
-	Write(ctx context.Context, content []byte, bucket string, filePath string) error
-	Delete(ctx context.Context, id string, bucket string) error
-	Read(ctx context.Context, bucket string, filePath string) (map[string]any, error)
-}
-
 type GcsFileHandler struct {
 	gcsClient storage.Client
 }

--- a/provider-service/vai/internal/provider/job_builder.go
+++ b/provider-service/vai/internal/provider/job_builder.go
@@ -13,23 +13,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type JobBuilder interface {
-	MkRunPipelineJob(
-		rd base.RunDefinition,
-		networkAttachment string,
-	) (*aiplatformpb.PipelineJob, error)
-	MkRunSchedulePipelineJob(
-		rsd base.RunScheduleDefinition,
-		networkAttachment string,
-	) (*aiplatformpb.PipelineJob, error)
-	MkSchedule(
-		rsd base.RunScheduleDefinition,
-		pipelineJob *aiplatformpb.PipelineJob,
-		parent string,
-		maxConcurrentRunCount int64,
-	) (*aiplatformpb.Schedule, error)
-}
-
 type DefaultJobBuilder struct {
 	serviceAccount      string
 	pipelineBucket      string

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -60,12 +60,29 @@ type jobEnricher interface {
 	) (*aiplatformpb.PipelineJob, error)
 }
 
+type jobBuilder interface {
+	MkRunPipelineJob(
+		rd base.RunDefinition,
+		networkAttachment string,
+	) (*aiplatformpb.PipelineJob, error)
+	MkRunSchedulePipelineJob(
+		rsd base.RunScheduleDefinition,
+		networkAttachment string,
+	) (*aiplatformpb.PipelineJob, error)
+	MkSchedule(
+		rsd base.RunScheduleDefinition,
+		pipelineJob *aiplatformpb.PipelineJob,
+		parent string,
+		maxConcurrentRunCount int64,
+	) (*aiplatformpb.Schedule, error)
+}
+
 type VAIProvider struct {
 	config         *config.VAIProviderConfig
 	fileHandler    fileHandler
 	pipelineClient pipelineJobCreator
 	scheduleClient scheduleClient
-	jobBuilder     JobBuilder
+	jobBuilder     jobBuilder
 	jobEnricher    jobEnricher
 }
 

--- a/provider-service/vai/internal/provider/provider.go
+++ b/provider-service/vai/internal/provider/provider.go
@@ -47,6 +47,12 @@ type scheduleClient interface {
 	) (*aiplatformpb.Schedule, error)
 }
 
+type fileHandler interface {
+	Write(ctx context.Context, content []byte, bucket string, filePath string) error
+	Delete(ctx context.Context, id string, bucket string) error
+	Read(ctx context.Context, bucket string, filePath string) (map[string]any, error)
+}
+
 type jobEnricher interface {
 	Enrich(
 		job *aiplatformpb.PipelineJob,
@@ -56,7 +62,7 @@ type jobEnricher interface {
 
 type VAIProvider struct {
 	config         *config.VAIProviderConfig
-	fileHandler    FileHandler
+	fileHandler    fileHandler
 	pipelineClient pipelineJobCreator
 	scheduleClient scheduleClient
 	jobBuilder     JobBuilder


### PR DESCRIPTION
Make the aforementioned provider interfaces consumer-driven, which follows golang best practices.