### PR TITLE
chore: assert no redelivery with Consistently instead of time.Sleep

### DIFF
--- a/provider-service/base/pkg/streams/sources/pub_sub_source_integration_test.go
+++ b/provider-service/base/pkg/streams/sources/pub_sub_source_integration_test.go
@@ -147,14 +147,7 @@ var _ = Context("Pub sub source", Ordered, func() {
 				msg.OnSuccess()
 				Expect(msg.Message).To(Equal(pipelineId))
 
-				time.Sleep(retryTimeout * 2)
-
-				select {
-				case _ = <-source.Out():
-					Fail("second message received")
-				default:
-					Succeed()
-				}
+				Consistently(source.Out(), retryTimeout*2).ShouldNot(Receive())
 			})
 		})
 
@@ -182,14 +175,7 @@ var _ = Context("Pub sub source", Ordered, func() {
 				msg.OnUnrecoverableFailureHandler()
 				Expect(msg.Message).To(Equal(pipelineId))
 
-				time.Sleep(retryTimeout)
-
-				select {
-				case _ = <-source.Out():
-					Fail("second message received")
-				default:
-					Succeed()
-				}
+				Consistently(source.Out(), retryTimeout).ShouldNot(Receive())
 			})
 		})
 


### PR DESCRIPTION
Two Pub/Sub source specs slept for a fixed duration and then checked once, via a non-blocking select, that no second message had been redelivered. A redelivery arriving during the sleep, or after the single check, could be missed.

Replace the sleep-then-check with Consistently(...).ShouldNot(Receive()), which polls the channel for the whole window and fails as soon as an unexpected message is received.