### PR TITLE
fix(provider): add reserved-name validation for provider podTemplateEnv

### DIFF
--- a/apis/pipelines/hub/provider_webhook.go
+++ b/apis/pipelines/hub/provider_webhook.go
@@ -1,10 +1,95 @@
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func (p *Provider) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, p).
 		Complete()
+}
+
+// Reserved env var names derived by the operator in
+// controllers/pipelines.populateServiceContainer. Keep this list in sync with
+// the ProviderNameEnvVar/PipelineRootStorageEnvVar constants and the
+// PARAMETERS_ prefix defined there; they cannot be imported here without an
+// import cycle (controllers depend on this API package).
+const (
+	reservedProviderNameEnvVar        = "PROVIDERNAME"
+	reservedPipelineRootStorageEnvVar = "PIPELINEROOTSTORAGE"
+	reservedParametersPrefix          = "PARAMETERS_"
+)
+
+func NewProviderValidatorWebhook(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &Provider{}).
+		WithValidator(&ProviderValidator{}).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-pipelines-kubeflow-org-v1beta1-provider,mutating=false,failurePolicy=fail,sideEffects=None,groups=pipelines.kubeflow.org,resources=providers,verbs=create;update,versions=v1beta1,name=vprovider.kb.io,admissionReviewVersions=v1
+//+kubebuilder:object:generate=false
+
+type ProviderValidator struct{}
+
+func (v *ProviderValidator) ValidateCreate(
+	_ context.Context,
+	provider *Provider,
+) (admission.Warnings, error) {
+	return v.validate(provider)
+}
+
+func (v *ProviderValidator) ValidateUpdate(
+	_ context.Context,
+	_ *Provider,
+	newObj *Provider,
+) (admission.Warnings, error) {
+	return v.validate(newObj)
+}
+
+func (v *ProviderValidator) ValidateDelete(
+	_ context.Context,
+	_ *Provider,
+) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func isReservedEnvVar(name string) bool {
+	upper := strings.ToUpper(name)
+	return upper == reservedProviderNameEnvVar ||
+		upper == reservedPipelineRootStorageEnvVar ||
+		strings.HasPrefix(upper, reservedParametersPrefix)
+}
+
+func (v *ProviderValidator) validate(
+	provider *Provider,
+) (admission.Warnings, error) {
+	var errs field.ErrorList
+	for i, envVar := range provider.Spec.PodTemplateEnv {
+		if isReservedEnvVar(envVar.Name) {
+			errs = append(errs, field.Forbidden(
+				field.NewPath("spec", "podTemplateEnv").Index(i).Child("name"),
+				fmt.Sprintf(
+					"environment variable %q is reserved by the operator and cannot be set via podTemplateEnv",
+					envVar.Name,
+				),
+			))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(
+		provider.GetObjectKind().GroupVersionKind().GroupKind(),
+		provider.GetNamespacedName().String(),
+		errs,
+	)
 }

--- a/apis/pipelines/hub/provider_webhook.go
+++ b/apis/pipelines/hub/provider_webhook.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sky-uk/kfp-operator/pkg/common"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,17 +16,6 @@ func (p *Provider) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, p).
 		Complete()
 }
-
-// Reserved env var names derived by the operator in
-// controllers/pipelines.populateServiceContainer. Keep this list in sync with
-// the ProviderNameEnvVar/PipelineRootStorageEnvVar constants and the
-// PARAMETERS_ prefix defined there; they cannot be imported here without an
-// import cycle (controllers depend on this API package).
-const (
-	reservedProviderNameEnvVar        = "PROVIDERNAME"
-	reservedPipelineRootStorageEnvVar = "PIPELINEROOTSTORAGE"
-	reservedParametersPrefix          = "PARAMETERS_"
-)
 
 func NewProviderValidatorWebhook(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &Provider{}).
@@ -62,9 +52,9 @@ func (v *ProviderValidator) ValidateDelete(
 
 func isReservedEnvVar(name string) bool {
 	upper := strings.ToUpper(name)
-	return upper == reservedProviderNameEnvVar ||
-		upper == reservedPipelineRootStorageEnvVar ||
-		strings.HasPrefix(upper, reservedParametersPrefix)
+	return upper == common.ProviderNameEnvVar ||
+		upper == common.PipelineRootStorageEnvVar ||
+		strings.HasPrefix(upper, common.ParametersEnvVarPrefix)
 }
 
 func (v *ProviderValidator) validate(

--- a/apis/pipelines/hub/provider_webhook_test.go
+++ b/apis/pipelines/hub/provider_webhook_test.go
@@ -1,0 +1,90 @@
+//go:build unit
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ProviderValidator Webhook", func() {
+	var (
+		validator ProviderValidator
+		provider  Provider
+	)
+
+	BeforeEach(func() {
+		validator = ProviderValidator{}
+		provider = Provider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "provider-name",
+				Namespace: "provider-ns",
+			},
+		}
+	})
+
+	Context("validate", func() {
+		When("podTemplateEnv contains no reserved names", func() {
+			It("should not error", func() {
+				provider.Spec.PodTemplateEnv = []corev1.EnvVar{
+					{Name: "KUBE_FEATURE_WatchListClient", Value: "true"},
+					{Name: "HTTPS_PROXY", Value: "http://proxy:3128"},
+				}
+
+				warnings, err := validator.validate(&provider)
+				Expect(warnings).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("podTemplateEnv is empty", func() {
+			It("should not error", func() {
+				warnings, err := validator.validate(&provider)
+				Expect(warnings).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		DescribeTable("rejecting reserved env var names",
+			func(name string) {
+				provider.Spec.PodTemplateEnv = []corev1.EnvVar{
+					{Name: name, Value: "x"},
+				}
+
+				warnings, err := validator.validate(&provider)
+				Expect(warnings).To(BeNil())
+
+				statusErr := &apierrors.StatusError{}
+				Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				Expect(err).To(BeAssignableToTypeOf(statusErr))
+				causes := err.(*apierrors.StatusError).Status().Details.Causes
+				Expect(causes).To(HaveLen(1))
+				Expect(causes[0].Type).To(Equal(metav1.CauseTypeForbidden))
+			},
+			Entry("PROVIDERNAME", "PROVIDERNAME"),
+			Entry("PIPELINEROOTSTORAGE", "PIPELINEROOTSTORAGE"),
+			Entry("PARAMETERS_ prefix", "PARAMETERS_FOO"),
+			Entry("lowercase providername", "providername"),
+			Entry("lowercase parameters prefix", "parameters_foo"),
+		)
+
+		When("multiple reserved names are present", func() {
+			It("should report every offending entry", func() {
+				provider.Spec.PodTemplateEnv = []corev1.EnvVar{
+					{Name: "SAFE", Value: "ok"},
+					{Name: "PROVIDERNAME", Value: "x"},
+					{Name: "PARAMETERS_KEY", Value: "y"},
+				}
+
+				warnings, err := validator.validate(&provider)
+				Expect(warnings).To(BeNil())
+				Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				causes := err.(*apierrors.StatusError).Status().Details.Causes
+				Expect(causes).To(HaveLen(2))
+			})
+		})
+	})
+})

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -30,6 +30,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-pipelines-kubeflow-org-v1beta1-provider
+  failurePolicy: Fail
+  name: vprovider.kb.io
+  rules:
+  - apiGroups:
+    - pipelines.kubeflow.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - providers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-pipelines-kubeflow-org-v1beta1-run
   failurePolicy: Fail
   name: vrun.kb.io

--- a/controllers/pipelines/provider_deployment_manager.go
+++ b/controllers/pipelines/provider_deployment_manager.go
@@ -40,9 +40,6 @@ type DeploymentManager struct {
 	config *config.ConfigSpec
 }
 
-const ProviderNameEnvVar = "PROVIDERNAME"
-const PipelineRootStorageEnvVar = "PIPELINEROOTSTORAGE"
-
 func (dm DeploymentManager) Create(ctx context.Context, new *appsv1.Deployment, owner *pipelineshub.Provider) error {
 	logger := log.FromContext(ctx)
 
@@ -150,14 +147,14 @@ func populateServiceContainer(serviceContainerName string, podTemplate corev1.Po
 	}
 
 	envVars := []corev1.EnvVar{{
-		Name:  ProviderNameEnvVar,
+		Name:  common.ProviderNameEnvVar,
 		Value: namespacedName,
 	}, {
-		Name:  PipelineRootStorageEnvVar,
+		Name:  common.PipelineRootStorageEnvVar,
 		Value: provider.Spec.PipelineRootStorage,
 	}}
 	for name, value := range provider.Spec.Parameters {
-		envVars = append(envVars, corev1.EnvVar{Name: fmt.Sprintf("PARAMETERS_%s", strings.ToUpper(name)), Value: jsonToString(value)})
+		envVars = append(envVars, corev1.EnvVar{Name: fmt.Sprintf("%s%s", common.ParametersEnvVarPrefix, strings.ToUpper(name)), Value: jsonToString(value)})
 	}
 
 	sort.Slice(envVars, func(a, b int) bool {

--- a/controllers/pipelines/provider_deployment_manager_test.go
+++ b/controllers/pipelines/provider_deployment_manager_test.go
@@ -211,7 +211,7 @@ var _ = Context("Provider Deployment Manager", func() {
 					Value: provider.Spec.PipelineRootStorage,
 				},
 				{
-					Name:  ProviderNameEnvVar,
+					Name:  common.ProviderNameEnvVar,
 					Value: providerNamespacedName,
 				},
 			}))
@@ -253,7 +253,7 @@ var _ = Context("Provider Deployment Manager", func() {
 				{Name: "SHARED", Value: "per-provider"},
 				{Name: "PARAMETERS_KEY1", Value: "value1"},
 				{Name: "PIPELINEROOTSTORAGE", Value: provider.Spec.PipelineRootStorage},
-				{Name: ProviderNameEnvVar, Value: providerNamespacedName},
+				{Name: common.ProviderNameEnvVar, Value: providerNamespacedName},
 				{Name: "CUSTOM", Value: "x"},
 			}))
 		})

--- a/controllers/pipelines/suite_decoupled_test.go
+++ b/controllers/pipelines/suite_decoupled_test.go
@@ -124,6 +124,27 @@ var _ = BeforeSuite(func() {
 	Expect(pipelineshub.NewPipelineValidatorWebhook(k8sManager)).To(Succeed())
 	Expect(pipelineshub.NewRunConfigurationValidatorWebhook(k8sManager)).To(Succeed())
 	Expect(pipelineshub.NewRunValidatorWebhook(k8sManager)).To(Succeed())
+	Expect(pipelineshub.NewProviderValidatorWebhook(k8sManager)).To(Succeed())
+
+	var managerCtx context.Context
+	managerCtx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(managerCtx)).To(Succeed())
+	}()
+
+	// Wait for webhook server to be ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
 
 	Provider = pipelineshub.RandomProvider()
 	Provider.Name = apis.RandomLowercaseString()
@@ -150,26 +171,6 @@ var _ = BeforeSuite(func() {
 		},
 	)
 	Expect(K8sClient.Create(Ctx, &providerSvc)).To(Succeed())
-
-	var managerCtx context.Context
-	managerCtx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
-
-	go func() {
-		defer GinkgoRecover()
-		Expect(k8sManager.Start(managerCtx)).To(Succeed())
-	}()
-
-	// Wait for webhook server to be ready
-	dialer := &net.Dialer{Timeout: time.Second}
-	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
-		if err != nil {
-			return err
-		}
-		conn.Close()
-		return nil
-	}).Should(Succeed())
 })
 
 var _ = BeforeEach(func() {

--- a/helm/kfp-operator/templates/webhook_manifests.yaml
+++ b/helm/kfp-operator/templates/webhook_manifests.yaml
@@ -37,6 +37,29 @@ webhooks:
       service:
         name: {{ include "kfp-operator.fullname" . }}-webhook-service
         namespace: {{ .Values.namespace.name }}
+        path: /validate-pipelines-kubeflow-org-v1beta1-provider
+      {{- if eq .Values.manager.webhookCertificates.provider "custom" }}
+      caBundle: {{ .Values.manager.webhookCertificates.caBundle }}
+      {{- end }}
+    failurePolicy: Fail
+    name: vprovider.kb.io
+    rules:
+      - apiGroups:
+          - pipelines.kubeflow.org
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - providers
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "kfp-operator.fullname" . }}-webhook-service
+        namespace: {{ .Values.namespace.name }}
         path: /validate-pipelines-kubeflow-org-v1beta1-run
       {{- if eq .Values.manager.webhookCertificates.provider "custom" }}
       caBundle: {{ .Values.manager.webhookCertificates.caBundle }}

--- a/main.go
+++ b/main.go
@@ -200,6 +200,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Provider")
 			os.Exit(1)
 		}
+		if err = pipelineshub.NewProviderValidatorWebhook(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Provider")
+			os.Exit(1)
+		}
 	}
 
 	// Resources that have a validation webhook in addition to conversion

--- a/pkg/common/provider_env.go
+++ b/pkg/common/provider_env.go
@@ -1,0 +1,9 @@
+package common
+
+// Env var names derived from the Provider spec and injected into the
+// provider-service container; the webhook also rejects them in podTemplateEnv.
+const (
+	ProviderNameEnvVar        = "PROVIDERNAME"
+	PipelineRootStorageEnvVar = "PIPELINEROOTSTORAGE"
+	ParametersEnvVarPrefix    = "PARAMETERS_"
+)


### PR DESCRIPTION
Closes #1329

spec.podTemplateEnv is merged over the provider-service container env, with per-provider entries winning on name collision. This lets a user shadow the operator-derived vars (PROVIDERNAME, PIPELINEROOTSTORAGE, PARAMETERS_*) and produce a container whose env contradicts the spec it was generated from.

Add a vprovider webhook rejecting podTemplateEnv entries matching those reserved names (case-insensitive). Helm-config defaults (SERVER_PORT, METRICS_PORT, OPERATORWEBHOOK) stay overridable by design.
