### PR TITLE
chore: mark test helpers with GinkgoHelper()

### DIFF
--- a/controllers/pipelines/runconfiguration_test_helper.go
+++ b/controllers/pipelines/runconfiguration_test_helper.go
@@ -3,6 +3,7 @@
 package pipelines
 
 import (
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/kfp-operator/apis"
 	pipelineshub "github.com/sky-uk/kfp-operator/apis/pipelines/hub"
@@ -11,6 +12,7 @@ import (
 )
 
 func createSucceededRcWithSchedule() *pipelineshub.RunConfiguration {
+	GinkgoHelper()
 	runConfiguration := createStableRcWith(func(runConfiguration *pipelineshub.RunConfiguration) *pipelineshub.RunConfiguration {
 		runConfiguration.Spec.Triggers = pipelineshub.RandomScheduleTrigger()
 		return runConfiguration
@@ -42,6 +44,7 @@ func createSucceededRcWith(modifyRc func(runConfiguration *pipelineshub.RunConfi
 }
 
 func createStableRcWith(modifyRc func(runConfiguration *pipelineshub.RunConfiguration) *pipelineshub.RunConfiguration, synchronizationState apis.SynchronizationState) *pipelineshub.RunConfiguration {
+	GinkgoHelper()
 	runConfiguration := pipelineshub.RandomRunConfiguration(
 		common.NamespacedName{
 			Name:      Provider.Name,
@@ -63,6 +66,7 @@ func createStableRcWith(modifyRc func(runConfiguration *pipelineshub.RunConfigur
 }
 
 func createRcWithLatestRun(succeeded pipelineshub.RunReference) *pipelineshub.RunConfiguration {
+	GinkgoHelper()
 	referencedRc := createSucceededRc()
 	referencedRc.Status.LatestRuns.Succeeded = succeeded
 	Expect(K8sClient.Status().Update(Ctx, referencedRc)).To(Succeed())
@@ -78,6 +82,7 @@ func matchRunConfiguration(runConfiguration *pipelineshub.RunConfiguration, matc
 }
 
 func updateOwnedSchedules(runConfiguration *pipelineshub.RunConfiguration, updateFn func(schedule *pipelineshub.RunSchedule)) error {
+	GinkgoHelper()
 	ownedSchedules, err := findOwnedRunSchedules(Ctx, K8sClient, runConfiguration)
 	if err != nil {
 		return err

--- a/controllers/pipelines/state_handler_test.go
+++ b/controllers/pipelines/state_handler_test.go
@@ -93,6 +93,7 @@ func (st StateTransitionTestCase) WithSucceededCreateWorkFlow(
 	providerId pipelineshub.ProviderAndId,
 	providerError string,
 ) StateTransitionTestCase {
+	GinkgoHelper()
 	workflow, err := workflowutil.SetWorkflowProvider(
 		CreateTestWorkflow(argo.WorkflowSucceeded),
 		provider)
@@ -116,6 +117,7 @@ func (st StateTransitionTestCase) WithSucceededUpdateWorkflow(
 	providerId pipelineshub.ProviderAndId,
 	providerError string,
 ) StateTransitionTestCase {
+	GinkgoHelper()
 	workflow, err := workflowutil.SetWorkflowProvider(
 		CreateTestWorkflow(argo.WorkflowSucceeded),
 		provider)
@@ -139,6 +141,7 @@ func (st StateTransitionTestCase) WithSucceededDeletionWorkflow(
 	providerId pipelineshub.ProviderAndId,
 	providerError string,
 ) StateTransitionTestCase {
+	GinkgoHelper()
 	workflow, err := workflowutil.SetWorkflowProvider(
 		CreateTestWorkflow(argo.WorkflowSucceeded),
 		provider)

--- a/triggers/run-completion-event-trigger/cmd/functional_test.go
+++ b/triggers/run-completion-event-trigger/cmd/functional_test.go
@@ -129,6 +129,7 @@ var _ = Context("RunCompletionEventTriggerService", Ordered, func() {
 })
 
 func getLatestMessageFromNats(natsSubscription *nats.Subscription) (*common.RunCompletionEvent, error) {
+	GinkgoHelper()
 	msg, err := natsSubscription.NextMsg(5 * time.Second)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Assertion failures inside shared test helpers reported the helper's location instead of the spec that called it, making it hard to tell which test case failed. Mark these helpers with GinkgoHelper() so failures point at the calling spec.