### PR TITLE
feat(kfp provider): scope kubeflow pipelines api server requests to provider namespace in multi user mode

### DIFF
--- a/provider-service/kfp/internal/config/config.go
+++ b/provider-service/kfp/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 
 type Parameters struct {
 	KfpNamespace             string `mapstructure:"kfpNamespace" yaml:"kfpNamespace,omitempty"`
+	KfpMultiUserMode         bool   `mapstructure:"kfpMultiUserMode" yaml:"kfpMultiUserMode,omitempty"`
 	RestKfpApiUrl            string `mapstructure:"restKfpApiUrl" yaml:"restKfpApiUrl,omitempty"`
 	GrpcMetadataStoreAddress string `mapstructure:"grpcMetadataStoreAddress" yaml:"grpcMetadataStoreAddress,omitempty"`
 	GrpcKfpApiAddress        string `mapstructure:"grpcKfpApiAddress" yaml:"grpcKfpApiAddress,omitempty"`

--- a/provider-service/kfp/internal/provider/experiment_service.go
+++ b/provider-service/kfp/internal/provider/experiment_service.go
@@ -36,8 +36,7 @@ type DefaultExperimentService struct {
 // The namespace sent on experiment requests is fixed for the lifetime of the
 // service. KFP multi-user mode requires every experiment request to be scoped
 // to a namespace, so requests are pinned to providerNamespace; single-user mode
-// requires the namespace to be empty. This is resolved once here rather than per
-// request because it never varies with the incoming request.
+// requires the namespace to be empty.
 func NewExperimentService(
 	conn *grpc.ClientConn,
 	multiUserMode bool,

--- a/provider-service/kfp/internal/provider/experiment_service.go
+++ b/provider-service/kfp/internal/provider/experiment_service.go
@@ -106,6 +106,10 @@ func (es *DefaultExperimentService) ExperimentIdByDisplayName(
 	ctx context.Context,
 	experiment common.NamespacedName,
 ) (string, error) {
+	if experiment.Namespace == "" {
+		experiment.Namespace = es.requestNamespace
+	}
+
 	experimentName, err := util.ResourceNameFromNamespacedName(experiment)
 	if err != nil {
 		return "", err

--- a/provider-service/kfp/internal/provider/experiment_service.go
+++ b/provider-service/kfp/internal/provider/experiment_service.go
@@ -25,7 +25,8 @@ type ExperimentService interface {
 }
 
 type DefaultExperimentService struct {
-	client client.ExperimentServiceClient
+	client        client.ExperimentServiceClient
+	multiUserMode bool
 	// requestNamespace scopes experiment requests to a KFP namespace: the
 	// provider namespace in multi-user mode, empty in single-user mode.
 	requestNamespace string
@@ -55,6 +56,7 @@ func NewExperimentService(
 
 	return &DefaultExperimentService{
 		client:           go_client.NewExperimentServiceClient(conn),
+		multiUserMode:    multiUserMode,
 		requestNamespace: requestNamespace,
 	}, nil
 }
@@ -106,7 +108,11 @@ func (es *DefaultExperimentService) ExperimentIdByDisplayName(
 	ctx context.Context,
 	experiment common.NamespacedName,
 ) (string, error) {
-	if experiment.Namespace == "" {
+	// In multi-user mode the experiment lives in the provider namespace, but
+	// the lookup is driven by a Run whose namespace is the run's, not the
+	// provider's. Scope the lookup to the provider namespace so the mangled
+	// display name matches the one CreateExperiment stored.
+	if es.multiUserMode {
 		experiment.Namespace = es.requestNamespace
 	}
 

--- a/provider-service/kfp/internal/provider/experiment_service.go
+++ b/provider-service/kfp/internal/provider/experiment_service.go
@@ -26,10 +26,22 @@ type ExperimentService interface {
 
 type DefaultExperimentService struct {
 	client client.ExperimentServiceClient
+	// requestNamespace scopes experiment requests to a KFP namespace: the
+	// provider namespace in multi-user mode, empty in single-user mode.
+	requestNamespace string
 }
 
+// NewExperimentService returns an ExperimentService backed by the KFP gRPC API.
+//
+// The namespace sent on experiment requests is fixed for the lifetime of the
+// service. KFP multi-user mode requires every experiment request to be scoped
+// to a namespace, so requests are pinned to providerNamespace; single-user mode
+// requires the namespace to be empty. This is resolved once here rather than per
+// request because it never varies with the incoming request.
 func NewExperimentService(
 	conn *grpc.ClientConn,
+	multiUserMode bool,
+	providerNamespace string,
 ) (ExperimentService, error) {
 	if conn == nil {
 		return nil, fmt.Errorf(
@@ -37,8 +49,14 @@ func NewExperimentService(
 		)
 	}
 
+	requestNamespace := ""
+	if multiUserMode {
+		requestNamespace = providerNamespace
+	}
+
 	return &DefaultExperimentService{
-		client: go_client.NewExperimentServiceClient(conn),
+		client:           go_client.NewExperimentServiceClient(conn),
+		requestNamespace: requestNamespace,
 	}, nil
 }
 
@@ -59,6 +77,7 @@ func (es *DefaultExperimentService) CreateExperiment(
 			Experiment: &go_client.Experiment{
 				DisplayName: experimentName,
 				Description: description,
+				Namespace:   es.requestNamespace,
 			},
 		},
 	)
@@ -96,7 +115,8 @@ func (es *DefaultExperimentService) ExperimentIdByDisplayName(
 	experimentResult, err := es.client.ListExperiments(
 		ctx,
 		&go_client.ListExperimentsRequest{
-			Filter: kfpUtil.ByDisplayNameFilter(experimentName),
+			Filter:    kfpUtil.ByDisplayNameFilter(experimentName),
+			Namespace: es.requestNamespace,
 		},
 	)
 	if err != nil {

--- a/provider-service/kfp/internal/provider/experiment_service.go
+++ b/provider-service/kfp/internal/provider/experiment_service.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
@@ -44,9 +45,13 @@ func NewExperimentService(
 	providerNamespace string,
 ) (ExperimentService, error) {
 	if conn == nil {
-		return nil, fmt.Errorf(
+		return nil, errors.New(
 			"no gRPC connection was provided to start experiment service",
 		)
+	}
+
+	if multiUserMode && providerNamespace == "" {
+		return nil, errors.New("multi-user mode requires a provider namespace")
 	}
 
 	requestNamespace := ""

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -96,6 +96,23 @@ var _ = Describe("ExperimentService", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("leaves an unqualified experiment name unscoped", func() {
+			unqualified := common.NamespacedName{Name: "Default"}
+			mockClient.On(
+				"ListExperiments",
+				&go_client.ListExperimentsRequest{
+					Filter:    util.ByDisplayNameFilter("Default"),
+					Namespace: "",
+				},
+			).Return(&go_client.ListExperimentsResponse{
+				Experiments: []*go_client.Experiment{{ExperimentId: "one"}},
+			}, nil)
+			res, err := experimentService.ExperimentIdByDisplayName(ctx, unqualified)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal("one"))
+		})
 	})
 
 	Context("multi-user mode", func() {
@@ -119,6 +136,23 @@ var _ = Describe("ExperimentService", func() {
 				Experiments: []*go_client.Experiment{{ExperimentId: "one"}},
 			}, nil)
 			res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal("one"))
+		})
+
+		It("scopes an unqualified experiment name to the provider namespace", func() {
+			unqualified := common.NamespacedName{Name: "default"}
+			mockClient.On(
+				"ListExperiments",
+				&go_client.ListExperimentsRequest{
+					Filter:    util.ByDisplayNameFilter("kfp-default"),
+					Namespace: providerNamespace,
+				},
+			).Return(&go_client.ListExperimentsResponse{
+				Experiments: []*go_client.Experiment{{ExperimentId: "one"}},
+			}, nil)
+			res, err := experimentService.ExperimentIdByDisplayName(ctx, unqualified)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("one"))

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -32,29 +32,37 @@ var _ = Describe("ExperimentService", func() {
 		mockClient = mocks.MockExperimentServiceClient{}
 	})
 
-	// namespaceScopedSpecs asserts the request namespace the service sends on the
-	// operations that carry one. expectedNamespace is the namespace the service is
-	// expected to send, independent of the resource's own namespace.
-	namespaceScopedSpecs := func(expectedNamespace string) {
-		It("CreateExperiment sends the expected namespace", func() {
+	// createExperimentSpec asserts the request namespace and display name
+	// CreateExperiment sends. CreateExperiment is mode-agnostic: it always
+	// mangles the display name from the input's own namespace and sends the
+	// service's request namespace. In multi-user mode the provider owner
+	// deploys the experiment into the provider namespace, so the input is
+	// already provider-scoped and no redirect is needed.
+	createExperimentSpec := func(input common.NamespacedName, expectedNamespace, expectedDisplayName string) {
+		It("CreateExperiment sends the expected namespace and display name", func() {
 			expectedId := "expected-result-id"
 			mockClient.On(
 				"CreateExperiment",
 				&go_client.CreateExperimentRequest{
 					Experiment: &go_client.Experiment{
-						DisplayName: "namespace-name",
+						DisplayName: expectedDisplayName,
 						Description: "description",
 						Namespace:   expectedNamespace,
 					},
 				},
 			).Return(&go_client.Experiment{ExperimentId: expectedId}, nil)
-			res, err := experimentService.CreateExperiment(ctx, nsn, "description")
+			res, err := experimentService.CreateExperiment(ctx, input, "description")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(expectedId))
 		})
+	}
 
-		It("ExperimentIdByDisplayName sends the expected namespace", func() {
+	// lookupExperimentSpec asserts the request namespace and display-name filter
+	// ExperimentIdByDisplayName sends. expectedNamespace is the request
+	// namespace; expectedDisplayName is the mangled name it filters on.
+	lookupExperimentSpec := func(expectedNamespace, expectedDisplayName string) {
+		It("ExperimentIdByDisplayName sends the expected namespace and filter", func() {
 			expectedResult := go_client.ListExperimentsResponse{
 				Experiments: []*go_client.Experiment{
 					{ExperimentId: "one"},
@@ -63,7 +71,7 @@ var _ = Describe("ExperimentService", func() {
 			mockClient.On(
 				"ListExperiments",
 				&go_client.ListExperimentsRequest{
-					Filter:    util.ByDisplayNameFilter("namespace-name"),
+					Filter:    util.ByDisplayNameFilter(expectedDisplayName),
 					Namespace: expectedNamespace,
 				},
 			).Return(&expectedResult, nil)
@@ -78,11 +86,14 @@ var _ = Describe("ExperimentService", func() {
 		BeforeEach(func() {
 			experimentService = &DefaultExperimentService{
 				client:           &mockClient,
+				multiUserMode:    false,
 				requestNamespace: "",
 			}
 		})
 
-		namespaceScopedSpecs("")
+		// A supplied experiment name keeps the resource (run) namespace.
+		createExperimentSpec(nsn, "", "namespace-name")
+		lookupExperimentSpec("", "namespace-name")
 
 		It("sends an empty namespace even though the resource is namespaced", func() {
 			mockClient.On(
@@ -119,27 +130,19 @@ var _ = Describe("ExperimentService", func() {
 		BeforeEach(func() {
 			experimentService = &DefaultExperimentService{
 				client:           &mockClient,
+				multiUserMode:    true,
 				requestNamespace: providerNamespace,
 			}
 		})
 
-		namespaceScopedSpecs(providerNamespace)
-
-		It("sends the provider namespace, not the resource namespace", func() {
-			mockClient.On(
-				"ListExperiments",
-				mock.MatchedBy(func(req *go_client.ListExperimentsRequest) bool {
-					return req.Namespace == providerNamespace &&
-						req.Namespace != nsn.Namespace
-				}),
-			).Return(&go_client.ListExperimentsResponse{
-				Experiments: []*go_client.Experiment{{ExperimentId: "one"}},
-			}, nil)
-			res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(res).To(Equal("one"))
-		})
+		// The provider owner deploys the experiment into the provider
+		// namespace, so CreateExperiment receives a provider-scoped input and
+		// mangles the display name from it. The lookup receives the run's
+		// namespace and overrides it to the provider namespace, producing the
+		// same mangled name.
+		providerNsn := common.NamespacedName{Name: nsn.Name, Namespace: providerNamespace}
+		createExperimentSpec(providerNsn, providerNamespace, providerNamespace+"-name")
+		lookupExperimentSpec(providerNamespace, providerNamespace+"-name")
 
 		It("scopes an unqualified experiment name to the provider namespace", func() {
 			unqualified := common.NamespacedName{Name: "default"}
@@ -160,6 +163,10 @@ var _ = Describe("ExperimentService", func() {
 	})
 
 	Context("mode-independent", func() {
+		// These specs exercise error propagation only, so the exact namespace
+		// and display name are incidental. multiUserMode is left false (no
+		// lookup override) while requestNamespace is set, letting the specs
+		// pin both a request namespace and an un-mangled display-name filter.
 		BeforeEach(func() {
 			experimentService = &DefaultExperimentService{
 				client:           &mockClient,

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/sky-uk/kfp-operator/pkg/common"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/mocks"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/util"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("ExperimentService", func() {
+	const providerNamespace = "kfp"
+
 	var (
 		mockClient        mocks.MockExperimentServiceClient
 		experimentService ExperimentService
@@ -27,14 +30,13 @@ var _ = Describe("ExperimentService", func() {
 
 	BeforeEach(func() {
 		mockClient = mocks.MockExperimentServiceClient{}
-		experimentService = &DefaultExperimentService{
-			client:           &mockClient,
-			requestNamespace: nsn.Namespace,
-		}
 	})
 
-	Context("CreateExperiment", func() {
-		It("should return experiment result id ", func() {
+	// namespaceScopedSpecs asserts the request namespace the service sends on the
+	// operations that carry one. expectedNamespace is the namespace the service is
+	// expected to send, independent of the resource's own namespace.
+	namespaceScopedSpecs := func(expectedNamespace string) {
+		It("CreateExperiment sends the expected namespace", func() {
 			expectedId := "expected-result-id"
 			mockClient.On(
 				"CreateExperiment",
@@ -42,7 +44,7 @@ var _ = Describe("ExperimentService", func() {
 					Experiment: &go_client.Experiment{
 						DisplayName: "namespace-name",
 						Description: "description",
-						Namespace:   nsn.Namespace,
+						Namespace:   expectedNamespace,
 					},
 				},
 			).Return(&go_client.Experiment{ExperimentId: expectedId}, nil)
@@ -52,70 +54,7 @@ var _ = Describe("ExperimentService", func() {
 			Expect(res).To(Equal(expectedId))
 		})
 
-		When("experiment namespaced name is invalid", func() {
-			It("should return error", func() {
-				invalidNsn := common.NamespacedName{
-					Namespace: "namespace",
-				}
-				res, err := experimentService.CreateExperiment(ctx, invalidNsn, "foo")
-
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
-			})
-		})
-
-		When("experimentServiceClient CreateExperiment errors", func() {
-			It("should return error", func() {
-				mockClient.On(
-					"CreateExperiment",
-					&go_client.CreateExperimentRequest{
-						Experiment: &go_client.Experiment{
-							DisplayName: "namespace-name",
-							Description: "description",
-							Namespace:   nsn.Namespace,
-						},
-					},
-				).Return(nil, errors.New("failed"))
-				res, err := experimentService.CreateExperiment(ctx, nsn, "description")
-
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
-			})
-		})
-	})
-
-	Context("DeleteExperiment", func() {
-		It("should not error", func() {
-			id := "delete-experiment-id"
-			mockClient.On(
-				"DeleteExperiment",
-				&go_client.DeleteExperimentRequest{
-					ExperimentId: id,
-				},
-			).Return(nil)
-			err := experimentService.DeleteExperiment(ctx, id)
-
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		When("experimentServiceClient DeleteExperiment errors", func() {
-			It("should return error", func() {
-				id := "delete-experiment-id"
-				mockClient.On(
-					"DeleteExperiment",
-					&go_client.DeleteExperimentRequest{
-						ExperimentId: id,
-					},
-				).Return(errors.New("failed"))
-				err := experimentService.DeleteExperiment(ctx, id)
-
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-
-	Context("ExperimentIdByDisplayName", func() {
-		It("should return the experiment result id", func() {
+		It("ExperimentIdByDisplayName sends the expected namespace", func() {
 			expectedResult := go_client.ListExperimentsResponse{
 				Experiments: []*go_client.Experiment{
 					{ExperimentId: "one"},
@@ -125,7 +64,7 @@ var _ = Describe("ExperimentService", func() {
 				"ListExperiments",
 				&go_client.ListExperimentsRequest{
 					Filter:    util.ByDisplayNameFilter("namespace-name"),
-					Namespace: nsn.Namespace,
+					Namespace: expectedNamespace,
 				},
 			).Return(&expectedResult, nil)
 			res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
@@ -133,74 +72,198 @@ var _ = Describe("ExperimentService", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("one"))
 		})
+	}
 
-		When("experiment namespaced name is invalid", func() {
-			It("should return error", func() {
-				invalidNsn := common.NamespacedName{
-					Namespace: "namespace",
-				}
-				res, err := experimentService.ExperimentIdByDisplayName(ctx, invalidNsn)
+	Context("single-user mode", func() {
+		BeforeEach(func() {
+			experimentService = &DefaultExperimentService{
+				client:           &mockClient,
+				requestNamespace: "",
+			}
+		})
 
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
+		namespaceScopedSpecs("")
+
+		It("sends an empty namespace even though the resource is namespaced", func() {
+			mockClient.On(
+				"CreateExperiment",
+				mock.MatchedBy(func(req *go_client.CreateExperimentRequest) bool {
+					return req.Experiment.Namespace == "" &&
+						req.Experiment.DisplayName == "namespace-name"
+				}),
+			).Return(&go_client.Experiment{ExperimentId: "id"}, nil)
+			_, err := experimentService.CreateExperiment(ctx, nsn, "description")
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("multi-user mode", func() {
+		BeforeEach(func() {
+			experimentService = &DefaultExperimentService{
+				client:           &mockClient,
+				requestNamespace: providerNamespace,
+			}
+		})
+
+		namespaceScopedSpecs(providerNamespace)
+
+		It("sends the provider namespace, not the resource namespace", func() {
+			mockClient.On(
+				"ListExperiments",
+				mock.MatchedBy(func(req *go_client.ListExperimentsRequest) bool {
+					return req.Namespace == providerNamespace &&
+						req.Namespace != nsn.Namespace
+				}),
+			).Return(&go_client.ListExperimentsResponse{
+				Experiments: []*go_client.Experiment{{ExperimentId: "one"}},
+			}, nil)
+			res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal("one"))
+		})
+	})
+
+	Context("mode-independent", func() {
+		BeforeEach(func() {
+			experimentService = &DefaultExperimentService{
+				client:           &mockClient,
+				requestNamespace: providerNamespace,
+			}
+		})
+
+		Context("CreateExperiment", func() {
+			When("experiment namespaced name is invalid", func() {
+				It("should return error", func() {
+					invalidNsn := common.NamespacedName{
+						Namespace: "namespace",
+					}
+					res, err := experimentService.CreateExperiment(ctx, invalidNsn, "foo")
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			When("experimentServiceClient CreateExperiment errors", func() {
+				It("should return error", func() {
+					mockClient.On(
+						"CreateExperiment",
+						&go_client.CreateExperimentRequest{
+							Experiment: &go_client.Experiment{
+								DisplayName: "namespace-name",
+								Description: "description",
+								Namespace:   providerNamespace,
+							},
+						},
+					).Return(nil, errors.New("failed"))
+					res, err := experimentService.CreateExperiment(ctx, nsn, "description")
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
 			})
 		})
 
-		When("experimentServiceClient ListExperiment errors", func() {
-			It("should return error", func() {
+		Context("ExperimentIdByDisplayName", func() {
+			When("experiment namespaced name is invalid", func() {
+				It("should return error", func() {
+					invalidNsn := common.NamespacedName{
+						Namespace: "namespace",
+					}
+					res, err := experimentService.ExperimentIdByDisplayName(ctx, invalidNsn)
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			When("experimentServiceClient ListExperiment errors", func() {
+				It("should return error", func() {
+					mockClient.On(
+						"ListExperiments",
+						&go_client.ListExperimentsRequest{
+							Filter:    util.ByDisplayNameFilter("namespace-name"),
+							Namespace: providerNamespace,
+						},
+					).Return(nil, errors.New("failed"))
+					res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			When("experimentServiceClient ListExperiment returns no experiments", func() {
+				It("should return error", func() {
+					mockClient.On(
+						"ListExperiments",
+						&go_client.ListExperimentsRequest{
+							Filter:    util.ByDisplayNameFilter("namespace-name"),
+							Namespace: providerNamespace,
+						},
+					).Return(&go_client.ListExperimentsResponse{
+						Experiments: []*go_client.Experiment{},
+					}, nil)
+					res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			When("experimentServiceClient ListExperiment returns > 1 experiments", func() {
+				It("should return error", func() {
+					mockClient.On(
+						"ListExperiments",
+						&go_client.ListExperimentsRequest{
+							Filter:    util.ByDisplayNameFilter("namespace-name"),
+							Namespace: providerNamespace,
+						},
+					).Return(&go_client.ListExperimentsResponse{
+						Experiments: []*go_client.Experiment{
+							{ExperimentId: "one"},
+							{ExperimentId: "two"},
+						},
+					}, nil)
+					res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+
+					Expect(err).To(HaveOccurred())
+					Expect(res).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("DeleteExperiment", func() {
+			It("should not error", func() {
+				id := "delete-experiment-id"
 				mockClient.On(
-					"ListExperiments",
-					&go_client.ListExperimentsRequest{
-						Filter:    util.ByDisplayNameFilter("namespace-name"),
-						Namespace: nsn.Namespace,
+					"DeleteExperiment",
+					&go_client.DeleteExperimentRequest{
+						ExperimentId: id,
 					},
-				).Return(nil, errors.New("failed"))
-				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
+				).Return(nil)
+				err := experimentService.DeleteExperiment(ctx, id)
 
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			When("experimentServiceClient DeleteExperiment errors", func() {
+				It("should return error", func() {
+					id := "delete-experiment-id"
+					mockClient.On(
+						"DeleteExperiment",
+						&go_client.DeleteExperimentRequest{
+							ExperimentId: id,
+						},
+					).Return(errors.New("failed"))
+					err := experimentService.DeleteExperiment(ctx, id)
+
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 
-		When("experimentServiceClient ListExperiment returns no experiments", func() {
-			It("should return error", func() {
-				expectedResult := go_client.ListExperimentsResponse{
-					Experiments: []*go_client.Experiment{},
-				}
-				mockClient.On(
-					"ListExperiments",
-					&go_client.ListExperimentsRequest{
-						Filter:    util.ByDisplayNameFilter("namespace-name"),
-						Namespace: nsn.Namespace,
-					},
-				).Return(&expectedResult, nil)
-				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
-
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
-			})
-		})
-
-		When("experimentServiceClient ListExperiment returns > 1 experiments", func() {
-			It("should return error", func() {
-				expectedResult := go_client.ListExperimentsResponse{
-					Experiments: []*go_client.Experiment{
-						{ExperimentId: "one"},
-						{ExperimentId: "two"},
-					},
-				}
-				mockClient.On(
-					"ListExperiments",
-					&go_client.ListExperimentsRequest{
-						Filter:    util.ByDisplayNameFilter("namespace-name"),
-						Namespace: nsn.Namespace,
-					},
-				).Return(&expectedResult, nil)
-				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
-
-				Expect(err).To(HaveOccurred())
-				Expect(res).To(BeEmpty())
-			})
-		})
 	})
 })

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -28,7 +28,8 @@ var _ = Describe("ExperimentService", func() {
 	BeforeEach(func() {
 		mockClient = mocks.MockExperimentServiceClient{}
 		experimentService = &DefaultExperimentService{
-			&mockClient,
+			client:           &mockClient,
+			requestNamespace: nsn.Namespace,
 		}
 	})
 
@@ -41,6 +42,7 @@ var _ = Describe("ExperimentService", func() {
 					Experiment: &go_client.Experiment{
 						DisplayName: "namespace-name",
 						Description: "description",
+						Namespace:   nsn.Namespace,
 					},
 				},
 			).Return(&go_client.Experiment{ExperimentId: expectedId}, nil)
@@ -70,6 +72,7 @@ var _ = Describe("ExperimentService", func() {
 						Experiment: &go_client.Experiment{
 							DisplayName: "namespace-name",
 							Description: "description",
+							Namespace:   nsn.Namespace,
 						},
 					},
 				).Return(nil, errors.New("failed"))
@@ -121,7 +124,8 @@ var _ = Describe("ExperimentService", func() {
 			mockClient.On(
 				"ListExperiments",
 				&go_client.ListExperimentsRequest{
-					Filter: util.ByDisplayNameFilter("namespace-name"),
+					Filter:    util.ByDisplayNameFilter("namespace-name"),
+					Namespace: nsn.Namespace,
 				},
 			).Return(&expectedResult, nil)
 			res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
@@ -147,7 +151,8 @@ var _ = Describe("ExperimentService", func() {
 				mockClient.On(
 					"ListExperiments",
 					&go_client.ListExperimentsRequest{
-						Filter: util.ByDisplayNameFilter("namespace-name"),
+						Filter:    util.ByDisplayNameFilter("namespace-name"),
+						Namespace: nsn.Namespace,
 					},
 				).Return(nil, errors.New("failed"))
 				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
@@ -165,7 +170,8 @@ var _ = Describe("ExperimentService", func() {
 				mockClient.On(
 					"ListExperiments",
 					&go_client.ListExperimentsRequest{
-						Filter: util.ByDisplayNameFilter("namespace-name"),
+						Filter:    util.ByDisplayNameFilter("namespace-name"),
+						Namespace: nsn.Namespace,
 					},
 				).Return(&expectedResult, nil)
 				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)
@@ -186,7 +192,8 @@ var _ = Describe("ExperimentService", func() {
 				mockClient.On(
 					"ListExperiments",
 					&go_client.ListExperimentsRequest{
-						Filter: util.ByDisplayNameFilter("namespace-name"),
+						Filter:    util.ByDisplayNameFilter("namespace-name"),
+						Namespace: nsn.Namespace,
 					},
 				).Return(&expectedResult, nil)
 				res, err := experimentService.ExperimentIdByDisplayName(ctx, nsn)

--- a/provider-service/kfp/internal/provider/experiment_service_test.go
+++ b/provider-service/kfp/internal/provider/experiment_service_test.go
@@ -13,11 +13,48 @@ import (
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/mocks"
 	"github.com/sky-uk/kfp-operator/provider-service/kfp/internal/util"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-var _ = Describe("ExperimentService", func() {
-	const providerNamespace = "kfp"
+const providerNamespace = "kfp"
 
+var _ = Describe("NewExperimentService", func() {
+	var conn *grpc.ClientConn
+
+	BeforeEach(func() {
+		var err error
+		conn, err = grpc.NewClient(
+			"passthrough:///unused",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("errors when no gRPC connection is provided", func() {
+		_, err := NewExperimentService(nil, false, providerNamespace)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors when configured for multi user mode without provider namespace", func() {
+		_, err := NewExperimentService(conn, true, "")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("pins the request namespace to the provider namespace in multi-user mode", func() {
+		svc, err := NewExperimentService(conn, true, providerNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(svc.(*DefaultExperimentService).requestNamespace).To(Equal(providerNamespace))
+	})
+
+	It("leaves the request namespace empty in single-user mode", func() {
+		svc, err := NewExperimentService(conn, false, providerNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(svc.(*DefaultExperimentService).requestNamespace).To(BeEmpty())
+	})
+})
+
+var _ = Describe("DefaultExperimentService", func() {
 	var (
 		mockClient        mocks.MockExperimentServiceClient
 		experimentService ExperimentService

--- a/provider-service/kfp/internal/provider/provider.go
+++ b/provider-service/kfp/internal/provider/provider.go
@@ -62,7 +62,11 @@ func NewKfpProvider(config *config.Config) (*KfpProvider, error) {
 		return nil, err
 	}
 
-	experimentService, err := NewExperimentService(conn)
+	experimentService, err := NewExperimentService(
+		conn,
+		config.Parameters.KfpMultiUserMode,
+		config.ProviderName.Namespace,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1335

Support Kubeflow Pipelines multi user mode and maintain backwards compatibility with single user mode.
