### PR TITLE
chore: replace verbose Gomega assertions with idiomatic matchers

### DIFF
--- a/apis/pipelines/hub/artifact_test.go
+++ b/apis/pipelines/hub/artifact_test.go
@@ -34,7 +34,7 @@ var _ = Context("OutputArtifact", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(artifactPath.Locator.Component).To(Equal(expectedArtifactPath.Locator.Component))
 			Expect(artifactPath.Locator.Artifact).To(Equal(expectedArtifactPath.Locator.Artifact))
-			Expect(artifactPath.Locator.Index).To(Equal(0))
+			Expect(artifactPath.Locator.Index).To(BeZero())
 			Expect(artifactPath.Filter).To(BeEmpty())
 		})
 
@@ -49,7 +49,7 @@ var _ = Context("OutputArtifact", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(artifactPath.Locator.Component).To(Equal(expectedArtifactPath.Locator.Component))
 			Expect(artifactPath.Locator.Artifact).To(Equal(expectedArtifactPath.Locator.Artifact))
-			Expect(artifactPath.Locator.Index).To(Equal(0))
+			Expect(artifactPath.Locator.Index).To(BeZero())
 			Expect(artifactPath.Filter).To(Equal(expectedArtifactPath.Filter))
 		})
 

--- a/apis/pipelines/hub/conversions_test.go
+++ b/apis/pipelines/hub/conversions_test.go
@@ -16,7 +16,7 @@ var _ = Context("Conversions", func() {
 			framework := NewPipelineFramework("tfx")
 
 			err := AddComponentsToFrameworkParams("", &framework)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(framework.Parameters).To(HaveKey("components"))
 		})
@@ -26,7 +26,7 @@ var _ = Context("Conversions", func() {
 			framework := NewPipelineFramework("tfx")
 
 			err := AddComponentsToFrameworkParams(tfxComponents, &framework)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			marshal, _ := json.Marshal(tfxComponents)
 			Expect(framework.Parameters).To(HaveKeyWithValue("components", &apiextensionsv1.JSON{Raw: marshal}))
@@ -39,7 +39,7 @@ var _ = Context("Conversions", func() {
 
 			err := AddBeamArgsToFrameworkParams([]apis.NamedValue{}, &framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(framework.Parameters).To(HaveKey("beamArgs"))
 		})
 
@@ -52,7 +52,7 @@ var _ = Context("Conversions", func() {
 			framework := NewPipelineFramework("tfx")
 
 			err := AddBeamArgsToFrameworkParams(beamArgs, &framework)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			marshal, _ := json.Marshal(beamArgs)
 			Expect(framework.Parameters).To(HaveKeyWithValue("beamArgs", &apiextensionsv1.JSON{Raw: marshal}))
@@ -66,7 +66,7 @@ var _ = Context("Conversions", func() {
 
 			components, err := ComponentsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(components).To(BeEmpty())
 		})
 
@@ -74,14 +74,14 @@ var _ = Context("Conversions", func() {
 			components := apis.RandomString()
 
 			jsonString, err := json.Marshal(components)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			framework := NewPipelineFramework("tfx")
 			framework.Parameters["components"] = &apiextensionsv1.JSON{Raw: jsonString}
 
 			result, err := ComponentsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(components).To(Equal(result))
 		})
 
@@ -90,7 +90,7 @@ var _ = Context("Conversions", func() {
 
 			components, err := ComponentsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(components).To(BeEmpty())
 		})
 	})
@@ -102,7 +102,7 @@ var _ = Context("Conversions", func() {
 
 			beamArgs, err := BeamArgsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(beamArgs).To(BeEmpty())
 		})
 
@@ -119,7 +119,7 @@ var _ = Context("Conversions", func() {
 
 			beamArgsFromFramework, err := BeamArgsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(beamArgsFromFramework).To(Equal(beamArgs))
 		})
 
@@ -128,7 +128,7 @@ var _ = Context("Conversions", func() {
 
 			beamArgs, err := BeamArgsFromFramework(&framework)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(beamArgs).To(BeEmpty())
 		})
 	})
@@ -139,7 +139,7 @@ var _ = Context("Conversions", func() {
 
 			beamArgs, err := BeamArgsFromJsonPatches(patches)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(beamArgs).To(BeEmpty())
 		})
 
@@ -160,14 +160,14 @@ var _ = Context("Conversions", func() {
 
 			patchOps := []apis.JsonPatchOperation{addOp, addOp2}
 			bytes, err := json.Marshal(patchOps)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			patches := []Patch{
 				{Type: "json", Payload: string(bytes)},
 			}
 
 			beamArgsFromPatches, err := BeamArgsFromJsonPatches(patches)
 
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(beamArgsFromPatches).To(Equal(beamArgs))
 		})
 
@@ -183,7 +183,7 @@ var _ = Context("Conversions", func() {
 
 			patchOps := []apis.JsonPatchOperation{addOp, addOp2}
 			bytes, err := json.Marshal(patchOps)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			patches := []Patch{
 				{Type: "json", Payload: string(bytes)},
 			}
@@ -205,7 +205,7 @@ var _ = Context("Conversions", func() {
 
 			patchOps := []apis.JsonPatchOperation{addOp, addOp2}
 			bytes, err := json.Marshal(patchOps)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			patches := []Patch{
 				{Type: "json", Payload: string(bytes)},
 			}

--- a/apis/pipelines/hub/pipeline_types_test.go
+++ b/apis/pipelines/hub/pipeline_types_test.go
@@ -45,7 +45,7 @@ var _ = Context("Pipeline", func() {
 			hash1 := pipeline.ComputeHash()
 
 			tfxComponentsJson, err := json.Marshal("someTfxComponentsValue")
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			pipeline.Spec.Framework = PipelineFramework{
 				Name: "tfx",
@@ -65,7 +65,7 @@ var _ = Context("Pipeline", func() {
 
 			beamArgs := []apis.NamedValue{{Name: "key", Value: "value"}}
 			beamArgsJson, err := json.Marshal(beamArgs)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			pipeline.Spec.Framework = PipelineFramework{
 				Name: "tfx",
@@ -136,14 +136,14 @@ var _ = Context("Pipeline", func() {
 		Specify("Returns pipeline name if version is missing", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline\""))
 		})
 
 		Specify("Returns pipeline name and version if both exist", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline", Version: "dummy-version"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline:dummy-version\""))
 		})
 	})
@@ -153,14 +153,14 @@ var _ = Context("Pipeline", func() {
 		Specify("Returns pipeline name if version is missing", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline\""))
 		})
 
 		Specify("Returns pipeline name and version if both exist", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline", Version: "dummy-version"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline:dummy-version\""))
 		})
 	})

--- a/apis/pipelines/v1alpha6/artifact_test.go
+++ b/apis/pipelines/v1alpha6/artifact_test.go
@@ -34,7 +34,7 @@ var _ = Context("OutputArtifact", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(artifactPath.Locator.Component).To(Equal(expectedArtifactPath.Locator.Component))
 			Expect(artifactPath.Locator.Artifact).To(Equal(expectedArtifactPath.Locator.Artifact))
-			Expect(artifactPath.Locator.Index).To(Equal(0))
+			Expect(artifactPath.Locator.Index).To(BeZero())
 			Expect(artifactPath.Filter).To(BeEmpty())
 		})
 
@@ -49,7 +49,7 @@ var _ = Context("OutputArtifact", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(artifactPath.Locator.Component).To(Equal(expectedArtifactPath.Locator.Component))
 			Expect(artifactPath.Locator.Artifact).To(Equal(expectedArtifactPath.Locator.Artifact))
-			Expect(artifactPath.Locator.Index).To(Equal(0))
+			Expect(artifactPath.Locator.Index).To(BeZero())
 			Expect(artifactPath.Filter).To(Equal(expectedArtifactPath.Filter))
 		})
 

--- a/apis/pipelines/v1alpha6/pipeline_types_test.go
+++ b/apis/pipelines/v1alpha6/pipeline_types_test.go
@@ -107,14 +107,14 @@ var _ = Context("Pipeline", func() {
 		Specify("Returns pipeline name if version is missing", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline\""))
 		})
 
 		Specify("Returns pipeline name and version if both exist", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline", Version: "dummy-version"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline:dummy-version\""))
 		})
 	})
@@ -124,14 +124,14 @@ var _ = Context("Pipeline", func() {
 		Specify("Returns pipeline name if version is missing", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline\""))
 		})
 
 		Specify("Returns pipeline name and version if both exist", func() {
 			pid := PipelineIdentifier{Name: "dummy-pipeline", Version: "dummy-version"}
 			json, err := pid.MarshalJSON()
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(json)).To(Equal("\"dummy-pipeline:dummy-version\""))
 		})
 	})

--- a/apis/pipelines/v1alpha6/provider_conversion_test.go
+++ b/apis/pipelines/v1alpha6/provider_conversion_test.go
@@ -57,7 +57,7 @@ var _ = Context("Provider Conversion", PropertyBased, func() {
 				},
 			}
 			bytes, err := json.Marshal(patchOps)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			framework.Patches = []hub.Patch{
 				{Type: "json", Payload: string(bytes)},
 			}

--- a/apis/utils_test.go
+++ b/apis/utils_test.go
@@ -31,7 +31,7 @@ var _ = Context("Utils", func() {
 			return strconv.Itoa(a), nil
 		})
 		if expectSuccess {
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(BeComparableTo(expected, cmpopts.EquateEmpty()))
 		} else {
 			Expect(err).NotTo(BeNil())

--- a/controllers/pipelines/internal/jsonutil/json_utils_test.go
+++ b/controllers/pipelines/internal/jsonutil/json_utils_test.go
@@ -28,18 +28,18 @@ var _ = Describe("PatchJson", func() {
 				Value: "c",
 			}
 			patchOpJson, err := json.Marshal([]common.JsonPatchOperation{patchOp})
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			patches := []pipelineshub.Patch{
 				{Type: JsonPatch, Payload: string(patchOpJson)},
 			}
 
 			result, err := PatchJson(patches, jsonBytes)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			var data map[string]any
 			err = json.Unmarshal([]byte(result), &data)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(data["baz"].(string)).To(Equal("c"))
 		})
 
@@ -53,18 +53,18 @@ var _ = Describe("PatchJson", func() {
 				Value: "newValue",
 			}
 			patchOpJson, err := json.Marshal([]common.JsonPatchOperation{patchOp})
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			patches := []pipelineshub.Patch{
 				{Type: JsonPatch, Payload: string(patchOpJson)},
 			}
 
 			result, err := PatchJson(patches, jsonBytes)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			var data map[string]any
 			err = json.Unmarshal([]byte(result), &data)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(data["bar"].([]any)[0].(string)).To(Equal("newValue"))
 			Expect(data["bar"].([]any)[1].(string)).To(Equal("b"))
 		})
@@ -79,18 +79,18 @@ var _ = Describe("PatchJson", func() {
 				Value: "hello",
 			}
 			patchOpJson, err := json.Marshal([]common.JsonPatchOperation{patchOp})
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			patches := []pipelineshub.Patch{
 				{Type: JsonPatch, Payload: string(patchOpJson)},
 			}
 
 			result, err := PatchJson(patches, jsonBytes)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			var data map[string]any
 			err = json.Unmarshal([]byte(result), &data)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(data["baz"].([]any)[0].(string)).To(Equal("hello"))
 		})
 	})
@@ -106,12 +106,12 @@ var _ = Describe("PatchJson", func() {
 			}
 
 			result, err := PatchJson(patches, jsonBytes)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			println(result)
 			var data map[string]any
 			err = json.Unmarshal([]byte(result), &data)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(data["foo"].(string)).To(Equal("z"))
 			Expect(data["bar"].(string)).To(Equal("b"))
 			Expect(data["baz"].(string)).To(Equal("c"))

--- a/controllers/pipelines/internal/workflowfactory/workflow_factory_test.go
+++ b/controllers/pipelines/internal/workflowfactory/workflow_factory_test.go
@@ -60,7 +60,7 @@ var _ = Describe("checkResourceNamespaceAllowed", func() {
 			Namespace: "foo",
 			Name:      "test-resource",
 		}, *provider)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("succeeds when the resource namespace is in the provider allowed namespaces", func() {
@@ -70,6 +70,6 @@ var _ = Describe("checkResourceNamespaceAllowed", func() {
 			Namespace: "foo",
 			Name:      "test-resource",
 		}, *provider)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/provider-service/base/pkg/streams/sources/workflow_source_unit_test.go
+++ b/provider-service/base/pkg/streams/sources/workflow_source_unit_test.go
@@ -76,7 +76,7 @@ var _ = Context("workflow source", func() {
 			workflow := &unstructured.Unstructured{}
 			setWorkflowPhase(workflow, phase)
 			_, hasFinished := runCompletionStatus(workflow)
-			Expect(hasFinished).To(Equal(false))
+			Expect(hasFinished).To(BeFalse())
 		},
 		Entry("unknown", argo.WorkflowUnknown),
 		Entry("pending", argo.WorkflowPending),
@@ -89,7 +89,7 @@ var _ = Context("workflow source", func() {
 			setWorkflowPhase(workflow, phase)
 			status, hasFinished := runCompletionStatus(workflow)
 			Expect(status).To(Equal(expectedStatus))
-			Expect(hasFinished).To(Equal(true))
+			Expect(hasFinished).To(BeTrue())
 		},
 		Entry("error", argo.WorkflowError, common.RunCompletionStatuses.Failed),
 		Entry("failed", argo.WorkflowFailed, common.RunCompletionStatuses.Failed),

--- a/provider-service/kfp/internal/client/kfp_api_unit_test.go
+++ b/provider-service/kfp/internal/client/kfp_api_unit_test.go
@@ -54,7 +54,7 @@ var _ = Context("KFP API", func() {
 				).Return(&mockRunDetail, nil)
 
 				resourceReferences, err := kfpApi.GetResourceReferences(context.Background(), runId)
-				Expect(err).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(resourceReferences).To(BeComparableTo(resource.References{
 					PipelineName: common.NamespacedName{
 						Name:      "PipelineName",

--- a/provider-service/vai/internal/provider/label_sanitizer_test.go
+++ b/provider-service/vai/internal/provider/label_sanitizer_test.go
@@ -55,7 +55,7 @@ var _ = Describe("DefaultLabelSanitizer", func() {
 			Expect(result).To(Equal(map[string]string{
 				key[:maxLength]: value[:maxLength],
 			}))
-			Expect(len(key[:maxLength])).To(Equal(63))
+			Expect(key[:maxLength]).To(HaveLen(63))
 		})
 
 		It("returns an empty map when input is empty", func() {

--- a/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/vai/internal/runcompletion/event_flow_unit_test.go
@@ -255,7 +255,7 @@ var _ = Context("VaiEventingServer", func() {
 				)
 				event, err := eventingFlow.runCompletionEventDataForRun(ctx, runId)
 				Expect(event).NotTo(BeNil())
-				Expect(err).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/triggers/run-completion-event-trigger/internal/publisher/publisher_handler_test.go
+++ b/triggers/run-completion-event-trigger/internal/publisher/publisher_handler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("PublisherHandler", func() {
 
 				err := publisher.Publish(event)
 
-				Expect(err).To(Not(HaveOccurred()))
+				Expect(err).NotTo(HaveOccurred())
 				mockNatsConn.AssertExpectations(GinkgoT())
 			})
 		})


### PR DESCRIPTION
The purpose-built matchers yield assertion-specific failure diagnostics rather than a generic Equal diff, and state intent directly.