### PR TITLE
refactor(config): scale webhook namespace patch to any number of webhooks

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,16 +2,10 @@ resources:
 - manifests.yaml
 - service.yaml
 
+namespace: kfp-operator-system
+
 patchesStrategicMerge:
 - patches/cainjection_in_manifests.yaml
-
-patches:
-- path: patches/namespace.yaml
-  target:
-    group: admissionregistration.k8s.io
-    version: v1
-    kind: ValidatingWebhookConfiguration
-    name: validating-webhook-configuration
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/webhook/patches/namespace.yaml
+++ b/config/webhook/patches/namespace.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /webhooks/0/clientConfig/service/namespace
-  value: kfp-operator-system
-- op: replace
-  path: /webhooks/1/clientConfig/service/namespace
-  value: kfp-operator-system
-- op: replace
-  path: /webhooks/2/clientConfig/service/namespace
-  value: kfp-operator-system


### PR DESCRIPTION
Closes #1327

Replaces the hand-maintained index-based webhook namespace patch with a scoped kustomize namespace transformer, using the namespace: fieldSpec already in kustomizeconfig.yaml. Applies to any number of webhooks with no manual upkeep.