### PR TITLE
chore: remove unused getPipelineNameFromAnnotation

### DIFF
--- a/provider-service/kfp/internal/runcompletion/event_flow.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow.go
@@ -2,7 +2,6 @@ package runcompletion
 
 import (
 	"context"
-	"encoding/json"
 	argo "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/sky-uk/kfp-operator/pkg/common"
@@ -42,10 +41,6 @@ const (
 	workflowPhaseLabel         = "workflows.argoproj.io/phase"
 	pipelineSpecAnnotationName = "pipelines.kubeflow.org/pipeline_spec"
 )
-
-type PipelineSpec struct {
-	Name string `json:"name"`
-}
 
 func (ef *EventFlow) In() chan<- StreamMessage[*unstructured.Unstructured] {
 	return ef.in
@@ -175,14 +170,4 @@ func runCompletionStatus(workflow *unstructured.Unstructured) (common.RunComplet
 	default:
 		return "", false
 	}
-}
-
-func getPipelineNameFromAnnotation(workflow *unstructured.Unstructured) string {
-	specString := workflow.GetAnnotations()[pipelineSpecAnnotationName]
-	spec := &PipelineSpec{}
-	if err := json.Unmarshal([]byte(specString), spec); err != nil {
-		return ""
-	}
-
-	return spec.Name
 }

--- a/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
+++ b/provider-service/kfp/internal/runcompletion/event_flow_unit_test.go
@@ -18,44 +18,6 @@ import (
 )
 
 var _ = Context("Eventing Flow", func() {
-	Describe("getPipelineNameFromAnnotation", func() {
-		It("returns empty when the workflow has no pipeline spec annotation", func() {
-			workflow := &unstructured.Unstructured{}
-
-			extractedName := getPipelineNameFromAnnotation(workflow)
-			Expect(extractedName).To(BeEmpty())
-		})
-
-		It("returns empty when the workflow's pipeline spec annotation is invalid", func() {
-			workflow := &unstructured.Unstructured{}
-			workflow.SetAnnotations(map[string]string{
-				pipelineSpecAnnotationName: fmt.Sprintf(`{invalid`),
-			})
-
-			extractedName := getPipelineNameFromAnnotation(workflow)
-			Expect(extractedName).To(BeEmpty())
-		})
-
-		It("returns empty when the name is missing from workflow's spec annotation", func() {
-			workflow := &unstructured.Unstructured{}
-			workflow.SetAnnotations(map[string]string{
-				pipelineSpecAnnotationName: fmt.Sprintf(`{}`),
-			})
-
-			extractedName := getPipelineNameFromAnnotation(workflow)
-			Expect(extractedName).To(BeEmpty())
-		})
-
-		It("returns the pipeline's name when the workflow has a pipeline spec annotation with the pipeline name", func() {
-			pipelineName := common.RandomString()
-			workflow := &unstructured.Unstructured{}
-			setPipelineNameInSpec(workflow, pipelineName)
-
-			extractedName := getPipelineNameFromAnnotation(workflow)
-			Expect(extractedName).To(Equal(pipelineName))
-		})
-	})
-
 	Describe("eventForWorkflow", func() {
 		It("Doesn't emit an event when the workflow has not finished", func() {
 			workflow := &unstructured.Unstructured{}


### PR DESCRIPTION
remove unused getPipelineNameFromAnnotation and PipelineSpec from kfp runcompletion event flow.